### PR TITLE
Don't override logging level due to logger default parameter, cf #374

### DIFF
--- a/koin-projects/examples/android-mvp/src/test/java/fr/ekito/myweatherapp/ModuleCheckTest.kt
+++ b/koin-projects/examples/android-mvp/src/test/java/fr/ekito/myweatherapp/ModuleCheckTest.kt
@@ -23,7 +23,7 @@ class ModuleCheckTest : KoinTest {
     @Test
     fun testRemoteConfiguration() {
         koinApplication {
-            logger(Level.DEBUG)
+            printLogger(Level.DEBUG)
             modules(onlineWeatherApp)
         }.checkModules()
     }
@@ -31,7 +31,7 @@ class ModuleCheckTest : KoinTest {
     @Test
     fun testLocalConfiguration() {
         koinApplication {
-            logger(Level.DEBUG)
+            printLogger(Level.DEBUG)
             androidContext(mockedApplication)
             modules(offlineWeatherApp)
         }.checkModules()
@@ -40,7 +40,7 @@ class ModuleCheckTest : KoinTest {
     @Test
     fun testTestConfiguration() {
         koinApplication {
-            logger(Level.DEBUG)
+            printLogger(Level.DEBUG)
             androidContext(mockedApplication)
             modules(testWeatherApp)
         }.checkModules()

--- a/koin-projects/examples/android-mvvm/src/test/java/fr/ekito/myweatherapp/ModuleCheckTest.kt
+++ b/koin-projects/examples/android-mvvm/src/test/java/fr/ekito/myweatherapp/ModuleCheckTest.kt
@@ -39,7 +39,7 @@ class ModuleCheckTest : KoinTest {
     @Test
     fun testTestConfiguration() {
         koinApplication {
-            logger(Level.DEBUG)
+            printLogger(Level.DEBUG)
             androidContext(mockedAndroidContext)
             modules(testWeatherApp)
         }.checkModules()

--- a/koin-projects/examples/coffee-maker/src/main/kotlin/org/koin/example/CoffeeApp.kt
+++ b/koin-projects/examples/coffee-maker/src/main/kotlin/org/koin/example/CoffeeApp.kt
@@ -13,7 +13,7 @@ class CoffeeApp : KoinComponent {
 fun main(vararg args: String) {
 
     startKoin {
-        logger()
+        printLogger()
         modules(coffeeAppModule)
     }
 

--- a/koin-projects/examples/coffee-maker/src/test/kotlin/org/koin/example/CoffeeMakerTest.kt
+++ b/koin-projects/examples/coffee-maker/src/test/kotlin/org/koin/example/CoffeeMakerTest.kt
@@ -19,7 +19,7 @@ class CoffeeMakerTest : AutoCloseKoinTest() {
     @Before
     fun before() {
         startKoin {
-            logger(Level.DEBUG)
+            printLogger(Level.DEBUG)
             modules(coffeeAppModule)
         }
 

--- a/koin-projects/koin-android-scope/src/test/java/org/koin/test/android/AndroidObserverTest.kt
+++ b/koin-projects/koin-android-scope/src/test/java/org/koin/test/android/AndroidObserverTest.kt
@@ -18,7 +18,7 @@ class AndroidObserverTest : AutoCloseKoinTest() {
     @Test
     fun `should close scoped definition on ON_DESTROY`() {
         startKoin {
-            logger(Level.DEBUG)
+            printLogger(Level.DEBUG)
             modules(
                 module {
                     scoped { MyService() }
@@ -44,7 +44,7 @@ class AndroidObserverTest : AutoCloseKoinTest() {
     @Test
     fun `should not close scoped definition`() {
         startKoin {
-            logger(Level.DEBUG)
+            printLogger(Level.DEBUG)
             modules(org.koin.dsl.module {
                 scoped { MyService() }
             })
@@ -63,7 +63,7 @@ class AndroidObserverTest : AutoCloseKoinTest() {
     @Test
     fun `should close scoped definition on ON_STOP`() {
         startKoin {
-            logger(Level.DEBUG)
+            printLogger(Level.DEBUG)
             modules(org.koin.dsl.module {
                 scoped { MyService() }
             })

--- a/koin-projects/koin-android-viewmodel/src/test/java/org/koin/android/viewmodel/ViewModelDSLTest.kt
+++ b/koin-projects/koin-android-viewmodel/src/test/java/org/koin/android/viewmodel/ViewModelDSLTest.kt
@@ -17,7 +17,7 @@ class ViewModelDSLTest {
     @Test
     fun `definition should be a viewmodel`() {
         val koinApp = koinApplication {
-            logger(Level.DEBUG)
+            printLogger(Level.DEBUG)
             modules(module {
                 viewModel { MyViewModel() }
             })
@@ -31,7 +31,7 @@ class ViewModelDSLTest {
     @Test
     fun `definition should not be a viewmodel`() {
         val koinApp = koinApplication {
-            logger(Level.DEBUG)
+            printLogger(Level.DEBUG)
             modules(module {
                 single { MyComponent() }
             })

--- a/koin-projects/koin-android-viewmodel/src/test/java/org/koin/android/viewmodel/ViewModelInstanceTest.kt
+++ b/koin-projects/koin-android-viewmodel/src/test/java/org/koin/android/viewmodel/ViewModelInstanceTest.kt
@@ -14,7 +14,7 @@ class ViewModelInstanceTest {
     @Test
     fun `should have a factory instance for ViewModel`() {
         val koinApp = koinApplication {
-            logger(Level.DEBUG)
+            printLogger(Level.DEBUG)
             modules(module {
                 viewModel { MyViewModel() }
             })

--- a/koin-projects/koin-android/src/main/java/org/koin/android/ext/koin/KoinExt.kt
+++ b/koin-projects/koin-android/src/main/java/org/koin/android/ext/koin/KoinExt.kt
@@ -35,14 +35,11 @@ import java.util.*
 /**
  * Setup Android Logger for Koin
  * @param level
- * @param Logger
  */
 fun KoinApplication.androidLogger(
-        level: Level = Level.INFO,
-        log: Logger = AndroidLogger()
+        level: Level = Level.INFO
 ): KoinApplication {
-    logger = log
-    logger.level = level
+    logger = AndroidLogger(level)
     return this
 }
 

--- a/koin-projects/koin-android/src/test/java/org/koin/test/android/AndroidModuleTest.kt
+++ b/koin-projects/koin-android/src/test/java/org/koin/test/android/AndroidModuleTest.kt
@@ -3,9 +3,14 @@ package org.koin.test.android
 import android.app.Application
 import android.content.Context
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.koin.android.ext.koin.androidApplication
 import org.koin.android.ext.koin.androidContext
+import org.koin.android.ext.koin.androidLogger
+import org.koin.android.logger.AndroidLogger
+import org.koin.core.KoinApplication
+import org.koin.core.logger.EmptyLogger
 import org.koin.core.logger.Level
 import org.koin.dsl.koinApplication
 import org.koin.dsl.module
@@ -38,7 +43,7 @@ class AndroidModuleTest : KoinTest {
         val mockedContext = mock(Context::class.java)
 
         val koin = koinApplication {
-            logger(Level.DEBUG)
+            printLogger(Level.DEBUG)
             androidContext(mockedContext)
             modules(SampleModule)
         }.koin
@@ -51,7 +56,7 @@ class AndroidModuleTest : KoinTest {
         val mockedContext = mock(Application::class.java)
 
         val koin = koinApplication {
-            logger(Level.DEBUG)
+            printLogger(Level.DEBUG)
             androidContext(mockedContext)
             modules(SampleModule)
         }.koin
@@ -64,7 +69,7 @@ class AndroidModuleTest : KoinTest {
         val mockedContext = mock(Context::class.java)
 
         val koin = koinApplication {
-            logger(Level.DEBUG)
+            printLogger(Level.DEBUG)
             androidContext(mockedContext)
             modules(SampleModule)
         }.koin
@@ -79,7 +84,7 @@ class AndroidModuleTest : KoinTest {
     fun `should inject property`() {
         val value = "URL"
         val koin = koinApplication {
-            logger(Level.DEBUG)
+            printLogger(Level.DEBUG)
             properties(hashMapOf(URL to value))
             modules(SampleModule)
         }.koin
@@ -87,5 +92,17 @@ class AndroidModuleTest : KoinTest {
         val s = koin.get<OtherService>()
 
         assertEquals(value, s.url)
+    }
+
+    @Test
+    fun `default to empty logger`() {
+        val mockedContext = mock(Application::class.java)
+
+        koinApplication {
+            androidContext(mockedContext)
+            modules(SampleModule)
+        }.koin
+
+        assertTrue(KoinApplication.logger is EmptyLogger)
     }
 }

--- a/koin-projects/koin-core-ext/src/test/kotlin/org/koin/experimental/builder/CreateAPITest.kt
+++ b/koin-projects/koin-core-ext/src/test/kotlin/org/koin/experimental/builder/CreateAPITest.kt
@@ -14,7 +14,7 @@ class CreateAPITest : KoinTest {
     @Test
     fun `should find 1st constructor and build`() {
         val koin = koinApplication {
-            logger(Level.DEBUG)
+            printLogger(Level.DEBUG)
             modules(module {
                 single { ComponentA() }
                 single { ComponentB(get()) }
@@ -27,7 +27,7 @@ class CreateAPITest : KoinTest {
         println("create api in $duration ms")
 
         val createKoin = koinApplication {
-            logger(Level.DEBUG)
+            printLogger(Level.DEBUG)
             modules(module {
                 single { ComponentA() }
                 single { create<ComponentB>(this) }
@@ -44,7 +44,7 @@ class CreateAPITest : KoinTest {
     fun `create with missing dependency`() {
         try {
             val koin = koinApplication {
-                logger(Level.DEBUG)
+                printLogger(Level.DEBUG)
                 modules(module {
                     single { create<ComponentB>(this) }
                 })
@@ -60,7 +60,7 @@ class CreateAPITest : KoinTest {
     @Test
     fun `create with empty ctor`() {
         val koin = koinApplication {
-            logger(Level.DEBUG)
+            printLogger(Level.DEBUG)
             modules(module {
                 single { create<ComponentA>(this) }
             })
@@ -72,7 +72,7 @@ class CreateAPITest : KoinTest {
     @Test
     fun `create for interface`() {
         val koin = koinApplication {
-            logger(Level.DEBUG)
+            printLogger(Level.DEBUG)
             modules(module {
                 single { ComponentA() }
                 single<Component> { create<ComponentD>(this) }
@@ -85,7 +85,7 @@ class CreateAPITest : KoinTest {
     @Test
     fun `create factory for interface`() {
         val koin = koinApplication {
-            logger(Level.DEBUG)
+            printLogger(Level.DEBUG)
             modules(module {
                 single { ComponentA() }
                 factory<Component> { create<ComponentD>(this) }
@@ -101,7 +101,7 @@ class CreateAPITest : KoinTest {
     @Test
     fun `create API overhead`() {
         val koin = koinApplication {
-            logger(Level.DEBUG)
+            printLogger(Level.DEBUG)
             modules(module {
                 single { create<ComponentA>(this) }
                 factory<Component> { create<ComponentD>(this) }

--- a/koin-projects/koin-core-ext/src/test/kotlin/org/koin/experimental/builder/MVPArchitectureTest.kt
+++ b/koin-projects/koin-core-ext/src/test/kotlin/org/koin/experimental/builder/MVPArchitectureTest.kt
@@ -25,7 +25,7 @@ class MVPArchitectureTest : AutoCloseKoinTest() {
     @Test
     fun `should create all MVP hierarchy`() {
         startKoin {
-            logger(Level.DEBUG)
+            printLogger(Level.DEBUG)
             modules(MVPModule, DataSourceModule)
         }
 
@@ -43,7 +43,7 @@ class MVPArchitectureTest : AutoCloseKoinTest() {
     @Test
     fun `check MVP hierarchy`() {
         startKoin {
-            logger(Level.DEBUG)
+            printLogger(Level.DEBUG)
             modules(MVPModule, DataSourceModule)
         }.checkModules()
     }

--- a/koin-projects/koin-core-ext/src/test/kotlin/org/koin/experimental/builder/ScopedMVPArchitectureTest.kt
+++ b/koin-projects/koin-core-ext/src/test/kotlin/org/koin/experimental/builder/ScopedMVPArchitectureTest.kt
@@ -24,7 +24,7 @@ class ScopedMVPArchitectureTest : AutoCloseKoinTest() {
     @Test
     fun `should create all MVP hierarchy`() {
         startKoin {
-            logger(Level.DEBUG)
+            printLogger(Level.DEBUG)
             modules(MVPModule, DataSourceModule)
         }
 
@@ -42,7 +42,7 @@ class ScopedMVPArchitectureTest : AutoCloseKoinTest() {
     @Test
     fun `check MVP hierarchy`() {
         startKoin {
-            logger(Level.DEBUG)
+            printLogger(Level.DEBUG)
             modules(MVPModule, DataSourceModule)
         }
     }

--- a/koin-projects/koin-core/src/main/kotlin/org/koin/core/KoinApplication.kt
+++ b/koin-projects/koin-core/src/main/kotlin/org/koin/core/KoinApplication.kt
@@ -83,15 +83,18 @@ class KoinApplication private constructor() {
 
     /**
      * Set Koin Logger
-     * @param level
      * @param logger - logger
      */
-    @JvmOverloads
-    fun logger(level: Level = Level.INFO, logger: Logger = PrintLogger()): KoinApplication {
+    fun logger(logger: Logger): KoinApplication {
         KoinApplication.logger = logger
-        KoinApplication.logger.level = level
         return this
     }
+
+    /**
+     * Set Koin to use [PrintLogger], by default at [Level.INFO]
+     */
+    @JvmOverloads
+    fun printLogger(level: Level = Level.INFO) = this.logger(PrintLogger(level))
 
     /**
      * Create Single instances Definitions marked as createdAtStart

--- a/koin-projects/koin-core/src/test/kotlin/org/koin/core/DefinitionCreatedAtStartTest.kt
+++ b/koin-projects/koin-core/src/test/kotlin/org/koin/core/DefinitionCreatedAtStartTest.kt
@@ -17,7 +17,7 @@ class DefinitionCreatedAtStartTest {
     @Test
     fun `is declared as created at start`() {
         val app = koinApplication {
-            logger(Level.DEBUG)
+            printLogger(Level.DEBUG)
             modules(
                 module {
                     single(createdAtStart = true) { Simple.ComponentA() }
@@ -33,7 +33,7 @@ class DefinitionCreatedAtStartTest {
     @Test
     fun `is created at start`() {
         val app = startKoin {
-            logger(Level.DEBUG)
+            printLogger(Level.DEBUG)
             modules(
                 module {
                     single(createdAtStart = true) { Simple.ComponentA() }

--- a/koin-projects/koin-core/src/test/kotlin/org/koin/core/ErrorCheckTest.kt
+++ b/koin-projects/koin-core/src/test/kotlin/org/koin/core/ErrorCheckTest.kt
@@ -59,7 +59,7 @@ class ErrorCheckTest {
     @Test
     fun `cycle error`() {
         val app = koinApplication {
-            logger(Level.DEBUG)
+            printLogger(Level.DEBUG)
             modules(module {
                 single { Errors.CycleA(get()) }
                 single { Errors.CycleB(get()) }

--- a/koin-projects/koin-core/src/test/kotlin/org/koin/core/GenericDeclarationTest.kt
+++ b/koin-projects/koin-core/src/test/kotlin/org/koin/core/GenericDeclarationTest.kt
@@ -39,7 +39,7 @@ class GenericDeclarationTest {
 
     private fun createKoin(): Koin {
         val koin = koinApplication {
-            logger(Level.DEBUG)
+            printLogger(Level.DEBUG)
             modules(modules)
         }.koin
         return koin

--- a/koin-projects/koin-core/src/test/kotlin/org/koin/core/ParametersInjectionTest.kt
+++ b/koin-projects/koin-core/src/test/kotlin/org/koin/core/ParametersInjectionTest.kt
@@ -67,7 +67,7 @@ class ParametersInjectionTest {
     @Test
     fun `chained factory injection`() {
         val koin = koinApplication {
-            logger(Level.DEBUG)
+            printLogger(Level.DEBUG)
             modules(
                 module {
                     factory { (i: Int) -> Simple.MyIntFactory(i) }

--- a/koin-projects/koin-core/src/test/kotlin/org/koin/dsl/AdditionalTypeBindingTest.kt
+++ b/koin-projects/koin-core/src/test/kotlin/org/koin/dsl/AdditionalTypeBindingTest.kt
@@ -12,7 +12,7 @@ class AdditionalTypeBindingTest {
     @Test
     fun `can resolve an additional type`() {
         val app = koinApplication {
-            logger()
+            printLogger()
             modules(
                 module {
                     single { Simple.Component1() } bind Simple.ComponentInterface1::class
@@ -32,7 +32,7 @@ class AdditionalTypeBindingTest {
     fun `additional type conflict`() {
         try {
             koinApplication {
-                logger()
+                printLogger()
                 modules(
                     module {
                         single { Simple.Component1() } bind Simple.ComponentInterface1::class
@@ -48,7 +48,7 @@ class AdditionalTypeBindingTest {
     @Test
     fun `should not conflict name & default type`() {
         val app = koinApplication {
-            logger()
+            printLogger()
             modules(
                 module {
                     single<Simple.ComponentInterface1>("default") { Simple.Component2() }

--- a/koin-projects/koin-core/src/test/kotlin/org/koin/dsl/BeanLifecycleTest.kt
+++ b/koin-projects/koin-core/src/test/kotlin/org/koin/dsl/BeanLifecycleTest.kt
@@ -10,7 +10,7 @@ class BeanLifecycleTest {
     fun `declare onClose for single`() {
         var result = ""
         val app = koinApplication {
-            logger()
+            printLogger()
             modules(
                     module {
                         single { Simple.Component1() } onClose { result = "closing" }
@@ -26,7 +26,7 @@ class BeanLifecycleTest {
     fun `declare onClose for factory`() {
         var result = ""
         val app = koinApplication {
-            logger()
+            printLogger()
             modules(
                     module {
                         factory { Simple.Component1() } onClose { result = "closing" }
@@ -42,7 +42,7 @@ class BeanLifecycleTest {
     fun `declare onClose for scoped`() {
         var result = ""
         val app = koinApplication {
-            logger()
+            printLogger()
             modules(
                     module {
                         scope("test") {
@@ -60,7 +60,7 @@ class BeanLifecycleTest {
     fun `declare onRelease for single`() {
         var result = ""
         val app = koinApplication {
-            logger()
+            printLogger()
             modules(
                     module {
                         single { Simple.Component1() } onRelease { result = "release" }
@@ -76,7 +76,7 @@ class BeanLifecycleTest {
     fun `declare onRelease for factory`() {
         var result = ""
         val app = koinApplication {
-            logger()
+            printLogger()
             modules(
                     module {
                         factory { Simple.Component1() } onRelease { result = "release" }
@@ -92,7 +92,7 @@ class BeanLifecycleTest {
     fun `declare onRelease for scoped`() {
         var result = ""
         val app = koinApplication {
-            logger()
+            printLogger()
             modules(
                     module {
                         scope("test") {

--- a/koin-projects/koin-core/src/test/kotlin/org/koin/dsl/EnvironmentPropertyDefinitionTest.kt
+++ b/koin-projects/koin-core/src/test/kotlin/org/koin/dsl/EnvironmentPropertyDefinitionTest.kt
@@ -13,7 +13,7 @@ class EnvironmentPropertyDefinitionTest {
         val aPropertyValue = sysProperties.getProperty(aPropertyKey)
 
         val koin = koinApplication {
-            logger(Level.DEBUG)
+            printLogger(Level.DEBUG)
             environmentProperties()
         }.koin
 

--- a/koin-projects/koin-core/src/test/kotlin/org/koin/dsl/FilePropertyDefinitionTest.kt
+++ b/koin-projects/koin-core/src/test/kotlin/org/koin/dsl/FilePropertyDefinitionTest.kt
@@ -13,7 +13,7 @@ class FilePropertyDefinitionTest {
         val value = "VALUE"
 
         val koin = koinApplication {
-            logger()
+            printLogger()
             fileProperties("/koin.properties")
         }.koin
 
@@ -28,7 +28,7 @@ class FilePropertyDefinitionTest {
         val value = "VALUE"
 
         val koin = koinApplication {
-            logger()
+            printLogger()
             fileProperties()
         }.koin
 
@@ -52,7 +52,7 @@ class FilePropertyDefinitionTest {
     @Test
     fun `get string value from file`() {
         val koin = koinApplication {
-            logger()
+            printLogger()
             fileProperties()
         }.koin
 
@@ -62,7 +62,7 @@ class FilePropertyDefinitionTest {
     @Test
     fun `get int value from file`() {
         val koin = koinApplication {
-            logger()
+            printLogger()
             fileProperties()
         }.koin
 
@@ -72,7 +72,7 @@ class FilePropertyDefinitionTest {
     @Test
     fun `get float value from file`() {
         val koin = koinApplication {
-            logger()
+            printLogger()
             fileProperties()
         }.koin
 

--- a/koin-projects/koin-core/src/test/kotlin/org/koin/dsl/KoinAppCreationTest.kt
+++ b/koin-projects/koin-core/src/test/kotlin/org/koin/dsl/KoinAppCreationTest.kt
@@ -10,6 +10,7 @@ import org.koin.core.context.startKoin
 import org.koin.core.context.stopKoin
 import org.koin.core.error.KoinAppAlreadyStartedException
 import org.koin.core.logger.Level
+import org.koin.core.logger.PrintLogger
 import org.koin.test.assertDefinitionsCount
 import org.koin.test.assertHasNoStandaloneInstance
 
@@ -53,8 +54,23 @@ class KoinAppCreationTest {
     @Test
     fun `allow declare a logger`() {
         startKoin {
-            logger(Level.DEBUG)
+            logger(PrintLogger(Level.ERROR))
         }
+
+        assertEquals(KoinApplication.logger.level, Level.ERROR)
+        
+        KoinApplication.logger.debug("debug")
+        KoinApplication.logger.info("info")
+        KoinApplication.logger.error("error")
+    }
+
+    @Test
+    fun `allow declare a print logger level`() {
+        startKoin {
+            printLogger(Level.ERROR)
+        }
+
+        assertEquals(KoinApplication.logger.level, Level.ERROR)
 
         KoinApplication.logger.debug("debug")
         KoinApplication.logger.info("info")

--- a/koin-projects/koin-core/src/test/kotlin/org/koin/dsl/ModuleCreationTest.kt
+++ b/koin-projects/koin-core/src/test/kotlin/org/koin/dsl/ModuleCreationTest.kt
@@ -108,7 +108,7 @@ class ModuleCreationTest {
     fun `create modules list timing`() {
 
         koinApplication {
-            logger(Level.DEBUG)
+            printLogger(Level.DEBUG)
             modules(
                 module {
                     single { Simple.ComponentA() }
@@ -120,7 +120,7 @@ class ModuleCreationTest {
         }
 
         koinApplication {
-            logger(Level.DEBUG)
+            printLogger(Level.DEBUG)
             modules(
                 listOf(
                     module {

--- a/koin-projects/koin-core/src/test/kotlin/org/koin/dsl/ModuleDeclarationRulesTest.kt
+++ b/koin-projects/koin-core/src/test/kotlin/org/koin/dsl/ModuleDeclarationRulesTest.kt
@@ -27,7 +27,7 @@ class ModuleDeclarationRulesTest {
     @Test
     fun `allow redeclaration - different names`() {
         val app = koinApplication {
-            logger(Level.INFO)
+            printLogger(Level.INFO)
             modules(module {
                 single("default") { Simple.ComponentA() }
                 single("other") { Simple.ComponentA() }

--- a/koin-projects/koin-core/src/test/kotlin/org/koin/koincomponent/AppTest.kt
+++ b/koin-projects/koin-core/src/test/kotlin/org/koin/koincomponent/AppTest.kt
@@ -21,7 +21,7 @@ class AppTest {
     @Test
     fun `can run KoinComponent app`() {
         val app = startKoin {
-            logger()
+            printLogger()
             modules(
                 module {
                     single { TasksView() }

--- a/koin-projects/koin-core/src/test/kotlin/org/koin/koincomponent/KoinComponentTest.kt
+++ b/koin-projects/koin-core/src/test/kotlin/org/koin/koincomponent/KoinComponentTest.kt
@@ -20,7 +20,7 @@ class KoinComponentTest {
     @Test
     fun `can lazy inject from KoinComponent`() {
         val app = startKoin {
-            logger()
+            printLogger()
             modules(
                 module {
                     single { Simple.ComponentA() }

--- a/koin-projects/koin-core/src/test/kotlin/org/koin/koincomponent/TODOAppTest.kt
+++ b/koin-projects/koin-core/src/test/kotlin/org/koin/koincomponent/TODOAppTest.kt
@@ -48,7 +48,7 @@ class TODOAppTest {
     @Test
     fun `should create all components`() {
         val koinApp = startKoin {
-            logger(Level.DEBUG)
+            printLogger(Level.DEBUG)
             modules(todoAppModule, repositoryModule)
         }
         val koin = koinApp.koin

--- a/koin-projects/koin-core/src/test/kotlin/org/koin/test/KoinApplicationExt.kt
+++ b/koin-projects/koin-core/src/test/kotlin/org/koin/test/KoinApplicationExt.kt
@@ -3,6 +3,8 @@ package org.koin.test
 import org.junit.Assert.assertEquals
 import org.koin.core.KoinApplication
 import org.koin.core.definition.BeanDefinition
+import org.koin.core.logger.Level
+import org.koin.core.logger.PrintLogger
 import kotlin.reflect.KClass
 
 fun KoinApplication.assertDefinitionsCount(count: Int) {

--- a/koin-projects/koin-java/src/test/java/org/koin/standalone/UnitJavaTest.java
+++ b/koin-projects/koin-java/src/test/java/org/koin/standalone/UnitJavaTest.java
@@ -20,7 +20,7 @@ public class UnitJavaTest {
     @Before
     public void before() {
         KoinApplication koinApp = KoinApplication.create()
-                .logger()
+                .printLogger()
                 .modules(koinModule);
 
         start(koinApp);

--- a/koin-projects/koin-test/src/test/kotlin/org/koin/test/CheckModulesTest.kt
+++ b/koin-projects/koin-test/src/test/kotlin/org/koin/test/CheckModulesTest.kt
@@ -12,7 +12,7 @@ class CheckModulesTest {
     @Test
     fun `check a simple module`() {
         koinApplication {
-            logger(Level.DEBUG)
+            printLogger(Level.DEBUG)
             modules(
                     module {
                         single { Simple.ComponentA() }
@@ -24,7 +24,7 @@ class CheckModulesTest {
     @Test
     fun `check a module with link`() {
         koinApplication {
-            logger(Level.DEBUG)
+            printLogger(Level.DEBUG)
             modules(
                     module {
                         single { Simple.ComponentA() }
@@ -38,7 +38,7 @@ class CheckModulesTest {
     fun `check a broken module`() {
         try {
             koinApplication {
-                logger(Level.DEBUG)
+                printLogger(Level.DEBUG)
                 modules(
                         module {
                             single { Simple.ComponentB(get()) }
@@ -54,7 +54,7 @@ class CheckModulesTest {
     @Test
     fun `check a module with params`() {
         koinApplication {
-            logger(Level.DEBUG)
+            printLogger(Level.DEBUG)
             modules(
                     module {
                         single { (s: String) -> Simple.MyString(s) }
@@ -66,7 +66,7 @@ class CheckModulesTest {
     @Test
     fun `check a module with property`() {
         koinApplication {
-            logger(Level.DEBUG)
+            printLogger(Level.DEBUG)
             properties(hashMapOf("aValue" to "value"))
             modules(
                     module {

--- a/koin-projects/koin-test/src/test/kotlin/org/koin/test/DeclareMockFromKoinTest.kt
+++ b/koin-projects/koin-test/src/test/kotlin/org/koin/test/DeclareMockFromKoinTest.kt
@@ -17,7 +17,7 @@ class DeclareMockFromKoinTest : AutoCloseKoinTest() {
     @Test
     fun `declareMock with KoinTest`() {
         startKoin {
-            logger(Level.DEBUG)
+            printLogger(Level.DEBUG)
             modules(
                 module {
                     single { Simple.UUIDComponent() }
@@ -36,7 +36,7 @@ class DeclareMockFromKoinTest : AutoCloseKoinTest() {
     @Test
     fun `declareMock factory with KoinTest`() {
         startKoin {
-            logger(Level.DEBUG)
+            printLogger(Level.DEBUG)
             modules(
                 module {
                     factory { Simple.UUIDComponent() }

--- a/koin-projects/koin-test/src/test/kotlin/org/koin/test/DeclareMockTests.kt
+++ b/koin-projects/koin-test/src/test/kotlin/org/koin/test/DeclareMockTests.kt
@@ -42,7 +42,7 @@ class DeclareMockTests : KoinTest {
     @Test
     fun `declare a Mock of an existing definition`() {
         val koin = koinApplication {
-            logger(Level.DEBUG)
+            printLogger(Level.DEBUG)
             modules(
                     module {
                         single { Simple.ComponentA() }
@@ -62,7 +62,7 @@ class DeclareMockTests : KoinTest {
     @Test
     fun `declare and mock an existing definition`() {
         val koin = koinApplication {
-            logger(Level.DEBUG)
+            printLogger(Level.DEBUG)
             modules(
                     module {
                         single { Simple.UUIDComponent() }

--- a/koin-projects/koin-test/src/test/kotlin/org/koin/test/DeclareTest.kt
+++ b/koin-projects/koin-test/src/test/kotlin/org/koin/test/DeclareTest.kt
@@ -12,7 +12,7 @@ class DeclareTest : KoinTest {
     @Test
     fun `declare on the fly with KoinTest`() {
         startKoin {
-            logger(Level.DEBUG)
+            printLogger(Level.DEBUG)
         }
 
         try {

--- a/koin-projects/koin-test/src/test/kotlin/org/koin/test/SandBoxInstanceTest.kt
+++ b/koin-projects/koin-test/src/test/kotlin/org/koin/test/SandBoxInstanceTest.kt
@@ -15,7 +15,7 @@ class SandBoxInstanceTest {
     @Test
     fun `Create a sandbox for given definition`() {
         val koin = koinApplication {
-            logger(Level.DEBUG)
+            printLogger(Level.DEBUG)
             modules(
                     module {
                         single { Simple.ComponentA() }


### PR DESCRIPTION
Instead, an explicit printLogger() function was added for easy setting of printer logger with explicit level.