### PR TITLE
Add fallback for instantiate function in FragmentFactory Fixes gh-738

### DIFF
--- a/koin-projects/koin-androidx-fragment/src/main/java/org/koin/androidx/fragment/android/KoinFragmentFactory.kt
+++ b/koin-projects/koin-androidx-fragment/src/main/java/org/koin/androidx/fragment/android/KoinFragmentFactory.kt
@@ -11,9 +11,13 @@ import org.koin.core.scope.Scope
 class KoinFragmentFactory(val scope: Scope? = null) : FragmentFactory(), KoinComponent {
 
     override fun instantiate(classLoader: ClassLoader, className: String): Fragment {
-        val javaClass = Class.forName(className)
-        return scope?.let { it.get<Fragment>(javaClass) }
-            ?: getKoin().get(javaClass.kotlin)
+        val clazz = Class.forName(className).kotlin
+        val instance = if (scope != null) {
+            scope.getOrNull<Fragment>(clazz)
+        }else{
+            getKoin().getOrNull<Fragment>(clazz)
+        }
+        return instance ?: super.instantiate(classLoader, className)
     }
 
 }

--- a/koin-projects/koin-core/src/main/kotlin/org/koin/core/Koin.kt
+++ b/koin-projects/koin-core/src/main/kotlin/org/koin/core/Koin.kt
@@ -112,6 +112,21 @@ class Koin {
             parameters: ParametersDefinition? = null
     ): T = _scopeRegistry.rootScope.get(clazz, qualifier, parameters)
 
+    /**
+     * Get a Koin instance if available
+     * @param clazz
+     * @param qualifier
+     * @param scope
+     * @param parameters
+     *
+     * @return instance of type T or null
+     */
+    fun <T> getOrNull(
+            clazz: KClass<*>,
+            qualifier: Qualifier? = null,
+            parameters: ParametersDefinition? = null
+    ): T? = _scopeRegistry.rootScope.getOrNull(clazz, qualifier, parameters)
+
 
     /**
      * Declare a component definition from the given instance


### PR DESCRIPTION
With this fix fragments with empty constructors will get instantiated "the old way" when not registered in koin container. This is helpful for fragments that does not require any parameters (in my case - all of external libraries fragments).

If user will define fragment with some parameters - instantiate will still fail, so there is no danger for missuse here

Resolves #738 