### PR TITLE
Allow overriding definitions in scopes by loading modules

### DIFF
--- a/koin-projects/koin-core/src/main/kotlin/org/koin/core/registry/ScopeRegistry.kt
+++ b/koin-projects/koin-core/src/main/kotlin/org/koin/core/registry/ScopeRegistry.kt
@@ -99,6 +99,15 @@ class ScopeRegistry {
             definitions[scopeSet.qualifier.toString()] = scopeSet.createDefinition()
         } else {
             foundScopeSet.addDefinitionsFrom(scopeSet)
+            allScopes(scopeSet.qualifier).forEach {
+                it.updateBeanRegistry()
+            }
+        }
+    }
+
+    private fun allScopes(qualifier: Qualifier?): List<Scope> {
+        return instances.values.filter {
+            it.scopeDefinition?.qualifier == qualifier
         }
     }
 

--- a/koin-projects/koin-core/src/main/kotlin/org/koin/core/scope/Scope.kt
+++ b/koin-projects/koin-core/src/main/kotlin/org/koin/core/scope/Scope.kt
@@ -27,6 +27,7 @@ import org.koin.core.parameter.ParametersDefinition
 import org.koin.core.qualifier.Qualifier
 import org.koin.core.registry.BeanRegistry
 import org.koin.core.time.measureDuration
+import org.koin.dsl.ScopeSet
 import org.koin.ext.getFullName
 import kotlin.reflect.KClass
 
@@ -299,6 +300,16 @@ data class Scope(
             it?.definitions?.forEach { definition ->
                 beanRegistry.saveDefinition(definition)
                 definition.createInstanceHolder()
+            }
+        }
+    }
+
+    internal fun updateBeanRegistry() {
+        scopeDefinition?.let { scopeDefinition ->
+            scopeDefinition.definitions.forEach {
+                if (beanRegistry.findDefinition(it.qualifier, it.primaryType) == null) {
+                    beanRegistry.saveDefinition(it)
+                }
             }
         }
     }

--- a/koin-projects/koin-core/src/test/kotlin/org/koin/core/ScopeAPITest.kt
+++ b/koin-projects/koin-core/src/test/kotlin/org/koin/core/ScopeAPITest.kt
@@ -221,4 +221,24 @@ class ScopeAPITest {
         val scope = koin.createScope("123", named("A"))
         assertEquals("C", scope.get<String>())
     }
+
+    @Test
+    fun `already open scopes are considered when loading scope definitions via modules on the fly`() {
+        val module = module {
+            scope(named("A")) {
+                scoped { "A" }
+            }
+        }
+        val koin = startKoin { modules(module) }.koin
+        val scope = koin.createScope("123", named("A"))
+
+        loadKoinModules(module {
+            scope(named("A")) {
+                scoped(named("B")) { "B" }
+            }
+        })
+
+        assertEquals("A", scope.get<String>())
+        assertEquals("B", scope.get<String>(named("B")))
+    }
 }


### PR DESCRIPTION
Previously, the definitions were not added when they were already present. Specifying the override parameter didn't work because only primaryType and qualifier are evaluated in the `hashCode()` and `equals()` method in the `BeanDefinition` class.