### PR TITLE
Add in Koin as an Argument for Android Library and View Model Library

### DIFF
--- a/koin-projects/koin-android-viewmodel/src/main/java/org/koin/android/viewmodel/ViewModelResolution.kt
+++ b/koin-projects/koin-android-viewmodel/src/main/java/org/koin/android/viewmodel/ViewModelResolution.kt
@@ -3,12 +3,16 @@ package org.koin.android.viewmodel
 import android.arch.lifecycle.*
 import android.support.v4.app.Fragment
 import android.support.v4.app.FragmentActivity
+import org.koin.core.Koin
 import org.koin.core.KoinComponent
+import org.koin.core.context.GlobalContext
 
-fun <T : ViewModel> LifecycleOwner.resolveViewModelInstance(parameters: ViewModelParameters<T>): T {
+fun <T : ViewModel> LifecycleOwner.resolveViewModelInstance(
+        parameters: ViewModelParameters<T>,
+        koin: Koin = GlobalContext.get().koin): T {
     val vmStore: ViewModelStore = getViewModelStore(parameters)
 
-    val viewModelProvider = makeViewModelProvider(vmStore, parameters)
+    val viewModelProvider = makeViewModelProvider(vmStore, parameters,koin)
 
     return viewModelProvider.getInstance(parameters)
 }
@@ -32,13 +36,14 @@ private fun <T : ViewModel> LifecycleOwner.getViewModelStore(
 
 private fun <T : ViewModel> makeViewModelProvider(
     vmStore: ViewModelStore,
-    parameters: ViewModelParameters<T>
+    parameters: ViewModelParameters<T>,
+    koin: Koin = GlobalContext.get().koin
 ): ViewModelProvider {
     return ViewModelProvider(
         vmStore,
-        object : ViewModelProvider.Factory, KoinComponent {
+        object : ViewModelProvider.Factory {
             override fun <T : ViewModel> create(modelClass: Class<T>): T {
-                return getKoin().get(parameters.clazz, parameters.name, null, parameters.parameters)
+                return koin.get(parameters.clazz, parameters.name, null, parameters.parameters)
             }
         })
 }

--- a/koin-projects/koin-android-viewmodel/src/main/java/org/koin/android/viewmodel/ext/FragmentExt.kt
+++ b/koin-projects/koin-android-viewmodel/src/main/java/org/koin/android/viewmodel/ext/FragmentExt.kt
@@ -21,6 +21,8 @@ import android.support.v4.app.Fragment
 import org.koin.android.viewmodel.ViewModelParameters
 import org.koin.android.viewmodel.ViewModelStoreOwnerDefinition
 import org.koin.android.viewmodel.resolveViewModelInstance
+import org.koin.core.Koin
+import org.koin.core.context.GlobalContext
 import org.koin.core.parameter.ParametersDefinition
 
 /**
@@ -35,12 +37,14 @@ import org.koin.core.parameter.ParametersDefinition
  * @param name - Koin BeanDefinition name (if have several ViewModel beanDefinition of the same type)
  * @param from - ViewModelStoreOwner that will store the viewModel instance. Examples: "parentFragment", "activity". Default: "activity"
  * @param parameters - parameters to pass to the BeanDefinition
+ * @param koin - Custom koin for context isolation
  */
 inline fun <reified T : ViewModel> Fragment.sharedViewModel(
     name: String? = null,
     noinline from: ViewModelStoreOwnerDefinition = { activity as ViewModelStoreOwner },
-    noinline parameters: ParametersDefinition? = null
-) = lazy { getSharedViewModel<T>(name, from, parameters) }
+    noinline parameters: ParametersDefinition? = null,
+    koin: Koin = GlobalContext.get().koin
+) = lazy { getSharedViewModel<T>(name, from, parameters, koin) }
 
 /**
  * Get a shared viewModel instance from underlying Activity
@@ -48,16 +52,18 @@ inline fun <reified T : ViewModel> Fragment.sharedViewModel(
  * @param name - Koin BeanDefinition name (if have several ViewModel beanDefinition of the same type)
  * @param from - ViewModelStoreOwner that will store the viewModel instance. Examples: ("parentFragment", "activity"). Default: "activity"
  * @param parameters - parameters to pass to the BeanDefinition
+ * @param koin - Custom koin for context isolation
  */
 inline fun <reified T : ViewModel> Fragment.getSharedViewModel(
     name: String? = null,
     noinline from: ViewModelStoreOwnerDefinition = { activity as ViewModelStoreOwner },
-    noinline parameters: ParametersDefinition? = null
+    noinline parameters: ParametersDefinition? = null,
+    koin: Koin = GlobalContext.get().koin
 ) = resolveViewModelInstance(
     ViewModelParameters(
         T::class,
         name,
         from,
         parameters
-    )
+    ), koin
 )

--- a/koin-projects/koin-android-viewmodel/src/main/java/org/koin/android/viewmodel/ext/KoinComponentExt.kt
+++ b/koin-projects/koin-android-viewmodel/src/main/java/org/koin/android/viewmodel/ext/KoinComponentExt.kt
@@ -21,26 +21,32 @@ import android.arch.lifecycle.LifecycleOwner
 import android.arch.lifecycle.ViewModel
 import org.koin.android.viewmodel.ViewModelParameters
 import org.koin.android.viewmodel.resolveViewModelInstance
+import org.koin.core.Koin
 import org.koin.core.KoinComponent
+import org.koin.core.context.GlobalContext
 
 /**
  * Lazy getByClass a viewModel instance
  *
  * @param lifecycleOwner
  * @param parameters
+ * @param koin - Custom koin for context isolation
  */
 inline fun <reified T : ViewModel> KoinComponent.viewModel(
     lifecycleOwner: LifecycleOwner,
-    parameters: ViewModelParameters<T>
-) = lazy { getViewModel(lifecycleOwner, parameters) }
+    parameters: ViewModelParameters<T>,
+    koin: Koin = GlobalContext.get().koin
+) = lazy { getViewModel(lifecycleOwner, parameters, koin) }
 
 /**
  * Get a viewModel instance
  *
  * @param lifecycleOwner
  * @param parameters
+ * @param koin - Custom koin for context isolation
  */
 inline fun <reified T : ViewModel> KoinComponent.getViewModel(
     lifecycleOwner: LifecycleOwner,
-    parameters: ViewModelParameters<T>
-) = lifecycleOwner.resolveViewModelInstance(parameters)
+    parameters: ViewModelParameters<T>,
+    koin: Koin = GlobalContext.get().koin
+) = lifecycleOwner.resolveViewModelInstance(parameters, koin)

