### PR TITLE
Add support for overriding on-the-fly declarations

### DIFF
--- a/koin-projects/koin-core/src/main/kotlin/org/koin/core/Koin.kt
+++ b/koin-projects/koin-core/src/main/kotlin/org/koin/core/Koin.kt
@@ -115,16 +115,15 @@ class Koin {
      * @param instance The instance you're declaring.
      * @param qualifier Qualifier for this declaration
      * @param secondaryTypes List of secondary bound types
-     * @param options Allows to set [Options] for the [BeanDefinition] that will be created, e.g. you can use it to
-     * override a previous declaration of the same type.
+     * @param override Allows to override a previous declaration of the same type (default to false).
      */
     inline fun <reified T> declare(
             instance: T,
             qualifier: Qualifier? = null,
             secondaryTypes: List<KClass<*>>? = null,
-            options: Options? = null
+            override: Boolean = false
     ) {
-        rootScope.declare(instance, qualifier, secondaryTypes, options)
+        rootScope.declare(instance, qualifier, secondaryTypes, override)
     }
 
     /**

--- a/koin-projects/koin-core/src/main/kotlin/org/koin/core/Koin.kt
+++ b/koin-projects/koin-core/src/main/kotlin/org/koin/core/Koin.kt
@@ -16,7 +16,6 @@
 package org.koin.core
 
 import org.koin.core.KoinApplication.Companion.logger
-import org.koin.core.definition.Options
 import org.koin.core.logger.Level
 import org.koin.core.parameter.ParametersDefinition
 import org.koin.core.qualifier.Qualifier

--- a/koin-projects/koin-core/src/main/kotlin/org/koin/core/Koin.kt
+++ b/koin-projects/koin-core/src/main/kotlin/org/koin/core/Koin.kt
@@ -16,6 +16,7 @@
 package org.koin.core
 
 import org.koin.core.KoinApplication.Companion.logger
+import org.koin.core.definition.Options
 import org.koin.core.logger.Level
 import org.koin.core.parameter.ParametersDefinition
 import org.koin.core.qualifier.Qualifier
@@ -111,15 +112,19 @@ class Koin {
      * Declare a component definition from the given instance
      * This result of declaring a single definition of type T, returning the given instance
      *
-     * @param instance
-     * @param qualifier
+     * @param instance The instance you're declaring.
+     * @param qualifier Qualifier for this declaration
+     * @param secondaryTypes List of secondary bound types
+     * @param options Allows to set [Options] for the [BeanDefinition] that will be created, e.g. you can use it to
+     * override a previous declaration of the same type.
      */
     inline fun <reified T> declare(
             instance: T,
             qualifier: Qualifier? = null,
-            secondaryTypes: List<KClass<*>>? = null
+            secondaryTypes: List<KClass<*>>? = null,
+            options: Options? = null
     ) {
-        rootScope.declare(instance, qualifier, secondaryTypes)
+        rootScope.declare(instance, qualifier, secondaryTypes, options)
     }
 
     /**

--- a/koin-projects/koin-core/src/main/kotlin/org/koin/core/registry/BeanRegistry.kt
+++ b/koin-projects/koin-core/src/main/kotlin/org/koin/core/registry/BeanRegistry.kt
@@ -123,7 +123,11 @@ class BeanRegistry {
         val secondaryTypeDefinitions: ArrayList<BeanDefinition<*>> = definitionsSecondaryTypes[type]
                 ?: createSecondaryType(type)
 
-        secondaryTypeDefinitions.add(definition)
+        if (definition in secondaryTypeDefinitions){
+            secondaryTypeDefinitions[secondaryTypeDefinitions.indexOf(definition)] = definition
+        } else {
+            secondaryTypeDefinitions.add(definition)
+        }
         if (logger.isAt(Level.INFO)) {
             logger.info("bind secondary type:'${type.getFullName()}' ~ $definition")
         }

--- a/koin-projects/koin-core/src/main/kotlin/org/koin/core/scope/Scope.kt
+++ b/koin-projects/koin-core/src/main/kotlin/org/koin/core/scope/Scope.kt
@@ -19,6 +19,7 @@ import org.koin.core.Koin
 import org.koin.core.KoinApplication
 import org.koin.core.definition.BeanDefinition
 import org.koin.core.definition.DefinitionFactory
+import org.koin.core.definition.Options
 import org.koin.core.error.MissingPropertyException
 import org.koin.core.error.NoBeanDefFoundException
 import org.koin.core.instance.InstanceContext
@@ -189,14 +190,17 @@ data class Scope(
      * This result of declaring a scoped/single definition of type T, returning the given instance
      * (single definition of th current scope is root)
      *
-     * @param instance
-     * @param qualifier
-     * @param secondaryTypes - list of secondary bound types
+     * @param instance The instance you're declaring.
+     * @param qualifier Qualifier for this declaration
+     * @param secondaryTypes List of secondary bound types
+     * @param options Allows to set [Options] for the [BeanDefinition] that will be created, e.g. you can use it to
+     * override a previous declaration of the same type.
      */
     inline fun <reified T> declare(
             instance: T,
             qualifier: Qualifier? = null,
-            secondaryTypes: List<KClass<*>>? = null
+            secondaryTypes: List<KClass<*>>? = null,
+            options: Options? = null
     ) {
         val definition = if (isRoot) {
             DefinitionFactory.createSingle(qualifier) { instance }
@@ -204,6 +208,7 @@ data class Scope(
             DefinitionFactory.createScoped(qualifier, scopeName = scopeDefinition?.qualifier) { instance }
         }
         secondaryTypes?.let { definition.secondaryTypes.addAll(it) }
+        options?.let { definition.options = it }
         beanRegistry.saveDefinition(definition)
     }
 

--- a/koin-projects/koin-core/src/main/kotlin/org/koin/core/scope/Scope.kt
+++ b/koin-projects/koin-core/src/main/kotlin/org/koin/core/scope/Scope.kt
@@ -19,7 +19,6 @@ import org.koin.core.Koin
 import org.koin.core.KoinApplication
 import org.koin.core.definition.BeanDefinition
 import org.koin.core.definition.DefinitionFactory
-import org.koin.core.definition.Options
 import org.koin.core.error.MissingPropertyException
 import org.koin.core.error.NoBeanDefFoundException
 import org.koin.core.instance.InstanceContext

--- a/koin-projects/koin-core/src/main/kotlin/org/koin/core/scope/Scope.kt
+++ b/koin-projects/koin-core/src/main/kotlin/org/koin/core/scope/Scope.kt
@@ -193,14 +193,13 @@ data class Scope(
      * @param instance The instance you're declaring.
      * @param qualifier Qualifier for this declaration
      * @param secondaryTypes List of secondary bound types
-     * @param options Allows to set [Options] for the [BeanDefinition] that will be created, e.g. you can use it to
-     * override a previous declaration of the same type.
+     * @param override Allows to override a previous declaration of the same type (default to false).
      */
     inline fun <reified T> declare(
             instance: T,
             qualifier: Qualifier? = null,
             secondaryTypes: List<KClass<*>>? = null,
-            options: Options? = null
+            override: Boolean = false
     ) {
         val definition = if (isRoot) {
             DefinitionFactory.createSingle(qualifier) { instance }
@@ -208,7 +207,7 @@ data class Scope(
             DefinitionFactory.createScoped(qualifier, scopeName = scopeDefinition?.qualifier) { instance }
         }
         secondaryTypes?.let { definition.secondaryTypes.addAll(it) }
-        options?.let { definition.options = it }
+        definition.options.override = override
         beanRegistry.saveDefinition(definition)
     }
 

--- a/koin-projects/koin-core/src/test/kotlin/org/koin/core/DeclareInstanceTest.kt
+++ b/koin-projects/koin-core/src/test/kotlin/org/koin/core/DeclareInstanceTest.kt
@@ -59,7 +59,7 @@ class DeclareInstanceTest {
 
         val a = Simple.MySingle(2)
 
-        koin.declare(a, options = Options(override = true))
+        koin.declare(a, override = true)
         assertEquals(2, koin.get<Simple.MySingle>().id)
     }
 
@@ -76,7 +76,7 @@ class DeclareInstanceTest {
         val a = Simple.MySingle(2)
 
         try {
-            koin.declare(a, options = Options(override = false))
+            koin.declare(a, override = false)
             fail()
         } catch (e: DefinitionOverrideException) {
             e.printStackTrace()
@@ -114,7 +114,7 @@ class DeclareInstanceTest {
 
         val a = Simple.ComponentA()
 
-        koin.declare(a, named("another_a"), options = Options(override = true))
+        koin.declare(a, named("another_a"), override = true)
 
         assertEquals(a, koin.get<Simple.ComponentA>(named("another_a")))
         assertNotEquals(a, koin.get<Simple.ComponentA>())
@@ -148,7 +148,7 @@ class DeclareInstanceTest {
         val b = Simple.Component1()
 
         koin.declare(a, secondaryTypes = listOf(Simple.ComponentInterface1::class))
-        koin.declare(b, secondaryTypes = listOf(Simple.ComponentInterface1::class), options = Options(override = true))
+        koin.declare(b, secondaryTypes = listOf(Simple.ComponentInterface1::class), override = true)
 
         assertEquals(b, koin.get<Simple.Component1>())
         assertEquals(b, koin.get<Simple.ComponentInterface1>())


### PR DESCRIPTION
This commit adds supports for passing an optional parameter of type
`Option` in the declare methods, used to declare instances on the fly.

This Option can be used to set the `override` flag to true and allow
subsequent declarations of the same type to succeed.

Fixes #477