### PR TITLE
Change purpose of Module's scoped definition.

### DIFF
--- a/koin-projects/koin-core/src/main/kotlin/org/koin/core/module/Module.kt
+++ b/koin-projects/koin-core/src/main/kotlin/org/koin/core/module/Module.kt
@@ -83,18 +83,21 @@ class Module(
     }
 
     /**
-     * Declare a ScopeInstance definition
+     * Declare a scoped definition with a given scope name
+     * @param scopeName
      * @param qualifier
      * @param override
      * @param definition - definition function
      */
     inline fun <reified T> scoped(
+            scopeName: Qualifier,
             qualifier: Qualifier? = null,
             override: Boolean = false,
             noinline definition: Definition<T>
     ): BeanDefinition<T> {
-        val beanDefinition = DefinitionFactory.createScoped(qualifier, definition = definition)
-        declareDefinition(beanDefinition, Options(override = override))
+        val scope = ScopeSet(scopeName, this)
+        val beanDefinition = scope.scoped(qualifier, override, definition)
+        declareScope(scope)
         return beanDefinition
     }
 


### PR DESCRIPTION
Change behaviour of `scoped` definition in Module's context.
Now `scoped` is declaring single definition with scope name and working the same as
```
scope(name) { 
    scoped { Constructor() }
}
```
Inspired by [issue 427](https://github.com/InsertKoinIO/koin/issues/427).