### PR TITLE
Fixed library version in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Badges: `[UPDATED]`, `[FIXED]`, `[ADDED]`, `[DEPRECATED]`, `[REMOVED]`,  `[BREAK
 
 ## [2.1.0]()
 
-### [alpha-11]()
+### [beta-1]()
 
 _Core_
 


### PR DESCRIPTION
## Overview
- I thought library version in CHANGELOG.md is beta-1, so I fixed it.