### PR TITLE
#480 Add viewModel functions for Java compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ class MyApplication : Application() {
 
 ### Articles & resouces about Koin
 
+* [Testing a Koin application with KotlinTest](https://dev.to/kerooker/testing-koin-applications-with-kotlintest-1iip)
 * [Ready for Koin 2.0](https://medium.com/koin-developers/ready-for-koin-2-0-2722ab59cac3)
 * [Migration from Dagger2 to Koin](https://proandroiddev.com/migrating-from-dagger2-to-koin-3b2b3f5285e9)
 * [From Dagger to Koin, a step by step migration guide](https://medium.com/@giuliani.arnaud/the-thermosiphon-app-from-dagger-to-koin-step-by-step-a09af7f5b5b1)

--- a/koin-projects/examples/android-samples/src/main/AndroidManifest.xml
+++ b/koin-projects/examples/android-samples/src/main/AndroidManifest.xml
@@ -29,6 +29,8 @@
         <activity android:name=".components.sdk.SDKActivity" />
         <activity android:name=".dynamic.DynamicActivity" />
 
+        <activity android:name=".compat.JavaActivity" />
+
     </application>
 
 </manifest>

--- a/koin-projects/examples/android-samples/src/main/java/org/koin/sample/android/MainApplication.kt
+++ b/koin-projects/examples/android-samples/src/main/java/org/koin/sample/android/MainApplication.kt
@@ -17,7 +17,7 @@ class MainApplication : Application() {
             androidLogger(Level.DEBUG)
             androidContext(this@MainApplication)
             androidFileProperties()
-            modules(listOf(appModule, mvpModule, mvvmModule, scopeModule, dynamicModule))
+            modules(listOf(appModule, mvpModule, mvvmModule, scopeModule, dynamicModule, javaModule))
         }
     }
 }

--- a/koin-projects/examples/android-samples/src/main/java/org/koin/sample/android/compat/JavaActivity.java
+++ b/koin-projects/examples/android-samples/src/main/java/org/koin/sample/android/compat/JavaActivity.java
@@ -1,0 +1,63 @@
+package org.koin.sample.android.compat;
+
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.support.v7.app.AppCompatActivity;
+import android.view.View;
+import android.widget.Button;
+
+import org.koin.sample.android.R;
+import org.koin.sample.android.components.compat.CompatSimpleViewModel;
+import org.koin.sample.android.dynamic.DynamicActivity;
+
+import kotlin.Lazy;
+
+import static org.junit.Assert.assertEquals;
+import static org.koin.android.viewmodel.compat.ScopeCompat.currentScope;
+import static org.koin.android.viewmodel.compat.ScopeCompat.getViewModel;
+import static org.koin.android.viewmodel.compat.ScopeCompat.viewModel;
+
+public class JavaActivity extends AppCompatActivity {
+
+    Lazy<CompatSimpleViewModel> viewModel = viewModel(
+            currentScope(this), this, CompatSimpleViewModel.class
+    );
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        final CompatSimpleViewModel compatVM = getViewModel(
+                currentScope(this), this, CompatSimpleViewModel.class
+        );
+
+        assertEquals(viewModel.getValue(), compatVM);
+
+        setTitle("Java Activity");
+        setContentView(R.layout.java_activity);
+
+        getSupportFragmentManager().beginTransaction()
+                .add(R.id.java_frame, new JavaFragment())
+                .commit();
+
+        Button javaButton = findViewById(R.id.java_button);
+        javaButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                navigateToNext();
+            }
+        });
+    }
+
+    private void navigateToNext() {
+        Intent intent = new Intent(this, DynamicActivity.class);
+        Bundle extras = getIntent().getExtras();
+        if (extras != null) {
+            intent.putExtras(extras);
+        }
+        startActivity(intent);
+    }
+
+}

--- a/koin-projects/examples/android-samples/src/main/java/org/koin/sample/android/compat/JavaFragment.java
+++ b/koin-projects/examples/android-samples/src/main/java/org/koin/sample/android/compat/JavaFragment.java
@@ -1,0 +1,48 @@
+package org.koin.sample.android.compat;
+
+import android.app.Activity;
+import android.arch.lifecycle.LifecycleOwner;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.v4.app.Fragment;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import org.koin.sample.android.R;
+import org.koin.sample.android.components.compat.CompatSimpleViewModel;
+
+import kotlin.Lazy;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.koin.android.viewmodel.compat.ScopeCompat.currentScope;
+import static org.koin.android.viewmodel.compat.ScopeCompat.getViewModel;
+import static org.koin.android.viewmodel.compat.SharedViewModelCompat.sharedViewModel;
+
+public class JavaFragment extends Fragment {
+
+    private Lazy<CompatSimpleViewModel> viewModel = sharedViewModel(this,
+            CompatSimpleViewModel.class);
+
+    @Nullable
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+        return inflater.inflate(R.layout.java_fragment, container, false);
+    }
+
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+        final JavaActivity activity = (JavaActivity) getActivity();
+        if (activity == null) return;
+
+        final CompatSimpleViewModel compatVM = getViewModel(
+                currentScope(activity), this, CompatSimpleViewModel.class
+        );
+
+        assertNotEquals(viewModel.getValue(), compatVM);
+        assertEquals(viewModel.getValue(), (activity).viewModel.getValue());
+    }
+}

