### PR TITLE
Better checkModules API with default values & Mocked dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 Badges: `[UPDATED]`, `[FIXED]`, `[ADDED]`, `[DEPRECATED]`, `[REMOVED]`,  `[BREAKING]`
 
+## [2.2.0]()
+
+_koin-test_
+
+* `[FIXED]` fixed checkModules to use Mock for injected parameters or default origin value of a Scope
+* `[ADDED]` setup detault values for injected parameters, for checkModules
+* `[UPDATED]` fixed `DefinitionParameters` to add the ability to know the injected type value
+
+
 ## [2.1.6]()
 
 _koin-core_

--- a/koin-projects/docs/reference/koin-test/checkmodules_plugin.md
+++ b/koin-projects/docs/reference/koin-test/checkmodules_plugin.md
@@ -29,6 +29,11 @@ Each of the module test will use the `checkModules` API to check the module:
 ```kotlin
 @Category(CheckModuleTest::class)
 class CheckModulesTest : KoinTest {
+    
+    @get:Rule
+    val mockProvider = MockProviderRule.create { clazz ->
+        Mockito.mock(clazz.java)
+    }
 
     @Test
     fun checkAllModules() = checkModules {
@@ -36,6 +41,8 @@ class CheckModulesTest : KoinTest {
     }
 }
 ```
+
+> You can notice that we need a `MockProviderRule` declaration to allow Koin mock any injected definition
 
 #### Verifying graph with injected parameters [since 2.2.0]
 
@@ -57,17 +64,13 @@ If you need, you can set a default value for all type in the checked modules. Fo
 Let's use the `defaultValues()` function, to define a default value for all definitions:
 
 ```kotlin
-@Category(CheckModuleTest::class)
-class CheckModulesTest : KoinTest {
-
-    @Test
-    fun checkAllModules() = checkModules(
-        parameters = {
-            defaultValues<String>("_ID_")
-        }   
-    ){
-        modules(myModules)
-    }
+@Test
+fun checkAllModules() = checkModules(
+    parameters = {
+        defaultValues<String>("_ID_")
+    }   
+){
+    modules(myModules)
 }
 ```
 
