### PR TITLE
Upgrade ViewModel-SavedState version

### DIFF
--- a/koin-projects/examples/androidx-samples/build.gradle
+++ b/koin-projects/examples/androidx-samples/build.gradle
@@ -31,7 +31,7 @@ dependencies {
 
     implementation "androidx.appcompat:appcompat:$androidx_lib_version"
     implementation "androidx.lifecycle:lifecycle-extensions:$android_arch_version"
-    implementation "androidx.lifecycle:lifecycle-viewmodel-savedstate:1.0.0-alpha01"
+    implementation "androidx.lifecycle:lifecycle-viewmodel-savedstate:$androidx_savedstate"
     implementation "org.jetbrains.anko:anko-commons:$anko_version"
 
 }

--- a/koin-projects/gradle/versions-android.gradle
+++ b/koin-projects/gradle/versions-android.gradle
@@ -11,5 +11,5 @@ ext {
 	android_arch_version = '1.1.1'
 	androidx_arch_version = '2.1.0'
 
-	androidx_savedstate = '1.0.0-alpha01'
+	androidx_savedstate = '1.0.0-alpha05'
 }

--- a/koin-projects/gradle/versions-android.gradle
+++ b/koin-projects/gradle/versions-android.gradle
@@ -10,4 +10,6 @@ ext {
 
 	android_arch_version = '1.1.1'
 	androidx_arch_version = '2.1.0'
+
+	androidx_savedstate = '1.0.0-alpha01'
 }

--- a/koin-projects/koin-androidx-ext/build.gradle
+++ b/koin-projects/koin-androidx-ext/build.gradle
@@ -34,7 +34,7 @@ dependencies {
         exclude module: "runtime"
         exclude group: "androidx.legacy"
     }
-    implementation("androidx.lifecycle:lifecycle-viewmodel-savedstate:1.0.0-alpha01") {
+    implementation("androidx.lifecycle:lifecycle-viewmodel-savedstate:$androidx_savedstate") {
         exclude module: "lifecycle-livedata"
         exclude module: "lifecycle-service"
         exclude module: "lifecycle-process"

--- a/koin-projects/koin-androidx-viewmodel/build.gradle
+++ b/koin-projects/koin-androidx-viewmodel/build.gradle
@@ -34,7 +34,7 @@ dependencies {
         exclude group: "androidx.legacy"
     }
 
-    implementation("androidx.lifecycle:lifecycle-viewmodel-savedstate:1.0.0-alpha01") {
+    implementation("androidx.lifecycle:lifecycle-viewmodel-savedstate:$androidx_savedstate") {
         exclude module: "lifecycle-livedata"
         exclude module: "lifecycle-service"
         exclude module: "lifecycle-process"

--- a/koin-projects/koin-androidx-viewmodel/src/main/java/org/koin/androidx/viewmodel/ViewModelResolution.kt
+++ b/koin-projects/koin-androidx-viewmodel/src/main/java/org/koin/androidx/viewmodel/ViewModelResolution.kt
@@ -6,7 +6,7 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelStore
-import androidx.lifecycle.AbstractSavedStateVMFactory
+import androidx.lifecycle.AbstractSavedStateViewModelFactory
 import androidx.lifecycle.SavedStateHandle
 import androidx.savedstate.SavedStateRegistryOwner
 import org.koin.androidx.viewmodel.dsl.isStateViewModel
@@ -68,7 +68,7 @@ fun <T : ViewModel> Scope.createViewModelProvider(
     return ViewModelProvider(
             vmStore,
             if(beanRegistry.findDefinition(parameters.qualifier, parameters.clazz)?.isStateViewModel() == true) {
-                object : AbstractSavedStateVMFactory(parameters.owner as SavedStateRegistryOwner, parameters.defaultArguments()) {
+                object : AbstractSavedStateViewModelFactory(parameters.owner as SavedStateRegistryOwner, parameters.defaultArguments()) {
                     override fun <T : ViewModel?> create(key: String, modelClass: Class<T>, handle: SavedStateHandle): T {
                         return get(parameters.clazz, parameters.qualifier) {
                             parametersOf(handle, *(parameters.parameters?.invoke() ?: emptyParametersHolder()).values)


### PR DESCRIPTION
Hi, I've update ViewModel-SavedState library from version `1.0.0-alpha01` to `1.0.0-alpha05`.
This update introduced some API changes, as per [release notes](https://developer.android.com/jetpack/androidx/releases/lifecycle#viewmodel-savedstate_version_100_2), so it wasn't possible for us to use koin `2.1.0-alpha-1` with newer versions of ViewModel-SavedState.