### PR TITLE
Feature/create with params

### DIFF
--- a/koin-projects/koin-android-viewmodel/src/main/java/org/koin/android/viewmodel/experimental/builder/ModuleDefinitionExt.kt
+++ b/koin-projects/koin-android-viewmodel/src/main/java/org/koin/android/viewmodel/experimental/builder/ModuleDefinitionExt.kt
@@ -17,5 +17,5 @@ inline fun <reified T : ViewModel> ModuleDefinition.viewModel(
     name: String = "",
     override: Boolean = false
 ) {
-    factory(name, override) { create<T>() }.bind(ViewModel::class)
+    factory(name, override) { create<T>(it) }.bind(ViewModel::class)
 }

--- a/koin-projects/koin-android-viewmodel/src/main/java/org/koin/android/viewmodel/experimental/builder/ModuleDefinitionExt.kt
+++ b/koin-projects/koin-android-viewmodel/src/main/java/org/koin/android/viewmodel/experimental/builder/ModuleDefinitionExt.kt
@@ -2,7 +2,7 @@ package org.koin.android.viewmodel.experimental.builder
 
 import android.arch.lifecycle.ViewModel
 import org.koin.dsl.context.ModuleDefinition
-import org.koin.experimental.builder.create
+import org.koin.experimental.builder.factory
 
 /**
  * Create ViewModel for Given type T
@@ -17,5 +17,5 @@ inline fun <reified T : ViewModel> ModuleDefinition.viewModel(
     name: String = "",
     override: Boolean = false
 ) {
-    factory(name, override) { create<T>(it) }.bind(ViewModel::class)
+    factory<T>(name, override).bind(ViewModel::class)
 }

--- a/koin-projects/koin-android-viewmodel/src/test/java/org/koin/test/android/ViewModelDSLWithParamsTest.kt
+++ b/koin-projects/koin-android-viewmodel/src/test/java/org/koin/test/android/ViewModelDSLWithParamsTest.kt
@@ -1,0 +1,50 @@
+package org.koin.test.android
+
+import android.arch.lifecycle.ViewModel
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.koin.android.viewmodel.experimental.builder.viewModel
+import org.koin.core.parameter.parametersOf
+import org.koin.dsl.module.module
+import org.koin.experimental.builder.create
+import org.koin.standalone.StandAloneContext.startKoin
+import org.koin.standalone.get
+import org.koin.test.AutoCloseKoinTest
+
+/**
+ * @author @fredy-mederos
+ */
+class ViewModelDSLWithParamsTest : AutoCloseKoinTest() {
+
+    interface MyService {
+        fun getData(id: Int): String
+    }
+
+    class MyServiceImpl(private val url: String) : MyService {
+        override fun getData(id: Int): String {
+            return "data from $url/$id"
+        }
+    }
+
+    class MyViewModel(
+        private val itemId: Int,
+        private val service: MyService
+    ) : ViewModel() {
+        fun getData() = service.getData(itemId)
+    }
+
+    private val module = module {
+        single<MyService> { create<MyServiceImpl>(it) } //create service with parameters
+        viewModel<MyViewModel>() //create viewmodel with parameters
+    }
+
+    @Test
+    fun view_model_parameters() {
+        startKoin(listOf(module))
+
+        //Getting MyViewModel and passing arguments for service url and itemId
+        val vm1 = get<MyViewModel> { parametersOf("http://url.com", 10) }
+
+        assertEquals("data from http://url.com/10", vm1.getData())
+    }
+}

--- a/koin-projects/koin-test/src/test/kotlin/org/koin/test/builder/AutoBuilderWithParamsTest.kt
+++ b/koin-projects/koin-test/src/test/kotlin/org/koin/test/builder/AutoBuilderWithParamsTest.kt
@@ -1,0 +1,77 @@
+package org.koin.test.builder
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.koin.core.parameter.parametersOf
+import org.koin.dsl.module.module
+import org.koin.experimental.builder.single
+import org.koin.standalone.StandAloneContext.startKoin
+import org.koin.standalone.get
+import org.koin.test.AutoCloseKoinTest
+
+/**
+ * @author @fredy-mederos
+ */
+class AutoBuilderWithParamsTest : AutoCloseKoinTest() {
+
+
+    class ComponentA(
+        val bool: Boolean
+    )
+
+    class ComponentB(
+        val text: String,
+        val a: ComponentA
+    )
+
+    /**
+     * ComponentC contains a lot of fields, some of them will be included in params, others will be obtained from definitions
+     */
+    class ComponentC(
+        val text: String,
+        val text2: String,
+        val text3: String,
+        val n: Int,
+        val a: ComponentA,
+        val b: ComponentB,
+        val bool: Boolean,
+        val d: ComponentD,
+        val l: List<ComponentA>
+    )
+
+    interface ComponentD
+
+    @Test
+    fun `should resolve params and build`() {
+        startKoin(listOf(module {
+            single<ComponentA>()
+            single<ComponentB>()
+            single<ComponentC>()
+            single { "TEXT" }
+        }))
+
+        //Getting componentC and passing some parameters. In parameters of the same type, order matters.
+        val c = get<ComponentC> {
+            parametersOf(
+                1,
+                "text",
+                true,
+                "text2",
+                listOf(ComponentA(false)),
+                object : ComponentD {})
+        }
+
+        //Asserting all componentC fields values
+        assertEquals("text", c.text)
+        assertEquals("text2", c.text2)
+        //only two strings where included in params, the next strings are obtained from definitions
+        assertEquals("TEXT", c.text3)
+        assertEquals(1, c.n)
+        assertEquals(true, c.bool)
+        assertEquals(1, c.l.size)
+
+        //Asserting componentA and componentB when created with componentC params
+        assertEquals("text", c.b.text)
+        assertEquals(true, c.a.bool)
+    }
+}


### PR DESCRIPTION
Including params awareness feature in the experimental "create" function #196 
Example:

```kotlin
 interface MyService {
        fun getData(id: Int): String
    }
     class MyServiceImpl(private val url: String) : MyService {
        override fun getData(id: Int): String {
            return "data from $url/$id"
        }
    }
     class MyViewModel(
        private val itemId: Int,
        private val service: MyService
    ) : ViewModel() {
        fun getData() = service.getData(itemId)
    }
     private val module = module {
        single<MyService> { create<MyServiceImpl>(it) } //create service with parameters
        viewModel<MyViewModel>() //create viewmodel with parameters
    }
     @Test
    fun view_model_parameters() {
        startKoin(listOf(module))
         //Getting MyViewModel and passing arguments for service url and itemId
        val vm1 = get<MyViewModel> { parametersOf("http://url.com", 10) }
         assertEquals("data from http://url.com/10", vm1.getData())
    }
```

Other example in https://github.com/InsertKoinIO/koin/compare/1.0.0...fredy-mederos:feature/create-with-params?expand=1#diff-802c04c8a99752575cb5eb898dde9ed6