@@ -85,17 +88,13 @@ module {
 You can define default value to be injected for one specific definition, with `create` function:
 
 ```kotlin
-@Category(CheckModuleTest::class)
-class CheckModulesTest : KoinTest {
-
-    @Test
-    fun checkAllModules() = checkModules(
-        parameters = {
-            create<FactoryPresenter> { parametersOf("_FactoryId_") }
-        }   
-    ){
-        modules(myModules)
-    }
+@Test
+fun checkAllModules() = checkModules(
+    parameters = {
+        create<FactoryPresenter> { parametersOf("_FactoryId_") }
+    }   
+){
+    modules(myModules)
 }
 ```
 

--- a/koin-projects/docs/reference/koin-test/checkmodules_plugin.md
+++ b/koin-projects/docs/reference/koin-test/checkmodules_plugin.md
@@ -20,9 +20,9 @@ buildscript {
 apply plugin: 'koin'
 ```
 
-### The JUnit CheckModules test
+### Checking your modules
 
-You need to add a JUnit catgeory to let us run your checkModules tests: `@Category(CheckModuleTest::class)`
+You need to add a JUnit category to let us run your checkModules tests: `@Category(CheckModuleTest::class)`
 
 Each of the module test will use the `checkModules` API to check the module:
 
@@ -36,6 +36,70 @@ class CheckModulesTest : KoinTest {
     }
 }
 ```
+
+#### Verifying graph with injected parameters [since 2.2.0]
+
+For any definition that is using injected parameters, the `checkModules` function provide default values or even mock object to help verify your definition:
+
+In the module below, Koin will verify your graph by passing a mock of `a : Simple.ComponentA` and a default value for `id : String`. 
+
+```kotlin
+module {
+    single { (a: Simple.ComponentA) -> Simple.ComponentB(a) }
+    factory { (id: String) -> FactoryPresenter(id) }
+}
+```
+
+#### Default values [since 2.2.0]
+
+If you need, you can set a default value for all type in the checked modules. For example, We can override all injected string values:
+
+Let's use the `defaultValues()` function, to define a default value for all definitions:
+
+```kotlin
+@Category(CheckModuleTest::class)
+class CheckModulesTest : KoinTest {
+
+    @Test
+    fun checkAllModules() = checkModules(
+        parameters = {
+            defaultValues<String>("_ID_")
+        }   
+    ){
+        modules(myModules)
+    }
+}
+```
+
+All injected definition that are using a injected `String` parameter, will receive `"_ID_"`:
+
+```kotlin
+module {
+    single { (i: String) -> Simple.ComponentC(i) }
+    factory { (id: String) -> FactoryPresenter(id) }
+}
+```
+
+#### Parameter creator
+
+You can define default value to be injected for one specific definition, with `create` function:
+
+```kotlin
+@Category(CheckModuleTest::class)
+class CheckModulesTest : KoinTest {
+
+    @Test
+    fun checkAllModules() = checkModules(
+        parameters = {
+            create<FactoryPresenter> { parametersOf("_FactoryId_") }
+        }   
+    ){
+        modules(myModules)
+    }
+}
+```
+
+### Checking injected parameters definitions
 
 ### Verify your modules (Kotlin project) - checkModules task
 

--- a/koin-projects/docs/reference/koin-test/testing.md
+++ b/koin-projects/docs/reference/koin-test/testing.md
@@ -70,7 +70,7 @@ Create mocks using MockK:
 @get:Rule
 val mockProvider = MockProviderRule.create { clazz ->
     // Your way to build a Mock here
-    mockkClass(clazz.java.kotlin)
+    mockkClass(clazz)
 }
 ```
 

--- a/koin-projects/examples/android-samples/build.gradle
+++ b/koin-projects/examples/android-samples/build.gradle
@@ -35,7 +35,7 @@ dependencies {
 
     testImplementation project(":koin-test")
 
-    testImplementation 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.13'
     testImplementation "androidx.test:core:1.1.1"
     testImplementation "androidx.test.ext:junit:1.1.1"
     testImplementation "org.robolectric:robolectric:4.2.1"

--- a/koin-projects/examples/android-samples/build.gradle
+++ b/koin-projects/examples/android-samples/build.gradle
@@ -42,5 +42,5 @@ dependencies {
     androidTestImplementation 'androidx.test:runner:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
 
-    testImplementation "org.mockito:mockito-inline:$mockito_version"
+    testImplementation "io.mockk:mockk:$mockk_version"
 }

--- a/koin-projects/examples/android-samples/build.gradle
+++ b/koin-projects/examples/android-samples/build.gradle
@@ -41,4 +41,6 @@ dependencies {
     testImplementation "org.robolectric:robolectric:4.2.1"
     androidTestImplementation 'androidx.test:runner:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
+
+    testImplementation "org.mockito:mockito-inline:$mockito_version"
 }

--- a/koin-projects/examples/android-samples/build.gradle
+++ b/koin-projects/examples/android-samples/build.gradle
@@ -33,4 +33,12 @@ dependencies {
     implementation "android.arch.lifecycle:extensions:$android_arch_version"
     implementation "org.jetbrains.anko:anko-commons:$anko_version"
 
+    testImplementation project(":koin-test")
+
+    testImplementation 'junit:junit:4.12'
+    testImplementation "androidx.test:core:1.1.1"
+    testImplementation "androidx.test.ext:junit:1.1.1"
+    testImplementation "org.robolectric:robolectric:4.2.1"
+    androidTestImplementation 'androidx.test:runner:1.1.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
 }

--- a/koin-projects/examples/android-samples/src/main/java/org/koin/sample/android/MainApplication.kt
+++ b/koin-projects/examples/android-samples/src/main/java/org/koin/sample/android/MainApplication.kt
@@ -17,7 +17,7 @@ class MainApplication : Application() {
             androidLogger(Level.DEBUG)
             androidContext(this@MainApplication)
             androidFileProperties()
-            modules(appModule + mvpModule + mvvmModule + scopeModule + dynamicModule + javaModule)
+            modules(allModules)
         }
     }
 }

--- a/koin-projects/examples/android-samples/src/main/java/org/koin/sample/android/di/AppModule.kt
+++ b/koin-projects/examples/android-samples/src/main/java/org/koin/sample/android/di/AppModule.kt
@@ -83,3 +83,5 @@ val javaModule = module {
         viewModel { CompatSimpleViewModel(get()) }
     }
 }
+
+val allModules = appModule + mvpModule + mvvmModule + scopeModule + dynamicModule + javaModule

--- a/koin-projects/examples/android-samples/src/test/java/CheckModulesTest.kt
+++ b/koin-projects/examples/android-samples/src/test/java/CheckModulesTest.kt
@@ -1,12 +1,20 @@
+import org.junit.Rule
 import org.junit.Test
 import org.junit.experimental.categories.Category
 import org.koin.core.logger.Level
 import org.koin.sample.android.di.allModules
 import org.koin.test.category.CheckModuleTest
 import org.koin.test.check.checkModules
+import org.koin.test.mock.MockProviderRule
+import org.mockito.Mockito
 
 @Category(CheckModuleTest::class)
 class CheckModulesTest {
+
+    @get:Rule
+    val mockProvider = MockProviderRule.create { clazz ->
+        Mockito.mock(clazz.java)
+    }
 
     @Test
     fun `test DI modules`() =

--- a/koin-projects/examples/android-samples/src/test/java/CheckModulesTest.kt
+++ b/koin-projects/examples/android-samples/src/test/java/CheckModulesTest.kt
@@ -1,3 +1,4 @@
+import io.mockk.mockkClass
 import org.junit.Rule
 import org.junit.Test
 import org.junit.experimental.categories.Category
@@ -6,14 +7,13 @@ import org.koin.sample.android.di.allModules
 import org.koin.test.category.CheckModuleTest
 import org.koin.test.check.checkModules
 import org.koin.test.mock.MockProviderRule
-import org.mockito.Mockito
 
 @Category(CheckModuleTest::class)
 class CheckModulesTest {
 
     @get:Rule
     val mockProvider = MockProviderRule.create { clazz ->
-        Mockito.mock(clazz.java)
+        mockkClass(clazz)
     }
 
     @Test

--- a/koin-projects/examples/android-samples/src/test/java/CheckModulesTest.kt
+++ b/koin-projects/examples/android-samples/src/test/java/CheckModulesTest.kt
@@ -1,12 +1,9 @@
-import android.app.Activity
 import org.junit.Test
 import org.junit.experimental.categories.Category
 import org.koin.core.logger.Level
-import org.koin.dsl.module
-import org.koin.sample.androidx.di.allModules
+import org.koin.sample.android.di.allModules
 import org.koin.test.category.CheckModuleTest
 import org.koin.test.check.checkModules
-import org.mockito.Mockito
 
 @Category(CheckModuleTest::class)
 class CheckModulesTest {

--- a/koin-projects/examples/androidx-samples/build.gradle
+++ b/koin-projects/examples/androidx-samples/build.gradle
@@ -63,4 +63,6 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-viewmodel-savedstate:$androidx_savedstate"
     implementation "org.jetbrains.anko:anko-commons:$anko_version"
 
+    testImplementation "org.mockito:mockito-inline:$mockito_version"
+
 }

--- a/koin-projects/examples/androidx-samples/src/main/java/org/koin/sample/androidx/components/scope/Session.kt
+++ b/koin-projects/examples/androidx-samples/src/main/java/org/koin/sample/androidx/components/scope/Session.kt
@@ -1,7 +1,7 @@
 package org.koin.sample.androidx.components.scope
 
 import org.koin.sample.androidx.scope.ScopedActivityA
-import java.util.*
+import java.util.UUID
 
 data class Session(var id: String = UUID.randomUUID().toString())
 

--- a/koin-projects/examples/androidx-samples/src/main/java/org/koin/sample/androidx/components/scope/Session.kt
+++ b/koin-projects/examples/androidx-samples/src/main/java/org/koin/sample/androidx/components/scope/Session.kt
@@ -1,8 +1,8 @@
 package org.koin.sample.androidx.components.scope
 
-import android.app.Activity
-import java.util.UUID
+import org.koin.sample.androidx.scope.ScopedActivityA
+import java.util.*
 
 data class Session(var id: String = UUID.randomUUID().toString())
 
-data class SessionActivity(val activity: Activity, val id: String = UUID.randomUUID().toString())
+data class SessionActivity(val activity: ScopedActivityA, val id: String = UUID.randomUUID().toString())

--- a/koin-projects/examples/androidx-samples/src/test/java/CheckModulesTest.kt
+++ b/koin-projects/examples/androidx-samples/src/test/java/CheckModulesTest.kt
@@ -1,4 +1,5 @@
 import android.app.Activity
+import org.junit.Rule
 import org.junit.Test
 import org.junit.experimental.categories.Category
 import org.koin.core.logger.Level
@@ -6,10 +7,16 @@ import org.koin.dsl.module
 import org.koin.sample.androidx.di.allModules
 import org.koin.test.category.CheckModuleTest
 import org.koin.test.check.checkModules
+import org.koin.test.mock.MockProviderRule
 import org.mockito.Mockito
 
 @Category(CheckModuleTest::class)
 class CheckModulesTest {
+
+    @get:Rule
+    val mockProvider = MockProviderRule.create { clazz ->
+        Mockito.mock(clazz.java)
+    }
 
     @Test
     fun `test DI modules`() =

--- a/koin-projects/examples/coffee-maker/src/test/kotlin/org/koin/example/CheckCoffeeModuleTest.kt
+++ b/koin-projects/examples/coffee-maker/src/test/kotlin/org/koin/example/CheckCoffeeModuleTest.kt
@@ -6,7 +6,7 @@ import org.koin.test.category.CheckModuleTest
 import org.koin.test.check.checkModules
 
 @Category(CheckModuleTest::class)
-class CheckCoffeeModuleTest {
+class CheckCoffeeModuleTest : MockitoTest() {
 
     @Test
     fun checkCoffeeModule() =

--- a/koin-projects/gradle/versions.gradle
+++ b/koin-projects/gradle/versions.gradle
@@ -18,6 +18,7 @@ ext {
     // Test
     junit_version = "4.12"
     mockito_version = "2.21.0"
+    mockk_version = "1.10.0"
 
     asciidoctor_version = "1.5.3"
     asciidoctor_pdf_version = "1.5.0-alpha.15"

--- a/koin-projects/koin-core/src/main/kotlin/org/koin/core/Koin.kt
+++ b/koin-projects/koin-core/src/main/kotlin/org/koin/core/Koin.kt
@@ -122,9 +122,9 @@ class Koin {
      * @return instance of type T or null
      */
     fun <T> getOrNull(
-            clazz: KClass<*>,
-            qualifier: Qualifier? = null,
-            parameters: ParametersDefinition? = null
+        clazz: KClass<*>,
+        qualifier: Qualifier? = null,
+        parameters: ParametersDefinition? = null
     ): T? = _scopeRegistry.rootScope.getOrNull(clazz, qualifier, parameters)
 
 
@@ -228,9 +228,10 @@ class Koin {
      * Get or Create a Scope instance
      * @param scopeId
      * @param qualifier
+     * @param source
      */
-    fun getOrCreateScope(scopeId: ScopeID, qualifier: Qualifier): Scope {
-        return _scopeRegistry.getScopeOrNull(scopeId) ?: createScope(scopeId, qualifier)
+    fun getOrCreateScope(scopeId: ScopeID, qualifier: Qualifier, source: Any? = null): Scope {
+        return _scopeRegistry.getScopeOrNull(scopeId) ?: createScope(scopeId, qualifier, source)
     }
 
     /**

--- a/koin-projects/koin-core/src/main/kotlin/org/koin/core/parameter/DefinitionParameters.kt
+++ b/koin-projects/koin-core/src/main/kotlin/org/koin/core/parameter/DefinitionParameters.kt
@@ -18,6 +18,8 @@ package org.koin.core.parameter
 import org.koin.core.error.DefinitionParameterException
 import org.koin.core.error.NoParameterFoundException
 import org.koin.core.parameter.DefinitionParameters.Companion.MAX_PARAMS
+import org.koin.ext.getFullName
+import kotlin.reflect.KClass
 
 /**
  * DefinitionParameters - Parameter holder
@@ -26,16 +28,17 @@ import org.koin.core.parameter.DefinitionParameters.Companion.MAX_PARAMS
  * @author - Arnaud GIULIANI
  */
 @Suppress("UNCHECKED_CAST")
-class DefinitionParameters internal constructor(vararg val values: Any?) {
+open class DefinitionParameters(vararg val values: Any?) {
 
-    private fun <T> elementAt(i: Int): T =
-        if (values.size > i) values[i] as T else throw NoParameterFoundException("Can't get parameter value #$i from $this")
+    open fun <T> elementAt(i: Int, clazz: KClass<*>): T =
+        if (values.size > i) values[i] as T else throw NoParameterFoundException(
+            "Can't get injected parameter #$i from $this for type '${clazz.getFullName()}'")
 
-    operator fun <T> component1(): T = elementAt(0)
-    operator fun <T> component2(): T = elementAt(1)
-    operator fun <T> component3(): T = elementAt(2)
-    operator fun <T> component4(): T = elementAt(3)
-    operator fun <T> component5(): T = elementAt(4)
+    inline operator fun <reified T> component1(): T = elementAt(0, T::class)
+    inline operator fun <reified T> component2(): T = elementAt(1, T::class)
+    inline operator fun <reified T> component3(): T = elementAt(2, T::class)
+    inline operator fun <reified T> component4(): T = elementAt(3, T::class)
+    inline operator fun <reified T> component5(): T = elementAt(4, T::class)
 
     /**
      * get element at given index
@@ -43,7 +46,7 @@ class DefinitionParameters internal constructor(vararg val values: Any?) {
      */
     operator fun <T> get(i: Int) = values[i] as T
 
-    fun <T> set(i: Int,t : T) {
+    fun <T> set(i: Int, t: T) {
         values.toMutableList()[i] = t
     }
 
@@ -71,6 +74,8 @@ class DefinitionParameters internal constructor(vararg val values: Any?) {
     companion object {
         const val MAX_PARAMS = 5
     }
+
+    override fun toString(): String = "DefinitionParameters${values.toList()}"
 }
 
 /**
@@ -80,12 +85,14 @@ class DefinitionParameters internal constructor(vararg val values: Any?) {
  * return ParameterList
  */
 fun parametersOf(vararg parameters: Any?) =
-    if (parameters.size <= MAX_PARAMS) DefinitionParameters(*parameters) else throw DefinitionParameterException("Can't build DefinitionParameters for more than $MAX_PARAMS arguments")
+    if (parameters.size <= MAX_PARAMS) DefinitionParameters(*parameters) else throw DefinitionParameterException(
+        "Can't build DefinitionParameters for more than $MAX_PARAMS arguments")
 
 /**
  *
  */
 fun emptyParametersHolder() = DefinitionParameters()
+
 
 /**
  * Help define a DefinitionParameters

--- a/koin-projects/koin-core/src/main/kotlin/org/koin/core/scope/Scope.kt
+++ b/koin-projects/koin-core/src/main/kotlin/org/koin/core/scope/Scope.kt
@@ -151,7 +151,7 @@ data class Scope(
         return try {
             get(clazz, qualifier, parameters)
         } catch (e: Exception) {
-            _koin._logger.error("Can't get instance for ${clazz.getFullName()}")
+            _koin._logger.debug("Koin.getOrNull - no instance found for ${clazz.getFullName()}")
             null
         }
     }
@@ -229,9 +229,9 @@ data class Scope(
         var instance: T? = null
         for (scope in _linkedScope) {
             instance = scope.getOrNull<T>(
-                    clazz,
-                    qualifier,
-                    parameters
+                clazz,
+                qualifier,
+                parameters
             )
             if (instance != null) break
         }

--- a/koin-projects/koin-test/build.gradle
+++ b/koin-projects/koin-test/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     // Koin
     compile project(":koin-core")
     compile "junit:junit:$junit_version"
-    compile "org.mockito:mockito-inline:$mockito_version"
+    testCompile "org.mockito:mockito-inline:$mockito_version"
 }
 
 apply from: '../gradle/publish.gradle'

--- a/koin-projects/koin-test/build.gradle
+++ b/koin-projects/koin-test/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     // Koin
     compile project(":koin-core")
     compile "junit:junit:$junit_version"
-    testImplementation "org.mockito:mockito-inline:$mockito_version"
+    compile "org.mockito:mockito-inline:$mockito_version"
 }
 
 apply from: '../gradle/publish.gradle'

--- a/koin-projects/koin-test/src/main/kotlin/org/koin/test/check/CheckModules.kt
+++ b/koin-projects/koin-test/src/main/kotlin/org/koin/test/check/CheckModules.kt
@@ -58,13 +58,13 @@ fun Koin.checkModules(parametersDefinition: CheckParameters? = null) {
 
 private fun Koin.declareParameterCreators(
     parametersDefinition: CheckParameters?
-): MutableMap<CheckedComponent, ParametersCreator> {
+): ParametersBinding {
     val bindings = ParametersBinding(this)
     parametersDefinition?.let { bindings.parametersDefinition() }
-    return bindings.parametersCreators
+    return bindings
 }
 
-private fun Koin.checkScopedDefinitions(allParameters: MutableMap<CheckedComponent, ParametersCreator>) {
+private fun Koin.checkScopedDefinitions(allParameters: ParametersBinding) {
     _scopeRegistry.scopeDefinitions.values.forEach { scopeDefinition ->
         checkScope(scopeDefinition, allParameters)
     }
@@ -72,7 +72,7 @@ private fun Koin.checkScopedDefinitions(allParameters: MutableMap<CheckedCompone
 
 private fun Koin.checkScope(
     scopeDefinition: ScopeDefinition,
-    allParameters: MutableMap<CheckedComponent, ParametersCreator>
+    allParameters: ParametersBinding
 ) {
     val qualifier = scopeDefinition.qualifier
     val sourceScopeValue = mockSourceValue(qualifier)
@@ -89,12 +89,13 @@ private fun mockSourceValue(qualifier: Qualifier): Any? {
 }
 
 private fun checkDefinition(
-    allParameters: MutableMap<CheckedComponent, ParametersCreator>,
+    allParameters: ParametersBinding,
     definition: BeanDefinition<*>,
     scope: Scope
 ) {
-    val parameters = allParameters[CheckedComponent(definition.qualifier, definition.primaryType)]?.invoke(
+    val parameters = allParameters.parametersCreators[CheckedComponent(definition.qualifier,
+        definition.primaryType)]?.invoke(
         definition.qualifier)
-        ?: MockParameter(scope) //TODO add default param check here
+        ?: MockParameter(scope, allParameters.defaultValues) //TODO add default param check here
     scope.get<Any>(definition.primaryType, definition.qualifier) { parameters }
 }

--- a/koin-projects/koin-test/src/main/kotlin/org/koin/test/check/CheckModules.kt
+++ b/koin-projects/koin-test/src/main/kotlin/org/koin/test/check/CheckModules.kt
@@ -26,8 +26,8 @@ import org.koin.core.scope.Scope
 import org.koin.core.scope.ScopeDefinition
 import org.koin.dsl.KoinAppDeclaration
 import org.koin.dsl.koinApplication
+import org.koin.test.mock.MockProvider
 import org.koin.test.parameter.MockParameter
-import org.mockito.Mockito
 
 /**
  * Check all definition's dependencies - start all modules and check if definitions can run
@@ -82,7 +82,7 @@ private fun Koin.checkScope(
 
 private fun mockSourceValue(qualifier: Qualifier): Any? {
     return if (qualifier is TypeQualifier) {
-        Mockito.mock(qualifier.type.java)
+        MockProvider.makeMock(qualifier.type)
     } else null
 }
 
@@ -94,6 +94,6 @@ private fun checkDefinition(
     val parameters = allParameters.parametersCreators[CheckedComponent(definition.qualifier,
         definition.primaryType)]?.invoke(
         definition.qualifier)
-        ?: MockParameter(scope, allParameters.defaultValues) //TODO add default param check here
+        ?: MockParameter(scope, allParameters.defaultValues)
     scope.get<Any>(definition.primaryType, definition.qualifier) { parameters }
 }

--- a/koin-projects/koin-test/src/main/kotlin/org/koin/test/check/CheckModules.kt
+++ b/koin-projects/koin-test/src/main/kotlin/org/koin/test/check/CheckModules.kt
@@ -58,9 +58,8 @@ fun Koin.checkModules(parametersDefinition: CheckParameters? = null) {
 
 private fun Koin.declareParameterCreators(
     parametersDefinition: CheckParameters?
-) = ParametersBinding(this).also { binding -> 
-    parametersDefinition?.invoke(binding) 
-}
+) = ParametersBinding(this).also { binding ->
+    parametersDefinition?.invoke(binding)
 }
 
 private fun Koin.checkScopedDefinitions(allParameters: ParametersBinding) {

--- a/koin-projects/koin-test/src/main/kotlin/org/koin/test/check/CheckModules.kt
+++ b/koin-projects/koin-test/src/main/kotlin/org/koin/test/check/CheckModules.kt
@@ -58,10 +58,9 @@ fun Koin.checkModules(parametersDefinition: CheckParameters? = null) {
 
 private fun Koin.declareParameterCreators(
     parametersDefinition: CheckParameters?
-): ParametersBinding {
-    val bindings = ParametersBinding(this)
-    parametersDefinition?.let { bindings.parametersDefinition() }
-    return bindings
+) = ParametersBinding(this).also { binding -> 
+    parametersDefinition?.invoke(binding) 
+}
 }
 
 private fun Koin.checkScopedDefinitions(allParameters: ParametersBinding) {

--- a/koin-projects/koin-test/src/main/kotlin/org/koin/test/check/CheckModulesDSL.kt
+++ b/koin-projects/koin-test/src/main/kotlin/org/koin/test/check/CheckModulesDSL.kt
@@ -22,11 +22,12 @@ import kotlin.reflect.KClass
 
 data class CheckedComponent(val qualifier: Qualifier? = null, val type: KClass<*>)
 
-class ParametersBinding {
-    val creators = mutableMapOf<CheckedComponent, ParametersCreator>()
-    lateinit var koin: Koin
+class ParametersBinding(val koin: Koin) {
+
+    val parametersCreators = mutableMapOf<CheckedComponent, ParametersCreator>()
+
     inline fun <reified T> create(qualifier: Qualifier? = null, noinline creator: ParametersCreator) =
-            creators.put(CheckedComponent(qualifier, T::class), creator)
+        parametersCreators.put(CheckedComponent(qualifier, T::class), creator)
 }
 
 typealias ParametersCreator = (Qualifier?) -> DefinitionParameters

--- a/koin-projects/koin-test/src/main/kotlin/org/koin/test/check/CheckModulesDSL.kt
+++ b/koin-projects/koin-test/src/main/kotlin/org/koin/test/check/CheckModulesDSL.kt
@@ -25,9 +25,12 @@ data class CheckedComponent(val qualifier: Qualifier? = null, val type: KClass<*
 class ParametersBinding(val koin: Koin) {
 
     val parametersCreators = mutableMapOf<CheckedComponent, ParametersCreator>()
+    val defaultValues = mutableMapOf<String, Any>()
 
     inline fun <reified T> create(qualifier: Qualifier? = null, noinline creator: ParametersCreator) =
         parametersCreators.put(CheckedComponent(qualifier, T::class), creator)
+
+    inline fun <reified T : Any> defaultValue(t: T) = defaultValues.put(T::class.java.simpleName, t)
 }
 
 typealias ParametersCreator = (Qualifier?) -> DefinitionParameters

--- a/koin-projects/koin-test/src/main/kotlin/org/koin/test/mock/MockProvider.kt
+++ b/koin-projects/koin-test/src/main/kotlin/org/koin/test/mock/MockProvider.kt
@@ -7,15 +7,20 @@ object MockProvider {
     val provider: Provider<*>
         get() {
             return _provider
-                    ?: error("Missing MockProvider. Please use MockProvider.register() to register a new mock provider")
+                ?: error("Missing MockProvider. Please use MockProvider.register() to register a new mock provider")
         }
 
     fun register(provider: Provider<*>) {
         _provider = provider
     }
 
-    inline fun <reified T> makeMock(): T {
+    inline fun <reified T : Any> makeMock(): T {
         return provider.invoke(T::class) as T
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    fun <T : Any> makeMock(kClass: KClass<T>): T {
+        return provider.invoke(kClass) as T
     }
 }
 

--- a/koin-projects/koin-test/src/main/kotlin/org/koin/test/parameter/MockParameter.kt
+++ b/koin-projects/koin-test/src/main/kotlin/org/koin/test/parameter/MockParameter.kt
@@ -2,9 +2,10 @@ package org.koin.test.parameter
 
 import org.koin.core.parameter.DefinitionParameters
 import org.koin.core.scope.Scope
-import org.mockito.Mockito
+import org.koin.test.mock.MockProvider
 import kotlin.reflect.KClass
 
+@Suppress("UNCHECKED_CAST")
 class MockParameter(
     private val scope: Scope,
     private val defaultValues: MutableMap<String, Any>
@@ -16,7 +17,7 @@ class MockParameter(
             Double::class.java.simpleName -> 0.0 as T
             Float::class.java.simpleName -> 0.0f as T
             else -> {
-                (scope.getOrNull<T?>(clazz = clazz) ?: Mockito.mock(clazz.java)) as T
+                (scope.getOrNull<T?>(clazz = clazz) ?: MockProvider.makeMock(clazz)) as T
             }
         }
     }

--- a/koin-projects/koin-test/src/main/kotlin/org/koin/test/parameter/MockParameter.kt
+++ b/koin-projects/koin-test/src/main/kotlin/org/koin/test/parameter/MockParameter.kt
@@ -1,0 +1,21 @@
+package org.koin.test.parameter
+
+import org.koin.core.parameter.DefinitionParameters
+import org.koin.core.scope.Scope
+import org.mockito.Mockito
+import kotlin.reflect.KClass
+
+class MockParameter(val scope: Scope) : DefinitionParameters(null) {
+    override fun <T> elementAt(i: Int, clazz: KClass<*>): T {
+        return when (clazz.simpleName) {
+            String::class.java.simpleName -> "" as T
+            Int::class.java.simpleName -> 0 as T
+            Double::class.java.simpleName -> 0.0 as T
+            Float::class.java.simpleName -> 0.0f as T
+            else -> {
+                val found = try { scope.getOrNull<T?>(clazz = clazz) } catch (e: Exception) { }
+                (found ?: Mockito.mock(clazz.java)) as T
+            }
+        }
+    }
+}

--- a/koin-projects/koin-test/src/main/kotlin/org/koin/test/parameter/MockParameter.kt
+++ b/koin-projects/koin-test/src/main/kotlin/org/koin/test/parameter/MockParameter.kt
@@ -16,12 +16,7 @@ class MockParameter(
             Double::class.java.simpleName -> 0.0 as T
             Float::class.java.simpleName -> 0.0f as T
             else -> {
-                val found = try {
-                    scope.getOrNull<T?>(clazz = clazz)
-                } catch (e: Exception) {
-                    // not found
-                }
-                (found ?: Mockito.mock(clazz.java)) as T
+                (scope.getOrNull<T?>(clazz = clazz) ?: Mockito.mock(clazz.java)) as T
             }
         }
     }

--- a/koin-projects/koin-test/src/main/kotlin/org/koin/test/parameter/MockParameter.kt
+++ b/koin-projects/koin-test/src/main/kotlin/org/koin/test/parameter/MockParameter.kt
@@ -5,15 +5,22 @@ import org.koin.core.scope.Scope
 import org.mockito.Mockito
 import kotlin.reflect.KClass
 
-class MockParameter(val scope: Scope) : DefinitionParameters(null) {
+class MockParameter(
+    private val scope: Scope,
+    private val defaultValues: MutableMap<String, Any>
+) : DefinitionParameters(null) {
     override fun <T> elementAt(i: Int, clazz: KClass<*>): T {
-        return when (clazz.simpleName) {
+        return defaultValues[clazz.simpleName] as? T ?: when (clazz.simpleName) {
             String::class.java.simpleName -> "" as T
             Int::class.java.simpleName -> 0 as T
             Double::class.java.simpleName -> 0.0 as T
             Float::class.java.simpleName -> 0.0f as T
             else -> {
-                val found = try { scope.getOrNull<T?>(clazz = clazz) } catch (e: Exception) { }
+                val found = try {
+                    scope.getOrNull<T?>(clazz = clazz)
+                } catch (e: Exception) {
+                    // not found
+                }
                 (found ?: Mockito.mock(clazz.java)) as T
             }
         }

--- a/koin-projects/koin-test/src/test/kotlin/org/koin/test/CheckModulesTest.kt
+++ b/koin-projects/koin-test/src/test/kotlin/org/koin/test/CheckModulesTest.kt
@@ -17,12 +17,12 @@ class CheckModulesTest {
         koinApplication {
             printLogger(Level.DEBUG)
             modules(
-                    module {
-                        scope(named("scope")) {
-                            scoped { Simple.ComponentA() }
-                            scoped { Simple.ComponentB(get()) }
-                        }
+                module {
+                    scope(named("scope")) {
+                        scoped { Simple.ComponentA() }
+                        scoped { Simple.ComponentB(get()) }
                     }
+                }
             )
         }.checkModules()
     }
@@ -33,12 +33,12 @@ class CheckModulesTest {
             koinApplication {
                 printLogger(Level.DEBUG)
                 modules(
-                        module {
-                            single { Simple.ComponentB(get()) }
-                            scope(named("scope")) {
-                                scoped { Simple.ComponentA() }
-                            }
+                    module {
+                        single { Simple.ComponentB(get()) }
+                        scope(named("scope")) {
+                            scoped { Simple.ComponentA() }
                         }
+                    }
                 )
             }.checkModules()
             fail()
@@ -53,14 +53,14 @@ class CheckModulesTest {
             koinApplication {
                 printLogger(Level.DEBUG)
                 modules(
-                        module {
-                            scope(named("scope2")) {
-                                scoped { Simple.ComponentB(get()) }
-                            }
-                            scope(named("scope1")) {
-                                scoped { Simple.ComponentA() }
-                            }
+                    module {
+                        scope(named("scope2")) {
+                            scoped { Simple.ComponentB(get()) }
                         }
+                        scope(named("scope1")) {
+                            scoped { Simple.ComponentA() }
+                        }
+                    }
                 )
             }.checkModules()
             fail()
@@ -74,17 +74,17 @@ class CheckModulesTest {
         koinApplication {
             printLogger(Level.DEBUG)
             modules(
-                    module {
-                        scope(named("scope2")) {
-                            scoped {
-                                val a = getScope("scopei1").get<Simple.ComponentA>()
-                                Simple.ComponentB(a)
-                            }
-                        }
-                        scope(named("scope1")) {
-                            scoped { Simple.ComponentA() }
+                module {
+                    scope(named("scope2")) {
+                        scoped {
+                            val a = getScope("scopei1").get<Simple.ComponentA>()
+                            Simple.ComponentB(a)
                         }
                     }
+                    scope(named("scope1")) {
+                        scoped { Simple.ComponentA() }
+                    }
+                }
             )
         }.checkModules {
             koin.createScope("scopei1", named("scope1"))
@@ -96,14 +96,14 @@ class CheckModulesTest {
         koinApplication {
             printLogger(Level.DEBUG)
             modules(
-                    module {
-                        scope(named("scope2")) {
-                            scoped { (scope1: Scope) -> Simple.ComponentB(scope1.get()) }
-                        }
-                        scope(named("scope1")) {
-                            scoped { Simple.ComponentA() }
-                        }
+                module {
+                    scope(named("scope2")) {
+                        scoped { (scope1: Scope) -> Simple.ComponentB(scope1.get()) }
                     }
+                    scope(named("scope1")) {
+                        scoped { Simple.ComponentA() }
+                    }
+                }
             )
         }.checkModules {
             create<Simple.ComponentB> { parametersOf(koin.createScope("scopei1", named("scope1"))) }
@@ -115,9 +115,9 @@ class CheckModulesTest {
         koinApplication {
             printLogger(Level.DEBUG)
             modules(
-                    module {
-                        single { Simple.ComponentA() }
-                    }
+                module {
+                    single { Simple.ComponentA() }
+                }
             )
         }.checkModules()
     }
@@ -127,10 +127,10 @@ class CheckModulesTest {
         koinApplication {
             printLogger(Level.DEBUG)
             modules(
-                    module {
-                        single { Simple.ComponentA() }
-                        single { Simple.ComponentB(get()) }
-                    }
+                module {
+                    single { Simple.ComponentA() }
+                    single { Simple.ComponentB(get()) }
+                }
             )
         }.checkModules()
     }
@@ -141,9 +141,9 @@ class CheckModulesTest {
             koinApplication {
                 printLogger(Level.DEBUG)
                 modules(
-                        module {
-                            single { Simple.ComponentB(get()) }
-                        }
+                    module {
+                        single { Simple.ComponentB(get()) }
+                    }
                 )
             }.checkModules()
             fail("should not pass with borken definitions")
@@ -157,14 +157,59 @@ class CheckModulesTest {
         koinApplication {
             printLogger(Level.DEBUG)
             modules(
-                    module {
-                        single { (s: String) -> Simple.MyString(s) }
-                        single(UpperCase) { (s: String) -> Simple.MyString(s.toUpperCase()) }
-                    }
+                module {
+                    single { (s: String) -> Simple.MyString(s) }
+                    single(UpperCase) { (s: String) -> Simple.MyString(s.toUpperCase()) }
+                }
             )
         }.checkModules {
             create<Simple.MyString> { parametersOf("param") }
             create<Simple.MyString>(UpperCase) { qualifier -> parametersOf(qualifier.toString()) }
+        }
+    }
+
+    @Test
+    fun `check a module with params - auto`() {
+        koinApplication {
+            printLogger(Level.DEBUG)
+            modules(
+                module {
+                    single { (s: String) -> Simple.MyString(s) }
+                    single { (a: Simple.ComponentA) -> Simple.ComponentB(a) }
+                }
+            )
+        }.checkModules()
+    }
+
+    @Test
+    fun `check a module with params - auto scope`() {
+        koinApplication {
+            printLogger(Level.DEBUG)
+            modules(
+                module {
+                    scope<Simple.ComponentA> {
+                        scoped { Simple.ComponentB(get()) }
+                    }
+                }
+            )
+        }.checkModules()
+    }
+
+    @Test
+    fun `check a module with params - auto scope - error`() {
+        try {
+            koinApplication {
+                printLogger(Level.DEBUG)
+                modules(
+                    module {
+                        scope<Simple.ComponentA> {
+                            scoped { Simple.ComponentC(get()) }
+                        }
+                    }
+                )
+            }.checkModules()
+            fail()
+        } catch (e: Exception) {
         }
     }
 
@@ -184,9 +229,9 @@ class CheckModulesTest {
             printLogger(Level.DEBUG)
             properties(hashMapOf("aValue" to "value"))
             modules(
-                    module {
-                        single { Simple.MyString(getProperty("aValue")) }
-                    }
+                module {
+                    single { Simple.MyString(getProperty("aValue")) }
+                }
             )
         }.checkModules()
     }

--- a/koin-projects/koin-test/src/test/kotlin/org/koin/test/CheckModulesTest.kt
+++ b/koin-projects/koin-test/src/test/kotlin/org/koin/test/CheckModulesTest.kt
@@ -182,6 +182,48 @@ class CheckModulesTest {
     }
 
     @Test
+    fun `check a module with params - default value`() {
+        val id = "_ID_"
+        var injectedValue: String? = null
+        koinApplication {
+            printLogger(Level.DEBUG)
+            modules(
+                module {
+                    single { (s: String) ->
+                        injectedValue = s
+                        Simple.MyString(s)
+                    }
+                }
+            )
+        }.checkModules {
+            defaultValue(id)
+        }
+
+        assert(injectedValue == id)
+    }
+
+    @Test
+    fun `check a module with params - default value object`() {
+        val a = Simple.ComponentA()
+        var injectedValue: Simple.ComponentA? = null
+        koinApplication {
+            printLogger(Level.DEBUG)
+            modules(
+                module {
+                    single { (a: Simple.ComponentA) ->
+                        injectedValue = a
+                        Simple.ComponentB(a)
+                    }
+                }
+            )
+        }.checkModules {
+            defaultValue(a)
+        }
+
+        assert(injectedValue == a)
+    }
+
+    @Test
     fun `check a module with params - auto scope`() {
         koinApplication {
             printLogger(Level.DEBUG)

--- a/koin-projects/koin-test/src/test/kotlin/org/koin/test/CheckModulesTest.kt
+++ b/koin-projects/koin-test/src/test/kotlin/org/koin/test/CheckModulesTest.kt
@@ -1,6 +1,7 @@
 package org.koin.test
 
 import org.junit.Assert.fail
+import org.junit.Rule
 import org.junit.Test
 import org.koin.core.logger.Level
 import org.koin.core.parameter.parametersOf
@@ -9,8 +10,15 @@ import org.koin.core.scope.Scope
 import org.koin.dsl.koinApplication
 import org.koin.dsl.module
 import org.koin.test.check.checkModules
+import org.koin.test.mock.MockProviderRule
+import org.mockito.Mockito
 
 class CheckModulesTest {
+
+    @get:Rule
+    val mockProvider = MockProviderRule.create { clazz ->
+        Mockito.mock(clazz.java)
+    }
 
     @Test
     fun `check a scoped module`() {

--- a/koin-projects/koin-test/src/test/kotlin/org/koin/test/Components.kt
+++ b/koin-projects/koin-test/src/test/kotlin/org/koin/test/Components.kt
@@ -7,6 +7,7 @@ import java.util.*
 class Simple {
     class ComponentA
     class ComponentB(val a: ComponentA)
+    class ComponentC(val b: ComponentB)
     class MyString(val s: String)
 
     class UUIDComponent {


### PR DESCRIPTION
Hi all,

here is a PR to fix `checkModules` API with the following:

- bring default values and Mock to help verify injected parameters definition without having to define a `create` for each definition
- allow to inject default Scope instance origin value

This should clearly help `checkModules` experience, as you can mainly check your modules without much extra setup.

