### PR TITLE
Made Logger optional.

### DIFF
--- a/koin-projects/koin-android-scope/src/main/java/org/koin/android/scope/ScopeObserver.kt
+++ b/koin-projects/koin-android-scope/src/main/java/org/koin/android/scope/ScopeObserver.kt
@@ -39,7 +39,7 @@ class ScopeObserver(val event: Lifecycle.Event, val target: Any, val scope: Scop
     @OnLifecycleEvent(Lifecycle.Event.ON_STOP)
     fun onStop() {
         if (event == Lifecycle.Event.ON_STOP) {
-            Koin.logger.info("$target received ON_STOP")
+            Koin.logger?.info("$target received ON_STOP")
             scope.close()
         }
     }
@@ -50,7 +50,7 @@ class ScopeObserver(val event: Lifecycle.Event, val target: Any, val scope: Scop
     @OnLifecycleEvent(Lifecycle.Event.ON_DESTROY)
     fun onDestroy() {
         if (event == Lifecycle.Event.ON_DESTROY) {
-            Koin.logger.info("$target received ON_DESTROY")
+            Koin.logger?.info("$target received ON_DESTROY")
             scope.close()
         }
     }

--- a/koin-projects/koin-android-viewmodel/src/main/java/org/koin/android/viewmodel/ext/android/LifecycleOwnerExt.kt
+++ b/koin-projects/koin-android-viewmodel/src/main/java/org/koin/android/viewmodel/ext/android/LifecycleOwnerExt.kt
@@ -92,7 +92,7 @@ fun <T : ViewModel> LifecycleOwner.getViewModelByClass(
     from: ViewModelStoreOwnerDefinition? = null,
     parameters: ParameterDefinition = emptyParameterDefinition()
 ): T {
-    Koin.logger.info("[ViewModel] ~ '$clazz'(name:'$name' key:'$key') - $this")
+    Koin.logger?.info("[ViewModel] ~ '$clazz'(name:'$name' key:'$key') - $this")
 
     val vmStoreOwner = from?.invoke() ?: this as? ViewModelStoreOwner
     ?: error("Can't getByClass ViewModel '$clazz' on $this - Is not a FragmentActivity nor a Fragment neither a valid ViewModelStoreOwner")
@@ -111,7 +111,7 @@ fun <T : ViewModel> LifecycleOwner.getViewModelByClass(
             viewModelProvider.get(clazz.java)
         }
 
-    Koin.logger.debug("[ViewModel] instance ~ $vmInstance")
+    Koin.logger?.debug("[ViewModel] instance ~ $vmInstance")
     return vmInstance
 }
 

--- a/koin-projects/koin-android/src/main/java/org/koin/android/ext/android/ComponentCallbacksExt.kt
+++ b/koin-projects/koin-android/src/main/java/org/koin/android/ext/android/ComponentCallbacksExt.kt
@@ -53,7 +53,7 @@ fun ComponentCallbacks.startKoin(
     modules: List<Module>,
     extraProperties: Map<String, Any> = HashMap(),
     loadProperties: Boolean = false,
-    logger: Logger = AndroidLogger()
+    logger: Logger? = AndroidLogger()
 ) {
     Koin.logger = logger
 

--- a/koin-projects/koin-android/src/main/java/org/koin/android/ext/koin/KoinExt.kt
+++ b/koin-projects/koin-android/src/main/java/org/koin/android/ext/koin/KoinExt.kt
@@ -34,7 +34,7 @@ import java.util.*
  * @param androidContext - Context
  */
 infix fun Koin.with(androidContext: Context): Koin {
-    Koin.logger.info("[init] declare Android Context")
+    Koin.logger?.info("[init] declare Android Context")
     val definition =
         beanRegistry.declare(
             BeanDefinition(
@@ -71,15 +71,15 @@ fun Koin.bindAndroidProperties(
             try {
                 androidContext.assets.open(koinPropertyFile).use { koinProperties.load(it) }
                 val nb = propertyResolver.import(koinProperties)
-                Koin.logger.info("[Android-Properties] loaded $nb properties from assets/koin.properties")
+                Koin.logger?.info("[Android-Properties] loaded $nb properties from assets/koin.properties")
             } catch (e: Exception) {
-                Koin.logger.info("[Android-Properties] error for binding properties : $e")
+                Koin.logger?.info("[Android-Properties] error for binding properties : $e")
             }
         } else {
-            Koin.logger.info("[Android-Properties] no assets/koin.properties file to load")
+            Koin.logger?.info("[Android-Properties] no assets/koin.properties file to load")
         }
     } catch (e: Exception) {
-        Koin.logger.err("[Android-Properties] error while loading properties from assets/koin.properties : $e")
+        Koin.logger?.err("[Android-Properties] error while loading properties from assets/koin.properties : $e")
     }
     return this
 }

--- a/koin-projects/koin-android/src/test/java/org/koin/test/android/AndroidModuleTest.kt
+++ b/koin-projects/koin-android/src/test/java/org/koin/test/android/AndroidModuleTest.kt
@@ -13,7 +13,6 @@ import org.koin.dsl.module.module
 import org.koin.log.PrintLogger
 import org.koin.standalone.StandAloneContext.startKoin
 import org.koin.standalone.get
-import org.koin.standalone.release
 import org.koin.standalone.setProperty
 import org.koin.test.AutoCloseKoinTest
 import org.koin.test.ext.junit.assertContextInstances

--- a/koin-projects/koin-androidx-scope/src/main/java/org/koin/androidx/scope/ScopeObserver.kt
+++ b/koin-projects/koin-androidx-scope/src/main/java/org/koin/androidx/scope/ScopeObserver.kt
@@ -21,7 +21,6 @@ import androidx.lifecycle.OnLifecycleEvent
 import org.koin.core.Koin
 import org.koin.core.scope.Scope
 import org.koin.standalone.KoinComponent
-import org.koin.standalone.release
 
 /**
  * Observe a LifecycleOwner
@@ -39,7 +38,7 @@ class ScopeObserver(val event: Lifecycle.Event, val target: Any, val scope: Scop
     @OnLifecycleEvent(Lifecycle.Event.ON_STOP)
     fun onStop() {
         if (event == Lifecycle.Event.ON_STOP) {
-            Koin.logger.info("$target received ON_STOP")
+            Koin.logger?.info("$target received ON_STOP")
             scope.close()
         }
     }
@@ -50,7 +49,7 @@ class ScopeObserver(val event: Lifecycle.Event, val target: Any, val scope: Scop
     @OnLifecycleEvent(Lifecycle.Event.ON_DESTROY)
     fun onDestroy() {
         if (event == Lifecycle.Event.ON_DESTROY) {
-            Koin.logger.info("$target received ON_DESTROY")
+            Koin.logger?.info("$target received ON_DESTROY")
             scope.close()
         }
     }

--- a/koin-projects/koin-androidx-viewmodel/src/main/java/org/koin/androidx/viewmodel/ext/android/LifecycleOwnerExt.kt
+++ b/koin-projects/koin-androidx-viewmodel/src/main/java/org/koin/androidx/viewmodel/ext/android/LifecycleOwnerExt.kt
@@ -92,7 +92,7 @@ fun <T : ViewModel> LifecycleOwner.getViewModelByClass(
     from: ViewModelStoreOwnerDefinition? = null,
     parameters: ParameterDefinition = emptyParameterDefinition()
 ): T {
-    Koin.logger.info("[ViewModel] ~ '$clazz'(name:'$name' key:'$key') - $this")
+    Koin.logger?.info("[ViewModel] ~ '$clazz'(name:'$name' key:'$key') - $this")
 
     val vmStoreOwner = from?.invoke() ?: this as? ViewModelStoreOwner
     ?: error("Can't getByClass ViewModel '$clazz' on $this - Is not a FragmentActivity nor a Fragment neither a valid ViewModelStoreOwner")
@@ -108,7 +108,7 @@ fun <T : ViewModel> LifecycleOwner.getViewModelByClass(
         if (key != null)
             viewModelProvider.get(key, clazz.java)
         else viewModelProvider.get(clazz.java)
-    Koin.logger.debug("[ViewModel] instance ~ $vmInstance")
+    Koin.logger?.debug("[ViewModel] instance ~ $vmInstance")
     return vmInstance
 }
 

--- a/koin-projects/koin-core/src/main/kotlin/org/koin/core/Koin.kt
+++ b/koin-projects/koin-core/src/main/kotlin/org/koin/core/Koin.kt
@@ -19,7 +19,6 @@ import org.koin.core.time.measureDuration
 import org.koin.dsl.context.ModuleDefinition
 import org.koin.dsl.module.Module
 import org.koin.dsl.path.Path
-import org.koin.log.EmptyLogger
 import org.koin.log.Logger
 import java.util.*
 import kotlin.reflect.KClass
@@ -57,7 +56,7 @@ class Koin(val koinContext: KoinContext) {
             val koinProperties = Properties()
             koinProperties.load(content.byteInputStream())
             val nb = propertyResolver.import(koinProperties)
-            logger.info("[properties] loaded $nb properties from '$koinFile' file")
+            logger?.info("[properties] loaded $nb properties from '$koinFile' file")
         }
         return this
     }
@@ -67,9 +66,9 @@ class Koin(val koinContext: KoinContext) {
      */
     fun bindEnvironmentProperties(): Koin {
         val n1 = propertyResolver.import(System.getProperties())
-        logger.info("[properties] loaded $n1 properties from properties")
+        logger?.info("[properties] loaded $n1 properties from properties")
         val n2 = propertyResolver.import(System.getenv().toProperties())
-        logger.info("[properties] loaded $n2 properties from env properties")
+        logger?.info("[properties] loaded $n2 properties from env properties")
         return this
     }
 
@@ -82,9 +81,9 @@ class Koin(val koinContext: KoinContext) {
                 registerDefinitions(module())
             }
 
-            logger.info("[modules] loaded ${beanRegistry.definitions.size} definitions")
+            logger?.info("[modules] loaded ${beanRegistry.definitions.size} definitions")
         }
-        logger.debug("[modules] loaded in $duration ms")
+        logger?.debug("[modules] loaded in $duration ms")
         return this
     }
 
@@ -128,7 +127,7 @@ class Koin(val koinContext: KoinContext) {
         /**
          * Koin Logger
          */
-        var logger: Logger = EmptyLogger()
+        var logger: Logger? = null
     }
 }
 

--- a/koin-projects/koin-core/src/main/kotlin/org/koin/core/KoinContext.kt
+++ b/koin-projects/koin-core/src/main/kotlin/org/koin/core/KoinContext.kt
@@ -23,7 +23,6 @@ import org.koin.core.parameter.ParameterDefinition
 import org.koin.core.parameter.emptyParameterDefinition
 import org.koin.core.property.PropertyRegistry
 import org.koin.core.scope.Scope
-import org.koin.core.scope.ScopeCallback
 import org.koin.core.scope.ScopeRegistry
 import org.koin.error.MissingPropertyException
 import org.koin.error.NoScopeFoundException
@@ -138,7 +137,7 @@ class KoinContext(
      * Close all resources
      */
     fun close() {
-        logger.info("[Close] Closing Koin context")
+        logger?.info("[Close] Closing Koin context")
         instanceRegistry.close()
         scopeRegistry.close()
         propertyResolver.clear()

--- a/koin-projects/koin-core/src/main/kotlin/org/koin/core/bean/BeanRegistry.kt
+++ b/koin-projects/koin-core/src/main/kotlin/org/koin/core/bean/BeanRegistry.kt
@@ -53,7 +53,7 @@ class BeanRegistry() {
         definitions += definition
 
         val kw = if (isOverriding) "override" else "declare"
-        Koin.logger.info("[module] $kw $definition")
+        Koin.logger?.info("[module] $kw $definition")
     }
 
     fun searchByClass(

--- a/koin-projects/koin-core/src/main/kotlin/org/koin/core/instance/InstanceFactory.kt
+++ b/koin-projects/koin-core/src/main/kotlin/org/koin/core/instance/InstanceFactory.kt
@@ -91,7 +91,7 @@ open class InstanceFactory {
      */
     fun release(definition: BeanDefinition<*>, scope: Scope? = null) {
         if (definition.kind == Kind.Scope) {
-            Koin.logger.debug("release $definition")
+            Koin.logger?.debug("release $definition")
             val holder = find(definition, scope)
             holder?.let {
                 instances.remove(it)

--- a/koin-projects/koin-core/src/main/kotlin/org/koin/core/instance/InstanceRegistry.kt
+++ b/koin-projects/koin-core/src/main/kotlin/org/koin/core/instance/InstanceRegistry.kt
@@ -80,7 +80,7 @@ class InstanceRegistry(
 
         var resultInstance: T? = null
         val clazzName = clazz.fullname()
-        val logIndent: String = resolutionStack.indent()
+        val logIndent: String by lazy(LazyThreadSafetyMode.NONE) { resolutionStack.indent() }
         val duration = measureDuration {
             try {
                 val beanDefinition: BeanDefinition<T> =
@@ -95,9 +95,10 @@ class InstanceRegistry(
                 val associatedScopeId = beanDefinition.getScope()
                 val targetScope : Scope? = scope ?: if (associatedScopeId.isNotEmpty()) scopeRegistry.getScope(associatedScopeId) else null
 
-                val logPath =
-                        if ("${beanDefinition.path}".isEmpty()) "" else "@ ${beanDefinition.path}"
-                val startChar = if (resolutionStack.isEmpty()) "+" else "+"
+                val logPath: String by lazy(LazyThreadSafetyMode.NONE) {
+                    if ("${beanDefinition.path}".isEmpty()) "" else "@ ${beanDefinition.path}"
+                }
+                val startChar: String by lazy(LazyThreadSafetyMode.NONE) { if (resolutionStack.isEmpty()) "+" else "+" }
 
                 Koin.logger?.info("$logIndent$startChar-- '$clazzName' $logPath") // @ [$beanDefinition]")
                 Koin.logger?.debug("$logIndent|-- [$beanDefinition]")

--- a/koin-projects/koin-core/src/main/kotlin/org/koin/core/instance/InstanceRegistry.kt
+++ b/koin-projects/koin-core/src/main/kotlin/org/koin/core/instance/InstanceRegistry.kt
@@ -98,9 +98,8 @@ class InstanceRegistry(
                 val logPath: String by lazy(LazyThreadSafetyMode.NONE) {
                     if ("${beanDefinition.path}".isEmpty()) "" else "@ ${beanDefinition.path}"
                 }
-                val startChar: String by lazy(LazyThreadSafetyMode.NONE) { if (resolutionStack.isEmpty()) "+" else "+" }
 
-                Koin.logger?.info("$logIndent$startChar-- '$clazzName' $logPath") // @ [$beanDefinition]")
+                Koin.logger?.info("$logIndent+-- '$clazzName' $logPath") // @ [$beanDefinition]")
                 Koin.logger?.debug("$logIndent|-- [$beanDefinition]")
 
                 resolutionStack.resolve(beanDefinition) {

--- a/koin-projects/koin-core/src/main/kotlin/org/koin/core/instance/InstanceRegistry.kt
+++ b/koin-projects/koin-core/src/main/kotlin/org/koin/core/instance/InstanceRegistry.kt
@@ -99,8 +99,8 @@ class InstanceRegistry(
                         if ("${beanDefinition.path}".isEmpty()) "" else "@ ${beanDefinition.path}"
                 val startChar = if (resolutionStack.isEmpty()) "+" else "+"
 
-                Koin.logger.info("$logIndent$startChar-- '$clazzName' $logPath") // @ [$beanDefinition]")
-                Koin.logger.debug("$logIndent|-- [$beanDefinition]")
+                Koin.logger?.info("$logIndent$startChar-- '$clazzName' $logPath") // @ [$beanDefinition]")
+                Koin.logger?.debug("$logIndent|-- [$beanDefinition]")
 
                 resolutionStack.resolve(beanDefinition) {
                     val (instance, created) = instanceFactory.retrieveInstance(
@@ -109,21 +109,21 @@ class InstanceRegistry(
                         targetScope
                     )
 
-                    Koin.logger.debug("$logIndent|-- $instance")
+                    Koin.logger?.debug("$logIndent|-- $instance")
                     // Log creation
                     if (created) {
-                        Koin.logger.info("$logIndent\\-- (*) Created")
+                        Koin.logger?.info("$logIndent\\-- (*) Created")
                     }
                     resultInstance = instance
                 }
             } catch (e: Exception) {
                 resolutionStack.clear()
-                Koin.logger.err("Error while resolving instance for class '$clazzName' - error: $e ")
+                Koin.logger?.err("Error while resolving instance for class '$clazzName' - error: $e ")
                 throw e
             }
         }
 
-        Koin.logger.debug("$logIndent!-- [$clazzName] resolved in $duration ms")
+        Koin.logger?.debug("$logIndent!-- [$clazzName] resolved in $duration ms")
 
         return if (resultInstance != null) resultInstance!! else error("Could not create instance for $clazzName")
     }
@@ -136,7 +136,7 @@ class InstanceRegistry(
         val definitions = beanRegistry.definitions.filter { it.isEager }
 
         if (definitions.isNotEmpty()) {
-            Koin.logger.info("Creating instances ...")
+            Koin.logger?.info("Creating instances ...")
             createInstances(definitions, defaultParameters)
         }
     }
@@ -170,7 +170,7 @@ class InstanceRegistry(
      * Close res
      */
     fun close() {
-        Koin.logger.debug("[Close] Closing instance resolver")
+        Koin.logger?.debug("[Close] Closing instance resolver")
         resolutionStack.clear()
         instanceFactory.clear()
         beanRegistry.clear()

--- a/koin-projects/koin-core/src/main/kotlin/org/koin/core/instance/ScopeInstanceHolder.kt
+++ b/koin-projects/koin-core/src/main/kotlin/org/koin/core/instance/ScopeInstanceHolder.kt
@@ -23,7 +23,7 @@ class ScopeInstanceHolder<T>(override val bean: BeanDefinition<T>, val scope : S
         if (needCreation){
             instance = create(parameters)
         }
-        Koin.logger.debug("[Scope] get '$instance' from $scope")
+        Koin.logger?.debug("[Scope] get '$instance' from $scope")
         return Instance(instance as T, needCreation)
     }
 

--- a/koin-projects/koin-core/src/main/kotlin/org/koin/core/property/PropertyRegistry.kt
+++ b/koin-projects/koin-core/src/main/kotlin/org/koin/core/property/PropertyRegistry.kt
@@ -59,7 +59,7 @@ class PropertyRegistry {
      */
     inline fun <reified T> getProperty(key: String, defaultValue: T): T {
         val value = getValue(key) ?: defaultValue
-        Koin.logger.debug("[Property] get $key << '$value'")
+        Koin.logger?.debug("[Property] get $key << '$value'")
         return value
     }
 
@@ -67,7 +67,7 @@ class PropertyRegistry {
      * Add properties
      */
     fun addAll(props: Map<String, Any>) {
-        Koin.logger.debug("[Property] add properties ${props.size}")
+        Koin.logger?.debug("[Property] add properties ${props.size}")
         properties += props
     }
 
@@ -91,7 +91,7 @@ class PropertyRegistry {
      * Add property
      */
     fun add(key: String, value: Any) {
-        Koin.logger.debug("[Property] set $key >> '$value'")
+        Koin.logger?.debug("[Property] set $key >> '$value'")
         properties += Pair(key, value)
     }
 
@@ -99,7 +99,7 @@ class PropertyRegistry {
      * Delete a property
      */
     fun delete(key: String) {
-        Koin.logger.debug("[Property] release $key")
+        Koin.logger?.debug("[Property] release $key")
         properties.remove(key)
     }
 

--- a/koin-projects/koin-core/src/main/kotlin/org/koin/core/scope/Scope.kt
+++ b/koin-projects/koin-core/src/main/kotlin/org/koin/core/scope/Scope.kt
@@ -33,7 +33,7 @@ class Scope(val id : String, val scopeRegistry: ScopeRegistry) {
     lateinit var instanceFactory: InstanceFactory
 
     fun close(){
-        Koin.logger.info("[Scope] closing '$id'")
+        Koin.logger?.info("[Scope] closing '$id'")
         holders.forEach {
             it.release()
             instanceFactory.release(it.bean,this)

--- a/koin-projects/koin-core/src/main/kotlin/org/koin/core/scope/ScopeRegistry.kt
+++ b/koin-projects/koin-core/src/main/kotlin/org/koin/core/scope/ScopeRegistry.kt
@@ -32,7 +32,7 @@ class ScopeRegistry {
         if (found == null) {
             found = Scope(id, this)
             scopes[id] = found
-            Koin.logger.info("[Scope] create $id")
+            Koin.logger?.info("[Scope] create $id")
         }
         return found
     }
@@ -42,7 +42,7 @@ class ScopeRegistry {
         if (found == null) {
             found = Scope(id, this)
             scopes[id] = found
-            Koin.logger.info("[Scope] create $id")
+            Koin.logger?.info("[Scope] create $id")
         } else {
             error("Already created scope with id '$id'")
         }
@@ -61,11 +61,11 @@ class ScopeRegistry {
     fun close() {
         scopes.values.forEach { it.holders.clear() }
         scopes.clear()
-        Koin.logger.debug("[Close] Closing all scopes")
+        Koin.logger?.debug("[Close] Closing all scopes")
     }
 
     fun register(callback: ScopeCallback) {
-        Koin.logger.info("[Scope] callback registering with $callback")
+        Koin.logger?.info("[Scope] callback registering with $callback")
         scopeCallbacks += callback
     }
 }

--- a/koin-projects/koin-core/src/main/kotlin/org/koin/standalone/StandAloneContext.kt
+++ b/koin-projects/koin-core/src/main/kotlin/org/koin/standalone/StandAloneContext.kt
@@ -17,7 +17,6 @@ package org.koin.standalone
 
 import org.koin.core.Koin
 import org.koin.core.KoinContext
-import org.koin.core.scope.ScopeCallback
 import org.koin.core.bean.BeanRegistry
 import org.koin.core.instance.InstanceFactory
 import org.koin.core.instance.InstanceRegistry
@@ -26,6 +25,7 @@ import org.koin.core.parameter.ParameterDefinition
 import org.koin.core.parameter.emptyParameterDefinition
 import org.koin.core.path.PathRegistry
 import org.koin.core.property.PropertyRegistry
+import org.koin.core.scope.ScopeCallback
 import org.koin.core.scope.ScopeRegistry
 import org.koin.core.time.measureDuration
 import org.koin.dsl.module.Module
@@ -71,7 +71,7 @@ object StandAloneContext {
      */
     private fun createContextIfNeeded() = synchronized(this) {
         if (!isStarted) {
-            Koin.logger.info("[context] create")
+            Koin.logger?.info("[context] create")
             val propertyResolver = PropertyRegistry()
             val scopeRegistry = ScopeRegistry()
             val instanceResolver = InstanceRegistry(
@@ -122,17 +122,17 @@ object StandAloneContext {
         val koin = getKoin()
 
         if (useKoinPropertiesFile) {
-            Koin.logger.info("[properties] load koin.properties")
+            Koin.logger?.info("[properties] load koin.properties")
             koin.bindKoinProperties()
         }
 
         if (extraProperties.isNotEmpty()) {
-            Koin.logger.info("[properties] load extras properties : ${extraProperties.size}")
+            Koin.logger?.info("[properties] load extras properties : ${extraProperties.size}")
             koin.bindAdditionalProperties(extraProperties)
         }
 
         if (useEnvironmentProperties) {
-            Koin.logger.info("[properties] load environment properties")
+            Koin.logger?.info("[properties] load environment properties")
             koin.bindEnvironmentProperties()
         }
         return koin
@@ -152,7 +152,7 @@ object StandAloneContext {
         useEnvironmentProperties: Boolean = false,
         useKoinPropertiesFile: Boolean = false,
         extraProperties: Map<String, Any> = HashMap(),
-        logger: Logger = PrintLogger()
+        logger: Logger? = PrintLogger()
     ): Koin {
         val duration = measureDuration {
             if (isStarted) {
@@ -169,7 +169,7 @@ object StandAloneContext {
             createEagerInstances(emptyParameterDefinition())
         }
 
-        Koin.logger.debug("Koin started in $duration ms")
+        Koin.logger?.debug("Koin started in $duration ms")
         return getKoin()
     }
 

--- a/koin-projects/koin-spark/src/main/kotlin/org/koin/spark/Spark.kt
+++ b/koin-projects/koin-spark/src/main/kotlin/org/koin/spark/Spark.kt
@@ -22,7 +22,6 @@ import org.koin.log.Logger.SLF4JLogger
 import org.koin.standalone.StandAloneContext
 import org.koin.standalone.StandAloneContext.createEagerInstances
 import org.koin.standalone.StandAloneContext.loadKoinModules
-import org.koin.standalone.StandAloneContext.startKoin
 import org.koin.standalone.StandAloneContext.stopKoin
 import spark.Spark
 import spark.kotlin.after

--- a/koin-projects/koin-test/src/main/kotlin/org/koin/test/AutoCloseKoinTest.kt
+++ b/koin-projects/koin-test/src/main/kotlin/org/koin/test/AutoCloseKoinTest.kt
@@ -28,7 +28,7 @@ abstract class AutoCloseKoinTest() : KoinTest {
 
     @After
     fun autoClose() {
-        Koin.logger.info("AutoClose Koin")
+        Koin.logger?.info("AutoClose Koin")
         stopKoin()
     }
 }

--- a/koin-projects/koin-test/src/main/kotlin/org/koin/test/KoinTest.kt
+++ b/koin-projects/koin-test/src/main/kotlin/org/koin/test/KoinTest.kt
@@ -74,7 +74,7 @@ inline fun <reified T : Any> KoinTest.declareMock(
     binds: List<KClass<*>> = emptyList()
 ) {
     val clazz = T::class.java
-    Koin.logger.info("[mock] declare mock for $clazz")
+    Koin.logger?.info("[mock] declare mock for $clazz")
     StandAloneContext.loadKoinModules(
         module(module ?: Path.ROOT) {
             val def = if (!isFactory) {
@@ -95,9 +95,9 @@ inline fun <reified T : Any> KoinTest.declareMock(
  * Displays Module paths
  */
 fun dumpModulePaths() {
-    Koin.logger.info("Module paths:")
+    Koin.logger?.info("Module paths:")
     (StandAloneContext.koinContext as KoinContext).instanceRegistry.pathRegistry.paths.forEach {
-        Koin.logger.info(
+        Koin.logger?.info(
             "[$it]"
         )
     }

--- a/koin-projects/koin-test/src/main/kotlin/org/koin/test/core/StandAloneContextExt.kt
+++ b/koin-projects/koin-test/src/main/kotlin/org/koin/test/core/StandAloneContextExt.kt
@@ -17,9 +17,9 @@ import org.koin.test.ext.koin.dryRun
 /**
  * Check all definition's dependencies
  */
-fun StandAloneContext.checkModules(list: List<Module>, logger: Logger) {
+fun StandAloneContext.checkModules(list: List<Module>, logger: Logger?) {
     Koin.logger = logger //PrintLogger(showDebug = true)
-    Koin.logger.info("[Sandbox]")
+    Koin.logger?.info("[Sandbox]")
     val scopeRegistry = ScopeRegistry()
     koinContext =
             KoinContext(

--- a/koin-projects/koin-test/src/main/kotlin/org/koin/test/core/instance/SandboxInstanceHolder.kt
+++ b/koin-projects/koin-test/src/main/kotlin/org/koin/test/core/instance/SandboxInstanceHolder.kt
@@ -33,7 +33,7 @@ class SandboxInstanceHolder<T>(override val bean: BeanDefinition<T>) : InstanceH
                 is NoBeanDefFoundException, is DependencyResolutionException, is BeanInstanceCreationException -> {
                     throw BrokenDefinitionException("Definition $bean is broken due to error : $e")
                 }
-                else -> Koin.logger.err("sandbox ~ intercepted error : $e")
+                else -> Koin.logger?.err("sandbox ~ intercepted error : $e")
             }
         }
         val clazz = bean.clazz.java

--- a/koin-projects/koin-test/src/main/kotlin/org/koin/test/ext/koin/KoinContextExt.kt
+++ b/koin-projects/koin-test/src/main/kotlin/org/koin/test/ext/koin/KoinContextExt.kt
@@ -36,7 +36,7 @@ import kotlin.reflect.KClass
  * Check all loaded definitions by resolving them one by one
  */
 fun KoinContext.dryRun(defaultParameters: ParameterDefinition) {
-    Koin.logger.info("[Check Modules]")
+    Koin.logger?.info("[Check Modules]")
 
     instanceRegistry.dryRun(defaultParameters)
 }

--- a/koin-projects/koin-test/src/test/kotlin/org/koin/test/core/StackTest.kt
+++ b/koin-projects/koin-test/src/test/kotlin/org/koin/test/core/StackTest.kt
@@ -7,7 +7,6 @@ import org.koin.core.Koin
 import org.koin.dsl.path.Path
 import org.koin.dsl.module.module
 import org.koin.error.BeanInstanceCreationException
-import org.koin.error.NotVisibleException
 import org.koin.log.PrintLogger
 import org.koin.standalone.StandAloneContext.startKoin
 import org.koin.standalone.get


### PR DESCRIPTION
For performance reason it is better to do the Logger as optional. Because if we use the EmptyLogger, It formats the duration message and visualizing the dependency graph even without printing them.