### PR TITLE
updated gradle version to be able open the samples in Android Studio 3.2

### DIFF
--- a/koin-projects/examples/android-mvp/build.gradle
+++ b/koin-projects/examples/android-mvp/build.gradle
@@ -33,8 +33,6 @@ android {
 }
 
 dependencies {
-    implementation fileTree(dir: 'libs', include: ['*.jar'])
-
     // Android Support
     implementation "com.android.support:appcompat-v7:$support_lib_version"
     implementation "com.android.support:design:$support_lib_version"

--- a/koin-projects/examples/android-mvvm-coroutines/build.gradle
+++ b/koin-projects/examples/android-mvvm-coroutines/build.gradle
@@ -33,8 +33,6 @@ android {
 }
 
 dependencies {
-    implementation fileTree(dir: 'libs', include: ['*.jar'])
-
     // Android Support
     implementation "com.android.support:appcompat-v7:$support_lib_version"
     implementation "com.android.support:design:$support_lib_version"

--- a/koin-projects/examples/android-mvvm/build.gradle
+++ b/koin-projects/examples/android-mvvm/build.gradle
@@ -46,8 +46,6 @@ android {
 }
 
 dependencies {
-    implementation fileTree(dir: 'libs', include: ['*.jar'])
-
     // Android Support
     implementation "com.android.support:appcompat-v7:$support_lib_version"
     implementation "com.android.support:design:$support_lib_version"

--- a/koin-projects/gradle/versions-android.gradle
+++ b/koin-projects/gradle/versions-android.gradle
@@ -4,7 +4,7 @@ ext {
     android_target_version = 27
     androidx_target_version = 28
 
-    android_gradle_version = "3.2.0-rc03"
+    android_gradle_version = "3.2.0"
 
     android_build_tools_version  = '28.0.2'
 


### PR DESCRIPTION
and removed unnecessary imports for jar files - we don't use them and it is a good practice to provide dependencies via maven artifacts