### PR TITLE
Remove kotlin-reflect dependency

### DIFF
--- a/koin-projects/koin-core-ext/build.gradle
+++ b/koin-projects/koin-core-ext/build.gradle
@@ -6,7 +6,6 @@ description = 'Koin - simple dependency injection for Kotlin - ' + archivesBaseN
 dependencies {
     // Koin
     compile project(":koin-core")
-    compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
 
     testCompile project(":koin-test")
 }


### PR DESCRIPTION
Koin doesn't use it, but it will increase about 1MB size