### PR TITLE
KoinApplication modules method vararg support

### DIFF
--- a/koin-projects/koin-core/src/main/kotlin/org/koin/core/KoinApplication.kt
+++ b/koin-projects/koin-core/src/main/kotlin/org/koin/core/KoinApplication.kt
@@ -41,7 +41,7 @@ class KoinApplication private constructor() {
      * @param modules
      */
     fun modules(modules: Module): KoinApplication {
-        return listOf(modules)
+        return modules(listOf(modules))
     }
     
     /**

--- a/koin-projects/koin-core/src/main/kotlin/org/koin/core/KoinApplication.kt
+++ b/koin-projects/koin-core/src/main/kotlin/org/koin/core/KoinApplication.kt
@@ -35,7 +35,15 @@ class KoinApplication private constructor() {
     internal fun loadDefaults() {
         koin.scopeRegistry.loadDefaultScopes(koin)
     }
-
+    
+    /**
+     * Load definitions from a single module
+     * @param modules
+     */
+    fun modules(modules: Module): KoinApplication {
+        return listOf(module)
+    }
+    
     /**
      * Load definitions from modules
      * @param modules
@@ -45,7 +53,7 @@ class KoinApplication private constructor() {
     }
 
     /**
-     * Load definitions from modules
+     * Load definitions from a list of modules
      * @param modules
      */
     fun modules(modules: List<Module>): KoinApplication {

--- a/koin-projects/koin-core/src/main/kotlin/org/koin/core/KoinApplication.kt
+++ b/koin-projects/koin-core/src/main/kotlin/org/koin/core/KoinApplication.kt
@@ -41,7 +41,7 @@ class KoinApplication private constructor() {
      * @param modules
      */
     fun modules(modules: Module): KoinApplication {
-        return listOf(module)
+        return listOf(modules)
     }
     
     /**

--- a/koin-projects/koin-core/src/main/kotlin/org/koin/core/KoinApplication.kt
+++ b/koin-projects/koin-core/src/main/kotlin/org/koin/core/KoinApplication.kt
@@ -41,6 +41,7 @@ class KoinApplication private constructor() {
      * @param modules
      */
     fun modules(vararg modules: Module): KoinApplication {
+        if (modules.isEmpty()) throw NoParameterFoundException("No modules were found. Koin requires at least a one module to initialize properly.")
         return modules(modules.toList())
     }
 

--- a/koin-projects/koin-core/src/main/kotlin/org/koin/core/KoinApplication.kt
+++ b/koin-projects/koin-core/src/main/kotlin/org/koin/core/KoinApplication.kt
@@ -41,7 +41,6 @@ class KoinApplication private constructor() {
      * @param modules
      */
     fun modules(vararg modules: Module): KoinApplication {
-        if (modules.isEmpty()) throw NoParameterFoundException("No modules were found. Koin requires at least a one module to initialize properly.")
         return modules(modules.toList())
     }
 

--- a/koin-projects/koin-core/src/main/kotlin/org/koin/core/KoinApplication.kt
+++ b/koin-projects/koin-core/src/main/kotlin/org/koin/core/KoinApplication.kt
@@ -40,8 +40,8 @@ class KoinApplication private constructor() {
      * Load definitions from modules
      * @param modules
      */
-    fun modules(modules: Module): KoinApplication {
-        return modules(listOf(modules))
+    fun modules(vararg modules: Module): KoinApplication {
+        return modules(modules.toList())
     }
 
     /**


### PR DESCRIPTION
Converted the KoinApplication `modules(modules: Module): KoinApplication` method to a more convenient `modules(vararg modules: Module): KoinApplication` method.
According to the official Kotlin vararg documentation: https://kotlinlang.org/docs/reference/functions.html#variable-number-of-arguments-varargs

In addition to providing an instance of a list of modules, users could also type their modules separated by a comma for a more convenient way.

list way:
`modules(listOf(moduleOne, moduleTwo, moduleThree))`

vararg way:
`modules(moduleOne, moduleTwo, moduleThree)`

single module way:
`modules(moduleOne)`