### PR TITLE
Fix typos in documentation

### DIFF
--- a/koin-projects/koin-test/src/main/kotlin/org/koin/test/check/CheckModules.kt
+++ b/koin-projects/koin-test/src/main/kotlin/org/koin/test/check/CheckModules.kt
@@ -20,12 +20,12 @@ import org.koin.core.KoinApplication
 import org.koin.core.parameter.parametersOf
 
 /**
- * Check all definition's dependencies - start all nodules and check ifdefinitions can run
+ * Check all definition's dependencies - start all modules and check if definitions can run
  */
 fun KoinApplication.checkModules(parameters: CheckParameters? = null) = koin.checkModules(parameters)
 
 /**
- * Check all definition's dependencies - start all nodules and check if definitions can run
+ * Check all definition's dependencies - start all modules and check if definitions can run
  */
 fun Koin.checkModules(parametersDefinition: CheckParameters? = null) {
     val bindings = ParametersBinding()

--- a/koin-projects/koin-website/getting-started/junit-test.md
+++ b/koin-projects/koin-website/getting-started/junit-test.md
@@ -69,7 +69,7 @@ class HelloAppTest : KoinTest() {
 
     @After
     fun after() {
-        closeKoin()
+        stopKoin()
     }
 
     @Test
@@ -84,7 +84,7 @@ class HelloAppTest : KoinTest() {
 {% endhighlight %}
 
 <div class="alert alert-warning" role="alert">
-  For each test, we start <b>startKoin()</b> and close Koin context <b>closeKoin()</b>.
+  For each test, we start <b>startKoin()</b> and close Koin context <b>stopKoin()</b>.
 </div>
 
 You can even make Mocks directly into MyPresenter, or test MyRepository. Those components doesn't have any link with Koin API.


### PR DESCRIPTION
Following spellings were changed:

* nodules → modules
* closeKoin → stopKoin