--- a/koin-projects/examples/android-samples/src/main/java/org/koin/sample/android/components/compat/CompatSimpleViewModel.kt
+++ b/koin-projects/examples/android-samples/src/main/java/org/koin/sample/android/components/compat/CompatSimpleViewModel.kt
@@ -1,0 +1,6 @@
+package org.koin.sample.android.components.compat
+
+import android.arch.lifecycle.ViewModel
+import org.koin.sample.android.components.scope.Session
+
+class CompatSimpleViewModel(val session: Session) : ViewModel()

--- a/koin-projects/examples/android-samples/src/main/java/org/koin/sample/android/components/sdk/SDKActivity.kt
+++ b/koin-projects/examples/android-samples/src/main/java/org/koin/sample/android/components/sdk/SDKActivity.kt
@@ -6,7 +6,7 @@ import kotlinx.android.synthetic.main.sdk_activity.*
 import org.junit.Assert.assertNotNull
 import org.koin.android.viewmodel.ext.android.viewModel
 import org.koin.sample.android.R
-import org.koin.sample.android.dynamic.DynamicActivity
+import org.koin.sample.android.compat.JavaActivity
 import org.koin.sample.android.utils.navigateTo
 
 class SDKActivity : AppCompatActivity(), CustomKoinComponent {
@@ -23,7 +23,7 @@ class SDKActivity : AppCompatActivity(), CustomKoinComponent {
         setContentView(R.layout.sdk_activity)
 
         sdk_activity_button.setOnClickListener {
-            navigateTo<DynamicActivity>()
+            navigateTo<JavaActivity>()
         }
     }
 }

--- a/koin-projects/examples/android-samples/src/main/java/org/koin/sample/android/di/AppModule.kt
+++ b/koin-projects/examples/android-samples/src/main/java/org/koin/sample/android/di/AppModule.kt
@@ -5,9 +5,11 @@ import org.koin.android.viewmodel.dsl.viewModel
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
 import org.koin.dsl.onRelease
+import org.koin.sample.android.compat.JavaActivity
 import org.koin.sample.android.components.Counter
 import org.koin.sample.android.components.SCOPE_ID
 import org.koin.sample.android.components.SCOPE_SESSION
+import org.koin.sample.android.components.compat.CompatSimpleViewModel
 import org.koin.sample.android.components.dynamic.DynScoped
 import org.koin.sample.android.components.dynamic.DynSingle
 import org.koin.sample.android.components.main.DumbServiceImpl
@@ -70,5 +72,12 @@ val dynamicModule = module {
     single { DynSingle() }
     scope(named("dynamic_scope")) {
         scoped { DynScoped() }
+    }
+}
+
+val javaModule = module {
+    scope(named<JavaActivity>()) {
+        scoped { Session() }
+        viewModel { CompatSimpleViewModel(get()) }
     }
 }

--- a/koin-projects/examples/android-samples/src/main/res/layout/java_activity.xml
+++ b/koin-projects/examples/android-samples/src/main/res/layout/java_activity.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:gravity="center"
+    android:orientation="vertical">
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:layout_margin="16dp"
+        android:text="Java Activity completed!" />
+
+    <FrameLayout
+        android:id="@+id/java_frame"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"/>
+
+    <Button
+        android:id="@+id/java_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Next"/>
+
+</LinearLayout>

--- a/koin-projects/examples/android-samples/src/main/res/layout/java_fragment.xml
+++ b/koin-projects/examples/android-samples/src/main/res/layout/java_fragment.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:gravity="center"
+    android:orientation="vertical">
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:layout_margin="16dp"
+        android:text="Java Fragment completed!" />
+
+</LinearLayout>

--- a/koin-projects/koin-android-viewmodel/src/docs/asciidoc/viewmodel.adoc
+++ b/koin-projects/koin-android-viewmodel/src/docs/asciidoc/viewmodel.adoc
@@ -65,6 +65,35 @@ class DetailActivity : AppCompatActivity() {
 }
 ----
 
