### PR TITLE
Update starting-with-koin-test.adoc

### DIFF
--- a/koin-projects/koin-test/src/docs/asciidoc/starting-with-koin-test.adoc
+++ b/koin-projects/koin-test/src/docs/asciidoc/starting-with-koin-test.adoc
@@ -4,7 +4,7 @@ The `koin-test` project is dedicated to help you making JUnit test with Koin con
 
 === Gradle setup
 
-Add the `koin-android` dependency to your Gradle project:
+Add the `koin-test` dependency to your Gradle project:
 
 [source,gradle,subs="attributes"]
 ----


### PR DESCRIPTION
I was reading through the docs and noticed this issue. I'll update this PR if I find anything else that's wrong and ping a maintainer once I'm done reading.

I'm not sure where the source for [this](https://insert-koin.io/docs/1.0/documentation/reference/index.html#_making_your_test_a_koincomponent_with_kointest) is, but:

`help you hceck your configuration` -> `help you check your configuration`