### PR TITLE
Added warning about ProGuard

### DIFF
--- a/koin-projects/koin-core/src/docs/asciidoc/dsl.adoc
+++ b/koin-projects/koin-core/src/docs/asciidoc/dsl.adoc
@@ -480,3 +480,7 @@ val myModule = module {
     single<Controller> { create<ControllerImpl>() }
 }
 ----
+
+===== Using ProGuard/R8 with create()
+
+When using ProGuard or R8, non-used classes and methods are removed. If you never use the constructor of a class other than with `create()`, ProGuard will remove the constructor because it does not see any usage of it. Fix it by either not using `create()` for such cases, or by adapting your ProGuard rules.


### PR DESCRIPTION
I had a problem after using `create()` on Android. My debug builds always worked, but then it failed on a release build. 
This was because my classes' constructor where removed by R8.

I added a warning in the documentation about it.