### PR TITLE
Make 'by inject()' function very lazy,

### DIFF
--- a/koin-projects/koin-core/src/main/kotlin/org/koin/core/KoinComponent.kt
+++ b/koin-projects/koin-core/src/main/kotlin/org/koin/core/KoinComponent.kt
@@ -52,7 +52,7 @@ inline fun <reified T> KoinComponent.inject(
         qualifier: Qualifier? = null,
         noinline parameters: ParametersDefinition? = null
 ): Lazy<T> =
-        getKoin().inject(qualifier, parameters)
+        lazy { getKoin().get<T>(qualifier, parameters) }
 
 /**
  * Get instance instance from Koin by Primary Type P, as secondary type S

--- a/koin-projects/koin-core/src/test/kotlin/org/koin/koincomponent/KoinComponentTest.kt
+++ b/koin-projects/koin-core/src/test/kotlin/org/koin/koincomponent/KoinComponentTest.kt
@@ -15,6 +15,10 @@ class MyComponent : KoinComponent {
     val aGet: Simple.ComponentA = get()
 }
 
+class MyLazyComponent : KoinComponent {
+    val anInject: Simple.ComponentA by inject()
+}
+
 class KoinComponentTest {
 
     @Test
@@ -33,6 +37,32 @@ class KoinComponentTest {
 
         Assert.assertEquals(component.anInject, a)
         Assert.assertEquals(component.aGet, a)
+
+        stopKoin()
+    }
+
+    @Test
+    fun `can lazy inject before starting Koin`() {
+        var caughtException: Exception? = null
+        var component: MyLazyComponent? = null
+        try {
+            component = MyLazyComponent()
+        } catch (e: Exception) {
+            caughtException = e
+        }
+        Assert.assertNull(caughtException)
+
+        val app = startKoin {
+            printLogger()
+            modules(
+                module {
+                    single { Simple.ComponentA() }
+                })
+        }
+
+        val koin = app.koin
+        val a: Simple.ComponentA = koin.get()
+        Assert.assertEquals(component?.anInject, a)
 
         stopKoin()
     }


### PR DESCRIPTION
This removes access to getKoin() during 'by inject()' declaration,
and moves all its declaration to a 'lazy{ }' block.
This allows for classes that declare by 'inject()' to be initialised before 'startKoin{}'

Added test for the condition.

Fixes gh-550