### PR TITLE
agp 3.+ is automatically uses a default version for Build Tools

### DIFF
--- a/koin-projects/examples/android-mvp/build.gradle
+++ b/koin-projects/examples/android-mvp/build.gradle
@@ -6,7 +6,6 @@ apply from: '../../gradle/versions-examples.gradle'
 
 android {
     compileSdkVersion android_target_version
-    buildToolsVersion android_build_tools_version
 
     defaultConfig {
         minSdkVersion 21

--- a/koin-projects/examples/android-mvvm-coroutines/build.gradle
+++ b/koin-projects/examples/android-mvvm-coroutines/build.gradle
@@ -7,7 +7,6 @@ apply from: '../../gradle/versions-examples.gradle'
 
 android {
     compileSdkVersion android_target_version
-    buildToolsVersion android_build_tools_version
 
     defaultConfig {
         minSdkVersion 21

--- a/koin-projects/examples/android-mvvm/build.gradle
+++ b/koin-projects/examples/android-mvvm/build.gradle
@@ -7,7 +7,6 @@ apply from: '../../gradle/versions-examples.gradle'
 
 android {
     compileSdkVersion android_target_version
-    buildToolsVersion android_build_tools_version
 
     defaultConfig {
         minSdkVersion 21

--- a/koin-projects/examples/android-navigation/build.gradle
+++ b/koin-projects/examples/android-navigation/build.gradle
@@ -6,7 +6,6 @@ apply from: '../../gradle/versions-examples.gradle'
 
 android {
     compileSdkVersion android_target_version
-    buildToolsVersion android_build_tools_version
 
     defaultConfig {
         minSdkVersion 21

--- a/koin-projects/gradle/versions-android.gradle
+++ b/koin-projects/gradle/versions-android.gradle
@@ -6,7 +6,6 @@ ext {
 
     android_gradle_version = "3.2.0-beta05"
 
-    android_build_tools_version  = '27.0.3'
 
 	android_arch_version = '1.1.1'
 	androidx_arch_version = '2.0.0-beta01'

--- a/koin-projects/koin-android-scope/build.gradle
+++ b/koin-projects/koin-android-scope/build.gradle
@@ -9,7 +9,6 @@ ext {
 
 android {
     compileSdkVersion android_target_version
-    buildToolsVersion android_build_tools_version
 
     defaultConfig {
         minSdkVersion android_min_version

--- a/koin-projects/koin-android-viewmodel/build.gradle
+++ b/koin-projects/koin-android-viewmodel/build.gradle
@@ -9,7 +9,6 @@ ext {
 
 android {
     compileSdkVersion android_target_version
-    buildToolsVersion android_build_tools_version
 
     defaultConfig {
         minSdkVersion android_min_version

--- a/koin-projects/koin-android/build.gradle
+++ b/koin-projects/koin-android/build.gradle
@@ -9,7 +9,6 @@ ext {
 
 android {
     compileSdkVersion android_target_version
-    buildToolsVersion android_build_tools_version
 
     defaultConfig {
         minSdkVersion android_min_version

--- a/koin-projects/koin-androidx-scope/build.gradle
+++ b/koin-projects/koin-androidx-scope/build.gradle
@@ -9,7 +9,6 @@ ext {
 
 android {
     compileSdkVersion android_target_version
-    buildToolsVersion android_build_tools_version
 
     defaultConfig {
         minSdkVersion android_min_version

--- a/koin-projects/koin-androidx-viewmodel/build.gradle
+++ b/koin-projects/koin-androidx-viewmodel/build.gradle
@@ -9,7 +9,6 @@ ext {
 
 android {
     compileSdkVersion androidx_target_version
-    buildToolsVersion android_build_tools_version
 
     defaultConfig {
         minSdkVersion android_min_version


### PR DESCRIPTION
i think, It is not necessary to specify the version of Build Tools. cuz AGP 3.+ is automatically uses a default version.

ref: https://developer.android.com/studio/releases/build-tools
