### PR TITLE
Fix missing parameter in example code

### DIFF
--- a/koin-projects/koin-core/src/docs/asciidoc/scope-api.adoc
+++ b/koin-projects/koin-core/src/docs/asciidoc/scope-api.adoc
@@ -76,7 +76,7 @@ Just inject it into constructor, with the right scope:
 ----
 module {
     // Shared user session data
-    scope { UserSession() }
+    scope("session") { UserSession() }
     // Inject UserSession instance from "session" Scope
     factory { Presenter(get())}
 }


### PR DESCRIPTION
Currently [Koin Reference Documentation](https://insert-koin.io/docs/1.0/documentation/reference/index.html#_inject_it_with_dsl) has (what I believe) to be an invalid example.

At first I couldn't understand how that specific example did its magic and when I tried to copy that example there was a compilation error.

This PR should fix it.