### PR TITLE
Allow enums to be used as Qualifiers (along with String or a class)

### DIFF
--- a/koin-projects/koin-core/src/main/kotlin/org/koin/core/qualifier/EnumQualifier.kt
+++ b/koin-projects/koin-core/src/main/kotlin/org/koin/core/qualifier/EnumQualifier.kt
@@ -4,8 +4,8 @@ package org.koin.core.qualifier
  * Class which allows enums to be used as Qualifiers.
  * More strict than strings and are better for refactoring.
  * @author Julian Bell
- * @sample get(named(Direction.NORTH))
- * @sample inject(named(Direction.SOUTH))
+ * @sample get(qualifier(Direction.NORTH))
+ * @sample inject(qualifier(Direction.SOUTH))
  */
 data class EnumQualifier<E : Enum<E>>(val value: E) : Qualifier {
     override fun toString(): String {

--- a/koin-projects/koin-core/src/main/kotlin/org/koin/core/qualifier/EnumQualifier.kt
+++ b/koin-projects/koin-core/src/main/kotlin/org/koin/core/qualifier/EnumQualifier.kt
@@ -1,0 +1,14 @@
+package org.koin.core.qualifier
+
+/**
+ * Class which allows enums to be used as Qualifiers.
+ * More strict than strings and are better for refactoring.
+ * @author Julian Bell
+ * @sample get(named(Direction.NORTH))
+ * @sample inject(named(Direction.SOUTH))
+ */
+data class EnumQualifier<E : Enum<E>>(val value: E) : Qualifier {
+    override fun toString(): String {
+        return value.toString()
+    }
+}

--- a/koin-projects/koin-core/src/main/kotlin/org/koin/core/qualifier/EnumQualifier.kt
+++ b/koin-projects/koin-core/src/main/kotlin/org/koin/core/qualifier/EnumQualifier.kt
@@ -9,6 +9,6 @@ package org.koin.core.qualifier
  */
 data class EnumQualifier<E : Enum<E>>(val value: E) : Qualifier {
     override fun toString(): String {
-        return value.toString()
+        return "${value.javaClass.name}.$value"
     }
 }

--- a/koin-projects/koin-core/src/main/kotlin/org/koin/core/qualifier/Qualifier.kt
+++ b/koin-projects/koin-core/src/main/kotlin/org/koin/core/qualifier/Qualifier.kt
@@ -18,4 +18,4 @@ inline fun <reified T> named() = TypeQualifier(T::class)
 /**
  * Give a enum based qualifier
  */
-fun <E : Enum<E>> qualified(qual: E) = EnumQualifier(qual)
+fun <E : Enum<E>> qualifier(qual: E) = EnumQualifier(qual)

--- a/koin-projects/koin-core/src/main/kotlin/org/koin/core/qualifier/Qualifier.kt
+++ b/koin-projects/koin-core/src/main/kotlin/org/koin/core/qualifier/Qualifier.kt
@@ -14,3 +14,8 @@ fun named(name: String) = StringQualifier(name)
  * Give a Type based qualifier
  */
 inline fun <reified T> named() = TypeQualifier(T::class)
+
+/**
+ * Give a enum based qualifier
+ */
+fun <E : Enum<E>> named(qual: E) = EnumQualifier(qual)

--- a/koin-projects/koin-core/src/main/kotlin/org/koin/core/qualifier/Qualifier.kt
+++ b/koin-projects/koin-core/src/main/kotlin/org/koin/core/qualifier/Qualifier.kt
@@ -18,4 +18,4 @@ inline fun <reified T> named() = TypeQualifier(T::class)
 /**
  * Give a enum based qualifier
  */
-fun <E : Enum<E>> named(qual: E) = EnumQualifier(qual)
+fun <E : Enum<E>> qualified(qual: E) = EnumQualifier(qual)

--- a/koin-projects/koin-core/src/test/kotlin/org/koin/core/qualifier/EnumQualifierTest.kt
+++ b/koin-projects/koin-core/src/test/kotlin/org/koin/core/qualifier/EnumQualifierTest.kt
@@ -19,22 +19,22 @@ class EnumQualifierTest {
 
     @Test
     fun `qualified enums work correctly and are distinct`() {
-        assertNotEquals(qualified(Indicate.LEFT), qualified(Indicate.RIGHT))
+        assertNotEquals(qualifier(Indicate.LEFT), qualifier(Indicate.RIGHT))
     }
 
     @Test
     fun `qualified enum not equal to string qualifier`() {
-        assertNotEquals(qualified(Indicate.LEFT).toString(), named("LEFT").toString())
+        assertNotEquals(qualifier(Indicate.LEFT).toString(), named("LEFT").toString())
     }
 
     @Test
     fun `qualified enum uses fully qualified name`() {
-        assertEquals(qualified(Indicate.LEFT).toString(), Indicate::class.java.name + ".LEFT")
+        assertEquals(qualifier(Indicate.LEFT).toString(), Indicate::class.java.name + ".LEFT")
     }
 
     @Test
     fun `different qualified enums with same name don't match`() {
-        assertNotEquals(qualified(Indicate.LEFT).toString(), qualified(Turn.LEFT))
+        assertNotEquals(qualifier(Indicate.LEFT).toString(), qualifier(Turn.LEFT))
     }
 
     @Test
@@ -44,7 +44,7 @@ class EnumQualifierTest {
                 modules(
                     module {
                         single(named("RIGHT")) { "A" }
-                        single(qualified(Turn.RIGHT)) { "B" }
+                        single(qualifier(Turn.RIGHT)) { "B" }
                     }
                 )
             }

--- a/koin-projects/koin-core/src/test/kotlin/org/koin/core/qualifier/EnumQualifierTest.kt
+++ b/koin-projects/koin-core/src/test/kotlin/org/koin/core/qualifier/EnumQualifierTest.kt
@@ -1,0 +1,19 @@
+package org.koin.core.qualifier
+
+import org.junit.Assert
+import org.junit.Test
+import org.koin.core.qualifier.EnumQualifierTest.Way.LEFT
+import org.koin.core.qualifier.EnumQualifierTest.Way.RIGHT
+
+class EnumQualifierTest {
+
+    private enum class Way {
+        LEFT, RIGHT
+    }
+
+    @Test
+    fun `named enum works correctly and are distinct`() {
+        Assert.assertNotEquals(named(LEFT), named(RIGHT))
+    }
+
+}

--- a/koin-projects/koin-core/src/test/kotlin/org/koin/core/qualifier/EnumQualifierTest.kt
+++ b/koin-projects/koin-core/src/test/kotlin/org/koin/core/qualifier/EnumQualifierTest.kt
@@ -4,6 +4,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Test
 import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
 import org.koin.dsl.module
 
 class EnumQualifierTest {
@@ -38,13 +39,17 @@ class EnumQualifierTest {
 
     @Test
     fun `string and enum qualifiers can both be defined`() {
-        startKoin {
-            modules(
-                module {
-                    single(named("RIGHT")) { "A" }
-                    single(qualified(Turn.RIGHT)) { "B" }
-                }
-            )
+        try {
+            startKoin {
+                modules(
+                    module {
+                        single(named("RIGHT")) { "A" }
+                        single(qualified(Turn.RIGHT)) { "B" }
+                    }
+                )
+            }
+        } finally {
+            stopKoin()
         }
     }
 

--- a/koin-projects/koin-core/src/test/kotlin/org/koin/core/qualifier/EnumQualifierTest.kt
+++ b/koin-projects/koin-core/src/test/kotlin/org/koin/core/qualifier/EnumQualifierTest.kt
@@ -1,19 +1,51 @@
 package org.koin.core.qualifier
 
-import org.junit.Assert
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
 import org.junit.Test
-import org.koin.core.qualifier.EnumQualifierTest.Way.LEFT
-import org.koin.core.qualifier.EnumQualifierTest.Way.RIGHT
+import org.koin.core.context.startKoin
+import org.koin.dsl.module
 
 class EnumQualifierTest {
 
-    private enum class Way {
+    private enum class Indicate {
+        LEFT, RIGHT
+    }
+
+    private enum class Turn {
         LEFT, RIGHT
     }
 
     @Test
-    fun `named enum works correctly and are distinct`() {
-        Assert.assertNotEquals(named(LEFT), named(RIGHT))
+    fun `qualified enums work correctly and are distinct`() {
+        assertNotEquals(qualified(Indicate.LEFT), qualified(Indicate.RIGHT))
+    }
+
+    @Test
+    fun `qualified enum not equal to string qualifier`() {
+        assertNotEquals(qualified(Indicate.LEFT).toString(), named("LEFT").toString())
+    }
+
+    @Test
+    fun `qualified enum uses fully qualified name`() {
+        assertEquals(qualified(Indicate.LEFT).toString(), Indicate::class.java.name + ".LEFT")
+    }
+
+    @Test
+    fun `different qualified enums with same name don't match`() {
+        assertNotEquals(qualified(Indicate.LEFT).toString(), qualified(Turn.LEFT))
+    }
+
+    @Test
+    fun `string and enum qualifiers can both be defined`() {
+        startKoin {
+            modules(
+                module {
+                    single(named("RIGHT")) { "A" }
+                    single(qualified(Turn.RIGHT)) { "B" }
+                }
+            )
+        }
     }
 
 }


### PR DESCRIPTION
This is a simple qualifier I am using and should be useful to others.  It allows an enum to be used as a qualifier.  This avoid defining equal strings in multiple areas and allows refactoring without any hidden surprises.