### PR TITLE
Fix typo in the message when NoBeanDefFoundException happens

### DIFF
--- a/koin-projects/koin-core/src/main/kotlin/org/koin/core/scope/Scope.kt
+++ b/koin-projects/koin-core/src/main/kotlin/org/koin/core/scope/Scope.kt
@@ -167,7 +167,7 @@ data class Scope(
 
     private fun findDefinition(qualifier: Qualifier?, clazz: KClass<*>): BeanDefinition<*> {
         return beanRegistry.findDefinition(qualifier, clazz) ?: if (isRoot) {
-            throw NoBeanDefFoundException("No definition found for '${clazz.getFullName()}' has been found. Check your module definitions.")
+            throw NoBeanDefFoundException("No definition for '${clazz.getFullName()}' has been found. Check your module definitions.")
         } else {
             _koin.rootScope.findDefinition(qualifier, clazz)
         }


### PR DESCRIPTION
There was an error in the message when `NoBeanDefFoundException` exception happens.
`No definition found for '${clazz.getFullName()}' has been found. Check your module definitions.` changed to `No definition for '${clazz.getFullName()}' has been found. Check your module definitions.`