+
+In a similar way, in Java you can inject the ViewModel instance, but using `viewModel()` or `getViewModel` static functions from `ViewModelCompat`:
+
+[source,java]
+----
+// import viewModel
+import static org.koin.android.viewmodel.compat.ViewModelCompat.viewModel;
+
+// import getViewModel
+import static org.koin.android.viewmodel.compat.ViewModelCompat.getViewModel;
+
+public class JavaActivity extends AppCompatActivity {
+
+    // lazy ViewModel
+    private Lazy<DetailViewModel> viewModelLazy = viewModel(this, DetailViewModel.class);
+
+    // directly get the ViewModel instance
+    private DetailViewModel viewModel = getViewModel(this, DetailViewModel.class);
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_simple);
+
+        //...
+    }
+}
+----
+
 === Shared ViewModel
 
 One ViewModel instance can be shared between Fragments and their host Activity.
@@ -120,6 +149,26 @@ class WeatherListFragment : Fragment() {
 ====
 The Activity sharing its ViewModel injects it with `by viewModel()` or `getViewModel()`. Fragments are reusing  the shared ViewModel with `by sharedViewModel()`.
 ====
+
+
+For your Java Fragment, must be used `sharedViewModel` or `getSharedViewModel` from `SharedViewModelCompat`.
+
+[source,java]
+----
+// import sharedViewModel static function
+import static org.koin.android.viewmodel.compat.SharedViewModelCompat.sharedViewModel;
+
+public class JavaFragment extends Fragment {
+
+    private Lazy<WeatherViewModel> viewModel = sharedViewModel(this, WeatherViewModel.class);
+
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+        //...
+    }
+}
+----
 
 
 === ViewModel and injection parameters

--- a/koin-projects/koin-android-viewmodel/src/main/java/org/koin/android/viewmodel/compat/ScopeCompat.kt
+++ b/koin-projects/koin-android-viewmodel/src/main/java/org/koin/android/viewmodel/compat/ScopeCompat.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2017-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.koin.android.viewmodel.compat
+
+import android.arch.lifecycle.LifecycleOwner
+import android.arch.lifecycle.ViewModel
+import org.koin.android.scope.currentScope
+import org.koin.android.viewmodel.ext.android.getViewModel
+import org.koin.android.viewmodel.ext.android.viewModel
+import org.koin.core.parameter.ParametersDefinition
+import org.koin.core.qualifier.Qualifier
+import org.koin.core.scope.Scope
+
+/**
+ * Scope functions to help for ViewModel in Java
+ *
+ * @author Jeziel Lago
+ */
+object ScopeCompat {
+
+    /**
+     * Lazy get a viewModel instance
+     *
+     * @param scope
+     * @param qualifier - Koin BeanDefinition qualifier (if have several ViewModel beanDefinition of the same type)
+     * @param parameters - parameters to pass to the BeanDefinition
+     * @param clazz
+     */
+    @JvmOverloads
+    @JvmStatic
+    fun <T : ViewModel> viewModel(
+            scope: Scope,
+            owner: LifecycleOwner,
+            clazz: Class<T>,
+            qualifier: Qualifier? = null,
+            parameters: ParametersDefinition? = null
+    ): Lazy<T> = scope.viewModel(owner, clazz.kotlin, qualifier, parameters)
+
+
+    /**
+     * Get a viewModel instance
+     *
+     * @param clazz - Class of the BeanDefinition to retrieve
+     * @param qualifier - Koin BeanDefinition qualifier (if have several ViewModel beanDefinition of the same type)
+     * @param parameters - parameters to pass to the BeanDefinition
+     */
+    @JvmOverloads
+    @JvmStatic
+    fun <T : ViewModel> getViewModel(
+            scope: Scope,
+            owner: LifecycleOwner,
+            clazz: Class<T>,
+            qualifier: Qualifier? = null,
+            parameters: ParametersDefinition? = null
+    ): T {
+        return scope.getViewModel(owner, clazz.kotlin, qualifier, parameters)
+    }
+
+    @JvmStatic
+    fun currentScope(owner: LifecycleOwner): Scope {
+        return owner.currentScope
+    }
+}

