### PR TITLE
Updated dependency quote marks in setup docs

### DIFF
--- a/koin-projects/docs/start/quickstart/android-java.md
+++ b/koin-projects/docs/start/quickstart/android-java.md
@@ -19,7 +19,7 @@ repositories {
 }
 dependencies {
     // Koin for Android
-    compile 'org.koin:koin-android:$koin_version'
+    compile "org.koin:koin-android:$koin_version"
 }
 ```
 

--- a/koin-projects/docs/start/quickstart/android-viewmodel.md
+++ b/koin-projects/docs/start/quickstart/android-viewmodel.md
@@ -20,7 +20,7 @@ repositories {
 dependencies {
     // Koin for Android - Scope feature
     // include koin-android-scope & koin-android
-    compile 'org.koin:koin-android-viewmodel:$koin_version'
+    compile "org.koin:koin-android-viewmodel:$koin_version"
 }
 ```
 

--- a/koin-projects/docs/start/quickstart/android.md
+++ b/koin-projects/docs/start/quickstart/android.md
@@ -19,7 +19,7 @@ repositories {
 }
 dependencies {
     // Koin for Android
-    compile 'org.koin:koin-android:$koin_version
+    compile "org.koin:koin-android:$koin_version"
 }
 ```
 

--- a/koin-projects/docs/start/quickstart/junit-test.md
+++ b/koin-projects/docs/start/quickstart/junit-test.md
@@ -19,7 +19,7 @@ repositories {
 }
 dependencies {
     // Koin testing tools
-    testcompile 'org.koin:koin-test:$koin_version'
+    testcompile "org.koin:koin-test:$koin_version"
 }
 ```
 

--- a/koin-projects/docs/start/quickstart/kotlin.md
+++ b/koin-projects/docs/start/quickstart/kotlin.md
@@ -19,9 +19,9 @@ repositories {
 }
 dependencies {
     // Koin for Kotlin apps
-    compile 'org.koin:koin-core:$koin_version'
+    compile "org.koin:koin-core:$koin_version"
     // Testing
-    testCompile 'org.koin:koin-test:$koin_version'
+    testCompile "org.koin:koin-test:$koin_version"
 }
 ```
 

--- a/koin-projects/docs/start/quickstart/ktor.md
+++ b/koin-projects/docs/start/quickstart/ktor.md
@@ -34,7 +34,7 @@ repositories {
 }
 dependencies {
     // Koin for Kotlin apps
-    compile 'org.koin:koin-ktor:$koin_version'
+    compile "org.koin:koin-ktor:$koin_version"
 }
 ```
 


### PR DESCRIPTION
The dependency declaration in the docs uses the `koin_version` variable and is supposed to be replaced by a predefined version of Koin.
In some places, single-quote `'` is used with interpolation, which Groovy does not support.
For example:
```
'org.koin:koin-android:$koin_version'
```
Direct copy-paste dependencies from docs will cause sync errors in Gradle files.

Groovy supports string interpolation in double quotes `"`, so I replaced the single quotes with double.

[Groovy Syntax Reference](https://groovy-lang.org/syntax.html) `4.4.1. String interpolation`