### PR TITLE
#492 Avoid closing definitions when a scope instance is closed

### DIFF
--- a/koin-projects/koin-core/src/main/kotlin/org/koin/core/Koin.kt
+++ b/koin-projects/koin-core/src/main/kotlin/org/koin/core/Koin.kt
@@ -230,7 +230,7 @@ class Koin {
      */
     fun close() {
         scopeRegistry.close()
-        rootScope.close()
+        rootScope.tearDown()
         propertyRegistry.close()
     }
 }

--- a/koin-projects/koin-core/src/main/kotlin/org/koin/core/definition/BeanDefinition.kt
+++ b/koin-projects/koin-core/src/main/kotlin/org/koin/core/definition/BeanDefinition.kt
@@ -48,6 +48,9 @@ class BeanDefinition<T>(
     var onRelease: OnReleaseCallback<T>? = null
     var onClose: OnCloseCallback<T>? = null
 
+    // declared by user after scope creation
+    var onTheFly: Boolean = false
+
     /**
      *
      */

--- a/koin-projects/koin-core/src/main/kotlin/org/koin/core/registry/BeanRegistry.kt
+++ b/koin-projects/koin-core/src/main/kotlin/org/koin/core/registry/BeanRegistry.kt
@@ -84,7 +84,7 @@ class BeanRegistry {
      * @param definition
      */
     private fun removeDefinition(definition: BeanDefinition<*>) {
-        definition.instance?.close()
+        definition.close()
         definitions.remove(definition)
         if (definition.qualifier != null) {
             removeDefinitionForName(definition)
@@ -272,11 +272,15 @@ class BeanRegistry {
     }
 
     fun close() {
-        definitions.forEach { it.close() }
         definitions.clear()
         definitionsNames.clear()
         definitionsPrimaryTypes.clear()
         definitionsToCreate.clear()
+    }
+
+    fun tearDown() {
+        definitions.forEach { it.close() }
+        close()
     }
 
     /**

--- a/koin-projects/koin-core/src/main/kotlin/org/koin/core/registry/BeanRegistry.kt
+++ b/koin-projects/koin-core/src/main/kotlin/org/koin/core/registry/BeanRegistry.kt
@@ -272,6 +272,9 @@ class BeanRegistry {
     }
 
     fun close() {
+        // Close all on the fly declarations since they are only used in the specific scope instance
+        // and are not present in the scope definition.
+        definitions.filter { it.onTheFly }.forEach { it.close() }
         definitions.clear()
         definitionsNames.clear()
         definitionsPrimaryTypes.clear()

--- a/koin-projects/koin-core/src/main/kotlin/org/koin/core/registry/ScopeRegistry.kt
+++ b/koin-projects/koin-core/src/main/kotlin/org/koin/core/registry/ScopeRegistry.kt
@@ -143,7 +143,7 @@ class ScopeRegistry {
     }
 
     fun close() {
-        instances.values.forEach { it.close() }
+        instances.values.forEach { it.tearDown() }
         definitions.clear()
         instances.clear()
     }

--- a/koin-projects/koin-core/src/main/kotlin/org/koin/core/scope/Scope.kt
+++ b/koin-projects/koin-core/src/main/kotlin/org/koin/core/scope/Scope.kt
@@ -39,6 +39,9 @@ data class Scope(
     var scopeDefinition: ScopeDefinition? = null
     private val callbacks = arrayListOf<ScopeCallback>()
 
+
+    private var isClosed: Boolean = false
+
     /**
      * Lazy inject a Koin instance
      * @param qualifier
@@ -298,15 +301,31 @@ data class Scope(
         scopeDefinition.let {
             it?.definitions?.forEach { definition ->
                 beanRegistry.saveDefinition(definition)
-                definition.createInstanceHolder()
             }
         }
     }
 
     /**
-     * Close all instances from this scope
+     * Close all instances of this scope without closing definitions since there might be other
+     * scopes instance with the same scope name.
      */
     fun close() = synchronized(this) {
+        release()
+        beanRegistry.close()
+    }
+
+    /**
+     * Close all instances of this scope including closing all related definitions
+     */
+    fun tearDown() = synchronized(this) {
+        release()
+        beanRegistry.tearDown()
+    }
+
+    private fun release() {
+        if (isClosed) {
+            return
+        }
         if (KoinApplication.logger.isAt(Level.DEBUG)) {
             KoinApplication.logger.info("closing scope:'$id'")
         }
@@ -315,8 +334,8 @@ data class Scope(
         callbacks.clear()
 
         scopeDefinition?.release(this)
-        beanRegistry.close()
         _koin.deleteScope(this.id)
+        isClosed = true
     }
 
     override fun toString(): String {

--- a/koin-projects/koin-core/src/main/kotlin/org/koin/core/scope/Scope.kt
+++ b/koin-projects/koin-core/src/main/kotlin/org/koin/core/scope/Scope.kt
@@ -208,6 +208,7 @@ data class Scope(
         } else {
             DefinitionFactory.createScoped(qualifier, scopeName = scopeDefinition?.qualifier) { instance }
         }
+        definition.onTheFly = true
         secondaryTypes?.let { definition.secondaryTypes.addAll(it) }
         definition.options.override = override
         beanRegistry.saveDefinition(definition)

--- a/koin-projects/koin-core/src/test/kotlin/org/koin/dsl/BeanLifecycleTest.kt
+++ b/koin-projects/koin-core/src/test/kotlin/org/koin/dsl/BeanLifecycleTest.kt
@@ -1,8 +1,10 @@
 package org.koin.dsl
 
-import org.junit.Assert.assertEquals
+import org.junit.Assert.*
 import org.junit.Test
 import org.koin.Simple
+import org.koin.core.definition.BeanDefinition
+import org.koin.core.error.NoBeanDefFoundException
 import org.koin.core.qualifier.named
 
 class BeanLifecycleTest {
@@ -108,5 +110,83 @@ class BeanLifecycleTest {
         scopeInstance.get<Simple.Component1>()
         scopeInstance.close()
         assertEquals("release", result)
+    }
+
+    /**
+     * https://github.com/InsertKoinIO/koin/issues/492
+     */
+    @Test
+    fun `closing scope A1 does not affect bean definitions of scope A2 when both scope instances have the same scope name A`() {
+        val koin = koinApplication {
+            modules(module {
+                scope(named("A")) {
+                    scoped { Simple.Component1() }
+                }
+            })
+        }.koin
+
+        val scopeA1 = koin.createScope("123", named("A"))
+        val scopeA2 = koin.createScope("234", named("A"))
+
+        val scopeA1Value = scopeA1.get<Simple.Component1>()
+        val scopeA2Value = scopeA2.get<Simple.Component1>()
+        assertNotNull(scopeA1Value)
+        assertNotNull(scopeA2Value)
+        assertNotEquals(scopeA1Value, scopeA2Value)
+
+        scopeA1.close()
+
+        assertEquals(scopeA2Value, scopeA2.get<Simple.Component1>())
+        try {
+            scopeA1.get<Simple.Component1>()
+            fail("Should not be able to resolve the instance from scope A because scope A is closed.")
+        } catch(e: NoBeanDefFoundException) {
+
+        }
+    }
+
+    @Test
+    fun `closing koin releases related instances from scopes`() {
+        val koin = koinApplication {
+            modules(module {
+                scope(named("A")) {
+                    scoped { Simple.Component1() }
+                }
+            })
+        }.koin
+
+        val scopeA = koin.createScope("123", named("A"))
+        val scopeB = koin.createScope("234", named("A"))
+
+        assertNotNull(scopeA.get<Simple.Component1>())
+        assertNotNull(scopeB.get<Simple.Component1>())
+
+        val definitionsA = scopeA.beanRegistry.getAllDefinitions().toList()
+        val definitionsB = scopeB.beanRegistry.getAllDefinitions().toList()
+        assert(definitionsA.isNotEmpty())
+        assert(definitionsB.isNotEmpty())
+
+        koin.close()
+
+        definitionsA.forEach { assertNull(it.instance) }
+        definitionsB.forEach { assertNull(it.instance) }
+        assertEquals(0, scopeA.beanRegistry.getAllDefinitions().size)
+        assertEquals(0, scopeB.beanRegistry.getAllDefinitions().size)
+    }
+
+    @Test
+    fun `closes bean definitions in root scope when koin is closed`() {
+        lateinit var definition: BeanDefinition<Simple.Component1>
+        val koin = koinApplication {
+            modules(module {
+                definition = single { Simple.Component1() }
+            })
+        }.koin
+
+        koin.get<Simple.Component1>()
+        assertNotNull(definition.instance)
+
+        koin.close()
+        assertNull(definition.instance)
     }
 }

--- a/koin-projects/koin-core/src/test/kotlin/org/koin/dsl/BeanLifecycleTest.kt
+++ b/koin-projects/koin-core/src/test/kotlin/org/koin/dsl/BeanLifecycleTest.kt
@@ -1,6 +1,10 @@
 package org.koin.dsl
 
-import org.junit.Assert.*
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.fail
 import org.junit.Test
 import org.koin.Simple
 import org.koin.core.definition.BeanDefinition


### PR DESCRIPTION
Since there might be other open scope instances with the same scope name. Fixes gh-492