### PR TITLE
Fixed typos in documentation

### DIFF
--- a/koin-projects/koin-android-scope/src/docs/asciidoc/scope.adoc
+++ b/koin-projects/koin-android-scope/src/docs/asciidoc/scope.adoc
@@ -74,7 +74,7 @@ val androidModule = module {
 
 [IMPORTANT]
 ====
-Most of Android memory leaks comes from referencing a UI/Android component from a non Android component. Th system keeps a reference
+Most of Android memory leaks comes from referencing a UI/Android component from a non Android component. The system keeps a reference
 on it and can't totally drop it via garbage collection.
 ====
 
@@ -143,7 +143,7 @@ or you can also inject it with Koin DSL. If a presenter need it:
 class Presenter(val userSession : UserSession)
 ----
 
-Just inject it into constructor, with teh right scope:
+Just inject it into constructor, with the right scope:
 
 [source,kotlin]
 ----

--- a/koin-projects/koin-android-viewmodel/src/docs/asciidoc/viewmodel.adoc
+++ b/koin-projects/koin-android-viewmodel/src/docs/asciidoc/viewmodel.adoc
@@ -1,6 +1,6 @@
 == Architecture Components with Koin: ViewModel
 
-The `koin-android-viewmodel` project is dedicated to bring Android Architecture VieModel features.
+The `koin-android-viewmodel` project is dedicated to bring Android Architecture ViewModel features.
 
 === Gradle setup
 
@@ -22,7 +22,7 @@ dependencies {
 
 === ViewModel DSL
 
-The `koin-android-viewmodel` introduces a new `viewModel` DSL keyword that comes in complement of `single` and `factory, to help declare a ViewModel
+The `koin-android-viewmodel` introduces a new `viewModel` DSL keyword that comes in complement of `single` and `factory`, to help declare a ViewModel
 component and bind it to an Android Component lifecycle.
 
 [source,kotlin]
@@ -42,7 +42,7 @@ and use the `get()` function to inject dependencies.
 
 [NOTE]
 ====
-The `viewModel` help declare a factory instance of ViewModel. This instance will be handled by internal ViewModelFactory and reattach ViewModel instance
+The `viewModel` keyword helps declaring a factory instance of ViewModel. This instance will be handled by internal ViewModelFactory and reattach ViewModel instance
 if needed.
 ====
 
@@ -120,7 +120,7 @@ class WeatherListFragment : Fragment() {
 
 [NOTE]
 ====
-The Activity sharing its ViewModel inject it with `by viewModel()` or `getViewModel()`. Fragments are reusing  the shared ViewModel with `by sharedViewModel()`.
+The Activity sharing its ViewModel injects it with `by viewModel()` or `getViewModel()`. Fragments are reusing  the shared ViewModel with `by sharedViewModel()`.
 ====
 
 

--- a/koin-projects/koin-android-viewmodel/src/main/java/org/koin/android/viewmodel/ext/koin/ContextExt.kt
+++ b/koin-projects/koin-android-viewmodel/src/main/java/org/koin/android/viewmodel/ext/koin/ContextExt.kt
@@ -22,7 +22,7 @@ import org.koin.dsl.definition.Definition
 
 /**
  * ViewModel DSL Extension
- * Allow to declare a vieModel - be later inject into Activity/Fragment with dedicated injector
+ * Allow to declare a ViewModel - be later inject into Activity/Fragment with dedicated injector
  *
  * @author Arnaud Giuliani
  *

--- a/koin-projects/koin-android/src/docs/asciidoc/starting-with-android.adoc
+++ b/koin-projects/koin-android/src/docs/asciidoc/starting-with-android.adoc
@@ -32,7 +32,7 @@ startKoin(androidContext, myAppModules)
 
 Also, there is a `with` operator that can help you bind the `Context` instance in the case of non Android class (Junit for example). It can help like follow:
 
-.Example of mocking Androic context in a JUnit
+.Example of mocking Android context in a JUnit
 [source,kotlin]
 ----
 // Start Koin and init Context instance definition

--- a/koin-projects/koin-androidx-viewmodel/src/main/java/org/koin/androidx/viewmodel/ext/koin/ContextExt.kt
+++ b/koin-projects/koin-androidx-viewmodel/src/main/java/org/koin/androidx/viewmodel/ext/koin/ContextExt.kt
@@ -22,7 +22,7 @@ import org.koin.dsl.definition.Definition
 
 /**
  * ViewModel DSL Extension
- * Allow to declare a vieModel - be later inject into Activity/Fragment with dedicated injector
+ * Allow to declare a ViewModel - be later inject into Activity/Fragment with dedicated injector
  *
  * @author Arnaud Giuliani
  *

--- a/koin-projects/koin-core/src/docs/asciidoc/examples.adoc
+++ b/koin-projects/koin-core/src/docs/asciidoc/examples.adoc
@@ -69,7 +69,7 @@ class ElectricHeater : Heater {
 }
 ----
 
-* `Thermosiphon` - is a implmentation of Pump using a `Heater`
+* `Thermosiphon` - is a implementation of Pump using a `Heater`
 
 [source,kotlin]
 ----

--- a/koin-projects/koin-core/src/docs/asciidoc/properties.adoc
+++ b/koin-projects/koin-core/src/docs/asciidoc/properties.adoc
@@ -14,7 +14,7 @@ You can load several type of properties at start:
 
 In a Koin module, you can get a property by its key:
 
-.in /src/main/resoucres/koin.propertie file
+.in /src/main/resoucres/koin.properties file
 [source,java]
 ----
 // Key - value

--- a/koin-projects/koin-core/src/docs/asciidoc/scope-api.adoc
+++ b/koin-projects/koin-core/src/docs/asciidoc/scope-api.adoc
@@ -70,7 +70,7 @@ If one of your definition need to inject a scope instance, just resolve it ... b
 class Presenter(val userSession : UserSession)
 ----
 
-Just inject it into constructor, with teh right scope:
+Just inject it into constructor, with the right scope:
 
 [source,kotlin]
 ----


### PR DESCRIPTION
I have read almost all the 1.0.0 documentation, and found those typos in it.