### PR TITLE
Replace fragment extension

### DIFF
--- a/koin-projects/docs/reference/koin-android/fragment-factory.md
+++ b/koin-projects/docs/reference/koin-android/fragment-factory.md
@@ -65,10 +65,20 @@ And retrieve your `Fragment` with your `supportFragmentManager`:
 
 ```kotlin
 supportFragmentManager.beginTransaction()
-            .replace(R.id.mvvm_frame, MyFragment::class.java, null, null)
+            .replace<MyFragment>(R.id.mvvm_frame)
             .commit()
 ```
 
+Put your `bundle` or `tag` using the overloaded optional params:
+
+```kotlin
+supportFragmentManager.beginTransaction()
+            .replace<MyFragment>(
+                containerViewId = R.id.mvvm_frame,
+                args = MyBundle(),
+                tag = MyString()
+            )
+```
 
 ## Fragment Factory & Koin Scopes
 

--- a/koin-projects/examples/androidx-samples/src/main/java/org/koin/sample/androidx/mvvm/MVVMActivity.kt
+++ b/koin-projects/examples/androidx-samples/src/main/java/org/koin/sample/androidx/mvvm/MVVMActivity.kt
@@ -5,6 +5,7 @@ import androidx.appcompat.app.AppCompatActivity
 import kotlinx.android.synthetic.main.mvvm_activity.*
 import org.junit.Assert.*
 import org.koin.android.ext.android.getKoin
+import org.koin.androidx.fragment.android.replace
 import org.koin.androidx.fragment.android.setupKoinFragmentFactory
 import org.koin.androidx.scope.lifecycleScope
 import org.koin.androidx.viewmodel.ext.android.getViewModel
@@ -75,7 +76,7 @@ class MVVMActivity : AppCompatActivity() {
         assertEquals("value to lifecycleScope.stateViewModel", scopedSavedVm.handle.get("vm2"))
 
         supportFragmentManager.beginTransaction()
-            .replace(R.id.mvvm_frame, MVVMFragment::class.java, null, null)
+            .replace<MVVMFragment>(R.id.mvvm_frame)
             .commit()
 
         getKoin().setProperty("session_id", lifecycleScope.get<Session>().id)

--- a/koin-projects/koin-androidx-fragment/src/main/java/org/koin/androidx/fragment/android/ActivityExt.kt
+++ b/koin-projects/koin-androidx-fragment/src/main/java/org/koin/androidx/fragment/android/ActivityExt.kt
@@ -22,6 +22,7 @@ fun FragmentActivity.setupKoinFragmentFactory(scope: Scope? = null) {
 /**
  * Replace container
  *
+ * @param containerViewId
  * @param args
  * @param tag
  */

--- a/koin-projects/koin-androidx-fragment/src/main/java/org/koin/androidx/fragment/android/ActivityExt.kt
+++ b/koin-projects/koin-androidx-fragment/src/main/java/org/koin/androidx/fragment/android/ActivityExt.kt
@@ -1,6 +1,10 @@
 package org.koin.androidx.fragment.android
 
+import android.os.Bundle
+import androidx.annotation.LayoutRes
+import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
+import androidx.fragment.app.FragmentTransaction
 import org.koin.android.ext.android.get
 import org.koin.core.scope.Scope
 
@@ -13,4 +17,18 @@ fun FragmentActivity.setupKoinFragmentFactory(scope: Scope? = null) {
     } else {
         supportFragmentManager.fragmentFactory = KoinFragmentFactory(scope)
     }
+}
+
+/**
+ * Replace container
+ *
+ * @param args
+ * @param tag
+ */
+inline fun <reified F : Fragment> FragmentTransaction.replace(
+    @LayoutRes containerViewId: Int,
+    args: Bundle? = null,
+    tag: String? = null
+): FragmentTransaction {
+    return replace(containerViewId, F::class.java, args, tag)
 }

--- a/koin-projects/koin-androidx-fragment/src/main/java/org/koin/androidx/fragment/android/ActivityExt.kt
+++ b/koin-projects/koin-androidx-fragment/src/main/java/org/koin/androidx/fragment/android/ActivityExt.kt
@@ -1,7 +1,7 @@
 package org.koin.androidx.fragment.android
 
 import android.os.Bundle
-import androidx.annotation.LayoutRes
+import androidx.annotation.IdRes
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.FragmentTransaction
@@ -27,7 +27,7 @@ fun FragmentActivity.setupKoinFragmentFactory(scope: Scope? = null) {
  * @param tag
  */
 inline fun <reified F : Fragment> FragmentTransaction.replace(
-    @LayoutRes containerViewId: Int,
+    @IdRes containerViewId: Int,
     args: Bundle? = null,
     tag: String? = null
 ): FragmentTransaction {


### PR DESCRIPTION
A simple way to recover and instantiate fragment. :)

I create this extension to make a sugar declaration when we need create the fragment. With this form we can set the tag only with the alias in method.

Before:
```kotlin
supportFragmentManager.beginTransaction()
    .replace(R.id.mvvm_frame, MVVMFragment::class.java, null, null)
    .commit()
```

After:
```kotlin
supportFragmentManager.beginTransaction()
      .replace<MVVMFragment>(R.id.mvvm_frame)
      .commit()
```