### PR TITLE
Use parameter name to retrieve same ViewModel from ViewModelProvider

### DIFF
--- a/koin-projects/koin-android-viewmodel/src/main/java/org/koin/android/viewmodel/ViewModelResolution.kt
+++ b/koin-projects/koin-android-viewmodel/src/main/java/org/koin/android/viewmodel/ViewModelResolution.kt
@@ -16,7 +16,9 @@ fun <T : ViewModel> LifecycleOwner.resolveViewModelInstance(parameters: ViewMode
 private fun <T : ViewModel> ViewModelProvider.getInstance(
     parameters: ViewModelParameters<T>
 ): T {
-    return this.get(parameters.clazz.java)
+    return parameters.name?.let{
+        this.get(it, parameters.clazz.java)
+    } ?: this.get(parameters.clazz.java)
 }
 
 private fun <T : ViewModel> LifecycleOwner.getViewModelStore(


### PR DESCRIPTION
Let users have differents sharedViewModel with same class name. Plus it's more viewModel friendly to use a key instead of rely on a single shared factory instance.