### PR TITLE
Including scopeId param in experimental builders

### DIFF
--- a/koin-projects/koin-core-ext/src/main/kotlin/org/koin/experimental/builder/ModuleDefinitionExt.kt
+++ b/koin-projects/koin-core-ext/src/main/kotlin/org/koin/experimental/builder/ModuleDefinitionExt.kt
@@ -17,6 +17,7 @@ package org.koin.experimental.builder
 
 import org.koin.core.parameter.ParameterDefinition
 import org.koin.core.parameter.emptyParameterDefinition
+import org.koin.core.scope.setScope
 import org.koin.dsl.context.ModuleDefinition
 import org.koin.dsl.definition.BeanDefinition
 import org.koin.dsl.definition.Kind
@@ -51,14 +52,18 @@ inline fun <reified T : Any> ModuleDefinition.factory(
 /**
  * Create a Scope definition for given type T
  *
+ * @param scopeId
  * @param name
  * @param override - allow definition override
  */
 inline fun <reified T : Any> ModuleDefinition.scope(
+    scopeId: String,
     name: String = "",
     override: Boolean = false
 ): BeanDefinition<T> {
-    return provide(name, false, override, Kind.Scope) { create<T>() }
+    val beanDefinition = provide(name, false, override, Kind.Scope) { create<T>() }
+    beanDefinition.setScope(scopeId)
+    return beanDefinition
 }
 
 /**
@@ -101,14 +106,18 @@ inline fun <reified R : Any, reified T : R> ModuleDefinition.factoryBy(
 /**
  * Create a Scope definition for given type T, applied to R
  *
+ * @param scopeId
  * @param name
  * @param override - allow definition override
  */
 inline fun <reified R : Any, reified T : R> ModuleDefinition.scopeBy(
+    scopeId: String,
     name: String = "",
     override: Boolean = false
 ): BeanDefinition<R> {
-    return provide(name, false, override, Kind.Scope) { create<T>() as R }
+    val beanDefinition = provide(name, false, override, Kind.Scope) { create<T>() as R }
+    beanDefinition.setScope(scopeId)
+    return beanDefinition
 }
 
 /**

--- a/koin-projects/koin-core-ext/src/test/kotlin/org/koin/experimental/builder/ScopeAutoBuilderDSLTest.kt
+++ b/koin-projects/koin-core-ext/src/test/kotlin/org/koin/experimental/builder/ScopeAutoBuilderDSLTest.kt
@@ -1,0 +1,91 @@
+package org.koin.experimental.builder
+
+import org.junit.Assert
+import org.junit.Assert.fail
+import org.junit.Test
+import org.koin.dsl.module.module
+import org.koin.error.NoScopeException
+import org.koin.log.PrintLogger
+import org.koin.standalone.StandAloneContext
+import org.koin.standalone.get
+import org.koin.standalone.getKoin
+import org.koin.test.AutoCloseKoinTest
+
+/**
+ * Scope DSL Test using experimental functions [scope] and [scopeBy]
+ * @see org.koin.test.scope.ScopeDSLTest
+ */
+class ScopeAutoBuilderDSLTest : AutoCloseKoinTest() {
+
+    interface IB
+    class A(val b: IB)
+    class B : IB
+
+    @Test
+    fun `use scope id from DSL`() {
+        StandAloneContext.startKoin(listOf(module {
+            scopeBy<IB, B>("session")
+        }), logger = PrintLogger(showDebug = true))
+
+        val koin = getKoin()
+
+        koin.createScope("session")
+
+        val b_1 = get<IB>()
+        val b_2 = get<IB>()
+
+        Assert.assertEquals(b_1, b_2)
+    }
+
+    @Test
+    fun `use closed scope id from DSL`() {
+        StandAloneContext.startKoin(listOf(module {
+            scope<B>("session")
+        }), logger = PrintLogger(showDebug = true))
+
+        val koin = getKoin()
+
+        val session = koin.createScope("session")
+        session.close()
+
+        try {
+            get<B>()
+            fail()
+        } catch (e: NoScopeException) {
+        }
+    }
+
+    @Test
+    fun `use scope id from DSL - dependency with same scope`() {
+        StandAloneContext.startKoin(listOf(module {
+            scopeBy<IB, B>("session")
+            scope<A>("session")
+        }), logger = PrintLogger(showDebug = true))
+
+        val koin = getKoin()
+
+        koin.createScope("session")
+
+        val b = get<IB>()
+        val a = get<A>()
+
+        Assert.assertEquals(a.b, b)
+    }
+
+    @Test
+    fun `use scope id and name from DSL`() {
+        StandAloneContext.startKoin(listOf(module {
+            scopeBy<IB, B>("session", "B1")
+            scopeBy<IB, B>("session", "B2")
+        }), logger = PrintLogger(showDebug = true))
+
+        val koin = getKoin()
+
+        koin.createScope("session")
+
+        val b_1 = get<IB>("B1")
+        val b_2 = get<IB>("B2")
+
+        Assert.assertNotEquals(b_1, b_2)
+    }
+}

--- a/koin-projects/koin-core/src/main/kotlin/org/koin/dsl/context/ModuleDefinition.kt
+++ b/koin-projects/koin-core/src/main/kotlin/org/koin/dsl/context/ModuleDefinition.kt
@@ -160,16 +160,18 @@ class ModuleDefinition(
      * Provide a Scope bean definition - scope provider
      * (can be released/recreated with Scope API)
      *
+     * @param scopeId
      * @param name
      * @param override - allow definition override
      * @param definition
      */
     inline fun <reified T : Any> scope(
         scopeId: String,
+        name: String = "",
         override: Boolean = false,
         noinline definition: Definition<T>
     ): BeanDefinition<T> {
-        val beanDefinition = provide("", false, override, Kind.Scope, definition)
+        val beanDefinition = provide(name, false, override, Kind.Scope, definition)
         beanDefinition.setScope(scopeId)
         return beanDefinition
     }


### PR DESCRIPTION
Including name param in scope functions
Including Tests to validate experimental builders an named scopes