### PR TITLE
parent koin

### DIFF
--- a/koin-projects/koin-core/src/main/kotlin/org/koin/core/Koin.kt
+++ b/koin-projects/koin-core/src/main/kotlin/org/koin/core/Koin.kt
@@ -36,7 +36,7 @@ import kotlin.reflect.KClass
  *
  * @author Arnaud Giuliani
  */
-class Koin {
+class Koin(val parent: Koin? = null) {
     val _scopeRegistry = ScopeRegistry(this)
     val _propertyRegistry = PropertyRegistry(this)
     var _logger: Logger = EmptyLogger()
@@ -200,7 +200,9 @@ class Koin {
      * @param qualifier
      */
     fun getOrCreateScope(scopeId: ScopeID, qualifier: Qualifier): Scope {
-        return _scopeRegistry.getScopeOrNull(scopeId) ?: createScope(scopeId, qualifier)
+        return _scopeRegistry.getScopeOrNull(scopeId)
+                ?: parent?._scopeRegistry?.getScopeOrNull(scopeId)
+                ?: createScope(scopeId, qualifier)
     }
 
     /**
@@ -210,7 +212,9 @@ class Koin {
      */
     inline fun <reified T> getOrCreateScope(scopeId: ScopeID): Scope {
         val qualifier = TypeQualifier(T::class)
-        return _scopeRegistry.getScopeOrNull(scopeId) ?: createScope(scopeId, qualifier)
+        return _scopeRegistry.getScopeOrNull(scopeId)
+                ?: parent?._scopeRegistry?.getScopeOrNull(scopeId)
+                ?: createScope(scopeId, qualifier)
     }
 
     /**
@@ -219,6 +223,7 @@ class Koin {
      */
     fun getScope(scopeId: ScopeID): Scope {
         return _scopeRegistry.getScopeOrNull(scopeId)
+                ?: parent?._scopeRegistry?.getScopeOrNull(scopeId)
                 ?: throw ScopeNotCreatedException("No scope found for id '$scopeId'")
     }
 
@@ -228,6 +233,7 @@ class Koin {
      */
     fun getScopeOrNull(scopeId: ScopeID): Scope? {
         return _scopeRegistry.getScopeOrNull(scopeId)
+                ?: parent?._scopeRegistry?.getScopeOrNull(scopeId)
     }
 
     /**
@@ -243,7 +249,9 @@ class Koin {
      * @param defaultValue
      */
     fun <T> getProperty(key: String, defaultValue: T): T {
-        return _propertyRegistry.getProperty<T>(key) ?: defaultValue
+        return _propertyRegistry.getProperty<T>(key)
+                ?: parent?._propertyRegistry?.getProperty<T>(key)
+                ?: defaultValue
     }
 
     /**
@@ -252,6 +260,7 @@ class Koin {
      */
     fun <T> getProperty(key: String): T? {
         return _propertyRegistry.getProperty(key)
+                ?: parent?._propertyRegistry?.getProperty(key)
     }
 
     /**

--- a/koin-projects/koin-core/src/main/kotlin/org/koin/core/KoinApplication.kt
+++ b/koin-projects/koin-core/src/main/kotlin/org/koin/core/KoinApplication.kt
@@ -27,9 +27,9 @@ import org.koin.core.time.measureDuration
  *
  * @author Arnaud Giuliani
  */
-class KoinApplication private constructor() {
+class KoinApplication private constructor(val parent: Koin? = null) {
 
-    val koin = Koin()
+    val koin = Koin(parent)
 
     internal fun init() {
         koin._scopeRegistry.createRootScopeDefinition()
@@ -157,6 +157,13 @@ class KoinApplication private constructor() {
         @JvmStatic
         fun init(): KoinApplication {
             val app = KoinApplication()
+            app.init()
+            return app
+        }
+
+        @JvmStatic
+        fun init(parent: Koin): KoinApplication {
+            val app = KoinApplication(parent)
             app.init()
             return app
         }

--- a/koin-projects/koin-core/src/main/kotlin/org/koin/core/registry/ScopeRegistry.kt
+++ b/koin-projects/koin-core/src/main/kotlin/org/koin/core/registry/ScopeRegistry.kt
@@ -120,6 +120,8 @@ class ScopeRegistry(private val _koin: Koin) {
         }
 
         val scopeDefinition = scopeDefinitions[qualifier.value]
+                ?: _koin.parent?._scopeRegistry?.scopeDefinitions?.get(qualifier.value)
+
         return if (scopeDefinition != null) {
             val createdScope: Scope = createScope(scopeId, scopeDefinition)
             _scopes[scopeId] = createdScope

--- a/koin-projects/koin-core/src/main/kotlin/org/koin/dsl/KoinApplication.kt
+++ b/koin-projects/koin-core/src/main/kotlin/org/koin/dsl/KoinApplication.kt
@@ -15,6 +15,7 @@
  */
 package org.koin.dsl
 
+import org.koin.core.Koin
 import org.koin.core.KoinApplication
 
 typealias KoinAppDeclaration = KoinApplication.() -> Unit
@@ -25,6 +26,17 @@ typealias KoinAppDeclaration = KoinApplication.() -> Unit
  */
 fun koinApplication(appDeclaration: KoinAppDeclaration): KoinApplication {
     val koinApplication = KoinApplication.init()
+    appDeclaration(koinApplication)
+    koinApplication.koin.createContextIfNeeded()
+    return koinApplication
+}
+
+/**
+ * Create a KoinApplication with parent koin
+ * @author Michal Nikodim
+ */
+fun koinApplication(parent: Koin, appDeclaration: KoinAppDeclaration): KoinApplication {
+    val koinApplication = KoinApplication.init(parent)
     appDeclaration(koinApplication)
     koinApplication.koin.createContextIfNeeded()
     return koinApplication

--- a/koin-projects/koin-core/src/test/java/org/koin/core/KoinSubApplicationTest.kt
+++ b/koin-projects/koin-core/src/test/java/org/koin/core/KoinSubApplicationTest.kt
@@ -1,0 +1,96 @@
+package org.koin.core
+
+import org.junit.Assert
+import org.junit.Test
+import org.koin.Simple
+import org.koin.dsl.koinApplication
+import org.koin.dsl.module
+import org.koin.ext.getOrCreateScope
+
+class KoinSubApplicationTest {
+
+    @Test
+    fun `create koin application with parent`() {
+        val parent = koinApplication {
+            modules(
+                    module {
+                        single { Simple.ComponentA() }
+                    })
+        }.koin
+
+        val koin = koinApplication(parent) {
+            modules(
+                    module {
+                        single { Simple.ComponentB(a = get()) }
+                    })
+        }.koin
+
+        val a1: Simple.ComponentA = parent.get()
+        val a2: Simple.ComponentA = koin.get()
+        val b: Simple.ComponentB = koin.get()
+
+        Assert.assertEquals(a1, a2)
+        Assert.assertNotNull(b)
+        Assert.assertEquals(a1, b.a)
+        Assert.assertEquals(a2, b.a)
+    }
+
+    @Test
+    fun `sub application getAll`() {
+        val parent = koinApplication {
+            modules(
+                    module {
+                        single { Simple.ComponentA() }
+                    })
+        }.koin
+
+        val koin = koinApplication(parent) {
+            modules(
+                    module {
+                        single { Simple.ComponentB(a = get()) }
+                    })
+        }.koin
+
+        val list1 = parent.getAll<Simple.ComponentA>()
+        val list2 = koin.getAll<Simple.ComponentA>()
+
+        Assert.assertEquals(list1.size,list2.size)
+        Assert.assertEquals(list1[0], list2[0])
+    }
+
+    @Test
+    fun `sub application scopes`() {
+        val parent = koinApplication() {
+            modules(
+                    module {
+                        single { A() }
+                        scope<A> {
+                            scoped { Simple.ComponentA() }
+                        }
+                    })
+        }.koin
+
+        val koin = koinApplication(parent) {
+            modules(
+                    module {
+                        single { B() }
+                        scope<B> {
+                            scoped { Simple.ComponentB(a = get<A>().getOrCreateScope(this@koinApplication.koin).get()) }
+                        }
+                    })
+        }.koin
+
+        val a = koin.get<A>()
+        val cA1 = a.getOrCreateScope(koin).get<Simple.ComponentA>()
+        val cA2 = a.getOrCreateScope(koin).get<Simple.ComponentA>()
+
+        val b = koin.get<B>()
+        val cB1 = b.getOrCreateScope(koin).get<Simple.ComponentB>()
+        val cB2 = b.getOrCreateScope(koin).get<Simple.ComponentB>()
+
+        Assert.assertEquals(cA1, cA2)
+        Assert.assertEquals(cB1, cB2)
+        Assert.assertEquals(cA1, cB1.a)
+        Assert.assertEquals(cA2, cB2.a)
+    }
+}


### PR DESCRIPTION
This is idea for solution of multi module Android app. 
If Android have these modules:
:core
:feature:login
:feature:market

then :core modul can have global koin and every :feature module can have own koin module binded with parent koin from :core. Parent koin contains shared instances (singletons) as OkHttp and Retrofit.

