### PR TITLE
Replace mockito-core with mockito-inline and remove MockMaker files.

### DIFF
--- a/koin-projects/examples/android-mvp/build.gradle
+++ b/koin-projects/examples/android-mvp/build.gradle
@@ -41,7 +41,7 @@ dependencies {
 
     // Android Test
     testImplementation "junit:junit:$junit_version"
-    testImplementation "org.mockito:mockito-core:$mockito_version"
+    testImplementation "org.mockito:mockito-inline:$mockito_version"
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestUtil 'com.android.support.test:orchestrator:1.0.2'
 

--- a/koin-projects/examples/android-mvp/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/koin-projects/examples/android-mvp/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,1 +1,0 @@
-mock-maker-inline

--- a/koin-projects/examples/android-mvvm-coroutines/build.gradle
+++ b/koin-projects/examples/android-mvvm-coroutines/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 
     // Android Test
     testImplementation "junit:junit:$junit_version"
-    testImplementation "org.mockito:mockito-core:$mockito_version"
+    testImplementation "org.mockito:mockito-inline:$mockito_version"
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestUtil 'com.android.support.test:orchestrator:1.0.2'
 

--- a/koin-projects/examples/android-mvvm-coroutines/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/koin-projects/examples/android-mvvm-coroutines/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,1 +1,0 @@
-mock-maker-inline

--- a/koin-projects/examples/android-mvvm/build.gradle
+++ b/koin-projects/examples/android-mvvm/build.gradle
@@ -54,7 +54,7 @@ dependencies {
 
     // Android Test
     testImplementation "junit:junit:$junit_version"
-    testImplementation "org.mockito:mockito-core:$mockito_version"
+    testImplementation "org.mockito:mockito-inline:$mockito_version"
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestUtil 'com.android.support.test:orchestrator:1.0.2'
 

--- a/koin-projects/examples/android-mvvm/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/koin-projects/examples/android-mvvm/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,1 +1,0 @@
-mock-maker-inline

--- a/koin-projects/examples/coffee-maker/build.gradle
+++ b/koin-projects/examples/coffee-maker/build.gradle
@@ -6,5 +6,5 @@ dependencies {
     compile project(":koin-core")
     testImplementation project(":koin-test")
 
-    testCompile "org.mockito:mockito-core:$mockito_version"
+    testCompile "org.mockito:mockito-inline:$mockito_version"
 }

--- a/koin-projects/examples/hello-spark/build.gradle
+++ b/koin-projects/examples/hello-spark/build.gradle
@@ -13,5 +13,5 @@ dependencies {
     compile "org.slf4j:slf4j-log4j12:1.7.21"
 
     testCompile "org.apache.httpcomponents:httpclient:4.5.3"
-    testCompile "org.mockito:mockito-core:$mockito_version"
+    testCompile "org.mockito:mockito-inline:$mockito_version"
 }

--- a/koin-projects/examples/hello-spark/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/koin-projects/examples/hello-spark/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,1 +1,0 @@
-mock-maker-inline

--- a/koin-projects/gradle/versions.gradle
+++ b/koin-projects/gradle/versions.gradle
@@ -20,7 +20,7 @@ ext {
 
     // Test
     junit_version = "4.12"
-    mockito_version = "2.18.3"
+    mockito_version = "2.21.0"
 
     asciidoctor_version = "1.5.3"
     asciidoctor_pdf_version = "1.5.0-alpha.15"

--- a/koin-projects/koin-android-scope/build.gradle
+++ b/koin-projects/koin-android-scope/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     api project(":koin-android") //"org.koin:koin-android:$koin_version"
     // Test
     testImplementation project(":koin-test")
-    testImplementation "org.mockito:mockito-core:$mockito_version"
+    testImplementation "org.mockito:mockito-inline:$mockito_version"
 
     // Architecture Lifecycle
     implementation("android.arch.lifecycle:common:$android_arch_version")

--- a/koin-projects/koin-android-scope/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/koin-projects/koin-android-scope/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,1 +1,0 @@
-mock-maker-inline

--- a/koin-projects/koin-android-viewmodel/build.gradle
+++ b/koin-projects/koin-android-viewmodel/build.gradle
@@ -23,7 +23,7 @@ dependencies {
 
     // Test
     testImplementation project(":koin-test")
-    testImplementation "org.mockito:mockito-core:$mockito_version"
+    testImplementation "org.mockito:mockito-inline:$mockito_version"
 
     // Architecture ViewModel
     implementation("android.arch.lifecycle:extensions:$android_arch_version") {

--- a/koin-projects/koin-android-viewmodel/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/koin-projects/koin-android-viewmodel/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,1 +1,0 @@
-mock-maker-inline

--- a/koin-projects/koin-android/build.gradle
+++ b/koin-projects/koin-android/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     api project(":koin-core")
     testImplementation project(":koin-test")
 
-    testImplementation "org.mockito:mockito-core:$mockito_version"
+    testImplementation "org.mockito:mockito-inline:$mockito_version"
 }
 
 apply from: '../gradle/publish-android.gradle'

--- a/koin-projects/koin-android/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/koin-projects/koin-android/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,1 +1,0 @@
-mock-maker-inline

--- a/koin-projects/koin-androidx-scope/build.gradle
+++ b/koin-projects/koin-androidx-scope/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     api project(":koin-android") //"org.koin:koin-android:$koin_version"
     // Test
     testImplementation project(":koin-test")
-    testImplementation "org.mockito:mockito-core:$mockito_version"
+    testImplementation "org.mockito:mockito-inline:$mockito_version"
 
     // Architecture ViewModel
     implementation("androidx.lifecycle:lifecycle-common:$androidx_arch_version"){

--- a/koin-projects/koin-androidx-scope/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/koin-projects/koin-androidx-scope/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,1 +1,0 @@
-mock-maker-inline

--- a/koin-projects/koin-androidx-viewmodel/build.gradle
+++ b/koin-projects/koin-androidx-viewmodel/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     api project(":koin-androidx-scope") //"org.koin:koin-android:$koin_version"
     // Test
     testImplementation project(":koin-test")
-    testImplementation "org.mockito:mockito-core:$mockito_version"
+    testImplementation "org.mockito:mockito-inline:$mockito_version"
 
     // Architecture ViewModel
     implementation("androidx.lifecycle:lifecycle-extensions:$androidx_arch_version") {

--- a/koin-projects/koin-androidx-viewmodel/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/koin-projects/koin-androidx-viewmodel/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,1 +1,0 @@
-mock-maker-inline

--- a/koin-projects/koin-test/build.gradle
+++ b/koin-projects/koin-test/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     compile project(":koin-core")
 
     compile "junit:junit:$junit_version"
-    compile "org.mockito:mockito-core:$mockito_version"
+    compile "org.mockito:mockito-inline:$mockito_version"
 
     // Coroutines
     testCompile "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"// Coroutines

--- a/koin-projects/koin-test/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/koin-projects/koin-test/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,1 +1,0 @@
-mock-maker-inline


### PR DESCRIPTION
This PR replaces `mockito-core` with `mockito-inline` which has inline mock maker preconfigured to avoid having to include `src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker` in all projects.

This also means consumers of `koin-test` don't need to include **mockito** explicitly if not using **mockito** for mocking, which was the main motivation for this PR as I'm using **mockk** and would like to not add `mockito-inline` or the `MockMaker` file to my test source.