--- a/koin-projects/koin-android-viewmodel/src/main/java/org/koin/android/viewmodel/compat/SharedViewModelCompat.kt
+++ b/koin-projects/koin-android-viewmodel/src/main/java/org/koin/android/viewmodel/compat/SharedViewModelCompat.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2017-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.koin.android.viewmodel.compat
+
+import android.arch.lifecycle.ViewModel
+import android.arch.lifecycle.ViewModelStoreOwner
+import android.support.v4.app.Fragment
+import org.koin.android.viewmodel.ViewModelStoreOwnerDefinition
+import org.koin.android.viewmodel.ext.android.getSharedViewModel
+import org.koin.android.viewmodel.ext.android.sharedViewModel
+import org.koin.core.parameter.ParametersDefinition
+import org.koin.core.qualifier.Qualifier
+
+/**
+ * Functions to help shared view models in Java
+ *
+ * @author Jeziel Lago
+ */
+object SharedViewModelCompat {
+
+    /**
+     * Lazy getByClass a viewModel instance shared with Activity
+     *
+     * @param fragment - Fragment
+     * @param qualifier - Koin BeanDefinition qualifier (if have several ViewModel beanDefinition of the same type)
+     * @param from - ViewModelStoreOwner that will store the viewModel instance. Examples: "parentFragment", "activity". Default: "activity"
+     * @param parameters - parameters to pass to the BeanDefinition
+     * @param clazz
+     */
+    @JvmOverloads
+    @JvmStatic
+    fun <T : ViewModel> sharedViewModel(
+            fragment: Fragment,
+            clazz: Class<T>,
+            qualifier: Qualifier? = null,
+            from: ViewModelStoreOwnerDefinition = { fragment.activity as ViewModelStoreOwner },
+            parameters: ParametersDefinition? = null
+    ): Lazy<T> = fragment.sharedViewModel(clazz.kotlin, qualifier, from, parameters)
+
+    /**
+     * Get a shared viewModel instance from underlying Activity
+     *
+     * @param fragment - Fragment
+     * @param qualifier - Koin BeanDefinition qualifier (if have several ViewModel beanDefinition of the same type)
+     * @param from - ViewModelStoreOwner that will store the viewModel instance. Examples: ("parentFragment", "activity"). Default: "activity"
+     * @param parameters - parameters to pass to the BeanDefinition
+     * @param clazz
+     */
+    @JvmOverloads
+    @JvmStatic
+    fun <T : ViewModel> getSharedViewModel(
+            fragment: Fragment,
+            clazz: Class<T>,
+            qualifier: Qualifier? = null,
+            from: ViewModelStoreOwnerDefinition = { fragment.activity as ViewModelStoreOwner },
+            parameters: ParametersDefinition? = null
+    ): T {
+        return fragment.getSharedViewModel(clazz.kotlin, qualifier, from, parameters)
+    }
+}

--- a/koin-projects/koin-android-viewmodel/src/main/java/org/koin/android/viewmodel/compat/ViewModelCompat.kt
+++ b/koin-projects/koin-android-viewmodel/src/main/java/org/koin/android/viewmodel/compat/ViewModelCompat.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2017-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.koin.android.viewmodel.compat
+
+import android.arch.lifecycle.LifecycleOwner
+import android.arch.lifecycle.ViewModel
+import org.koin.android.viewmodel.ext.android.getViewModel
+import org.koin.android.viewmodel.ext.android.viewModel
+import org.koin.core.parameter.ParametersDefinition
+import org.koin.core.qualifier.Qualifier
+
+/**
+ * LifecycleOwner functions to help for ViewModel in Java
+ *
+ * @author Jeziel Lago
+ */
+object ViewModelCompat {
+
+    /**
+     * Lazy get a viewModel instance
+     *
+     * @param owner - LifecycleOwner
+     * @param clazz - viewModel class dependency
+     * @param qualifier - Koin BeanDefinition qualifier (if have several ViewModel beanDefinition of the same type)
+     * @param parameters - parameters to pass to the BeanDefinition
+     */
+    @JvmOverloads
+    @JvmStatic
+    fun <T : ViewModel> viewModel(
+            owner: LifecycleOwner,
+            clazz: Class<T>,
+            qualifier: Qualifier? = null,
+            parameters: ParametersDefinition? = null
+    ): Lazy<T> = owner.viewModel(clazz.kotlin, qualifier, parameters)
+
+
+    /**
+     * Get a viewModel instance
+     *
+     * @param owner - LifecycleOwner
+     * @param clazz - Class of the BeanDefinition to retrieve
+     * @param qualifier - Koin BeanDefinition qualifier (if have several ViewModel beanDefinition of the same type)
+     * @param parameters - parameters to pass to the BeanDefinition
+     */
+    @JvmOverloads
+    @JvmStatic
+    fun <T : ViewModel> getViewModel(
+            owner: LifecycleOwner,
+            clazz: Class<T>,
+            qualifier: Qualifier? = null,
+            parameters: ParametersDefinition? = null
+    ): T {
+        return owner.getViewModel(clazz.kotlin, qualifier, parameters)
+    }
+}


### PR DESCRIPTION
This PR fix #480 
I add some classes for create Java compatibility with `viewModel` and `sharedViewModel` extensions.
Also, I created on sample one activity and fragment in Java, showing the view model injections.