--- a/koin-projects/koin-android-viewmodel/src/main/java/org/koin/android/viewmodel/ext/LifecycleOwnerExt.kt
+++ b/koin-projects/koin-android-viewmodel/src/main/java/org/koin/android/viewmodel/ext/LifecycleOwnerExt.kt
@@ -19,6 +19,8 @@ import android.arch.lifecycle.LifecycleOwner
 import android.arch.lifecycle.ViewModel
 import org.koin.android.viewmodel.ViewModelParameters
 import org.koin.android.viewmodel.resolveViewModelInstance
+import org.koin.core.Koin
+import org.koin.core.context.GlobalContext
 import org.koin.core.parameter.ParametersDefinition
 import kotlin.reflect.KClass
 
@@ -34,10 +36,12 @@ import kotlin.reflect.KClass
  * @param VIEW_MODEL_KEY - ViewModel Factory VIEW_MODEL_KEY (if have several instances from same ViewModel)
  * @param name - Koin BeanDefinition name (if have several ViewModel beanDefinition of the same type)
  * @param parameters - parameters to pass to the BeanDefinition
+ * @param koin - Custom koin for context isolation
  */
 inline fun <reified T : ViewModel> LifecycleOwner.viewModel(
     name: String? = null,
-    noinline parameters: ParametersDefinition? = null
+    noinline parameters: ParametersDefinition? = null,
+    koin: Koin = GlobalContext.get().koin
 ) = lazy { getViewModel<T>(name, parameters) }
 
 /**
@@ -46,17 +50,19 @@ inline fun <reified T : ViewModel> LifecycleOwner.viewModel(
  * @param VIEW_MODEL_KEY - ViewModel Factory VIEW_MODEL_KEY (if have several instances from same ViewModel)
  * @param name - Koin BeanDefinition name (if have several ViewModel beanDefinition of the same type)
  * @param parameters - parameters to pass to the BeanDefinition
+ * @param koin - Custom koin for context isolation
  */
 inline fun <reified T : ViewModel> LifecycleOwner.getViewModel(
     name: String? = null,
-    noinline parameters: ParametersDefinition? = null
+    noinline parameters: ParametersDefinition? = null,
+    koin: Koin = GlobalContext.get().koin
 ) = resolveViewModelInstance(
     ViewModelParameters(
         T::class,
         name,
         null,
         parameters
-    )
+    ), koin
 )
 
 
@@ -72,13 +78,14 @@ inline fun <reified T : ViewModel> LifecycleOwner.getViewModel(
 fun <T : ViewModel> LifecycleOwner.getViewModel(
     clazz: KClass<T>,
     name: String? = null,
-    parameters: ParametersDefinition? = null
+    parameters: ParametersDefinition? = null,
+    koin: Koin = GlobalContext.get().koin
 ) = resolveViewModelInstance(
     ViewModelParameters(
         clazz,
         name,
         null,
         parameters
-    )
+    ), koin
 )
 

--- a/koin-projects/koin-android/src/main/java/org/koin/android/ext/android/ComponentCallbacksExt.kt
+++ b/koin-projects/koin-android/src/main/java/org/koin/android/ext/android/ComponentCallbacksExt.kt
@@ -39,21 +39,25 @@ fun ComponentCallbacks.getKoin(): Koin = GlobalContext.get().koin
  * @param name - bean name / optional
  * @param scope
  * @param parameters - injection parameters
+ * @param koin - Custom koin for context isolation
  */
 inline fun <reified T : Any> ComponentCallbacks.inject(
         name: String = "",
         scope: ScopeInstance? = null,
-        noinline parameters: ParametersDefinition? = null
-) = lazy { get<T>(name, scope, parameters) }
+        noinline parameters: ParametersDefinition? = null,
+        koin:Koin = GlobalContext.get().koin
+) = lazy { get<T>(name, scope, parameters, koin) }
 
 /**
  * get given dependency for Android koincomponent
  * @param name - bean name
  * @param scope
  * @param parameters - injection parameters
+ * @param koin - Custom koin for context isolation
  */
 inline fun <reified T : Any> ComponentCallbacks.get(
         name: String = "",
         scope: ScopeInstance? = null,
-        noinline parameters: ParametersDefinition? = null
-): T = getKoin().get(name, scope, parameters)
+        noinline parameters: ParametersDefinition? = null,
+        koin:Koin = GlobalContext.get().koin
+): T = koin.get(name, scope, parameters)


### PR DESCRIPTION
Solves the problem of developing an Android SDK with its own Koin context
If a local koin is required it can be passed in. 
The default uses the global context to maintain compatibility