### PR TITLE
Add missing quote

### DIFF
--- a/koin-projects/docs/start/quickstart/android.md
+++ b/koin-projects/docs/start/quickstart/android.md
@@ -19,7 +19,7 @@ repositories {
 }
 dependencies {
     // Koin for Android
-    compile 'org.koin:koin-android:$koin_version
+    compile 'org.koin:koin-android:$koin_version'
 }
 ```
 


### PR DESCRIPTION
In the documentation, a quote `'` was missing at the end of dependency.