### PR TITLE
Fix link to changelog on Koin website

### DIFF
--- a/koin-projects/docs/reference/sidebar.md
+++ b/koin-projects/docs/reference/sidebar.md
@@ -27,7 +27,7 @@
 - **Koin Ktor**
 - [Injecting with Ktor](koin-ktor/ktor)
 - **Links**
-- [Changelog](_https://github.com/InsertKoinIO/koin/blob/master/CHANGELOG.md)
+- [Changelog](https://github.com/InsertKoinIO/koin/blob/master/CHANGELOG.md)
 - [WebSite](https://insert-koin.io/)
 - [Getting Started Documentation](https://start.insert-koin.io/)
 - [![Github](https://icongram.jgog.in/simple/github.svg?color=808080&size=16)Github](https://github.com/InsertKoinIO/koin)

--- a/koin-projects/docs/start/sidebar.md
+++ b/koin-projects/docs/start/sidebar.md
@@ -17,7 +17,7 @@
 - [Koin for Android](getting-started/koin-for-android)
 - [Koin for Ktor](getting-started/koin-for-ktor)
 - **Links**
-- [Changelog](_https://github.com/InsertKoinIO/koin/blob/master/CHANGELOG.md)
+- [Changelog](https://github.com/InsertKoinIO/koin/blob/master/CHANGELOG.md)
 - [WebSite](https://insert-koin.io/)
 - [Reference Documentation](https://doc.insert-koin.io/)
 - [![Github](https://icongram.jgog.in/simple/github.svg?color=808080&size=16)Github](https://github.com/InsertKoinIO/koin)


### PR DESCRIPTION
There was a typo which led users to 404 error if they tried to click on `Changelog` in the sidebar of either `Start` or `Documentation` sections.

This PR fixes the typo.