### PR TITLE
Add new create method using KClass on check-dsl for test

### DIFF
--- a/koin-projects/docs/reference/koin-test/checkmodules_plugin.md
+++ b/koin-projects/docs/reference/koin-test/checkmodules_plugin.md
@@ -92,6 +92,8 @@ You can define default value to be injected for one specific definition, with `c
 fun checkAllModules() = checkModules(
     parameters = {
         create<FactoryPresenter> { parametersOf("_FactoryId_") }
+        // or
+        create(FactoryPresenter::class) { parametersOf("_FactoryId_") }
     }   
 ){
     modules(myModules)

--- a/koin-projects/koin-test-core/src/main/kotlin/org/koin/test/check/CheckModulesDSL.kt
+++ b/koin-projects/koin-test-core/src/main/kotlin/org/koin/test/check/CheckModulesDSL.kt
@@ -28,7 +28,10 @@ class ParametersBinding(val koin: Koin) {
     val defaultValues = mutableMapOf<String, Any>()
 
     inline fun <reified T> create(qualifier: Qualifier? = null, noinline creator: ParametersCreator) =
-        parametersCreators.put(CheckedComponent(qualifier, T::class), creator)
+            parametersCreators.put(CheckedComponent(qualifier, T::class), creator)
+
+    fun create(clazz: KClass<*>, qualifier: Qualifier? = null, creator: ParametersCreator) =
+            parametersCreators.put(CheckedComponent(qualifier, clazz), creator)
 
     inline fun <reified T : Any> defaultValue(t: T) = defaultValues.put(T::class.java.simpleName, t)
 }

--- a/koin-projects/koin-test/src/test/kotlin/org/koin/test/CheckModulesTest.kt
+++ b/koin-projects/koin-test/src/test/kotlin/org/koin/test/CheckModulesTest.kt
@@ -177,6 +177,24 @@ class CheckModulesTest {
     }
 
     @Test
+    fun `check a module with params using create method with KClass`() {
+        koinApplication {
+            printLogger(Level.DEBUG)
+            modules(
+                    module {
+                        single { (s: String) -> Simple.MyString(s) }
+                        single(UpperCase) { (s: String) -> Simple.MyString(s.toUpperCase()) }
+                    }
+            )
+        }.checkModules {
+            create(Simple.MyString::class) { parametersOf("param") }
+            create(Simple.MyString::class, UpperCase) { qualifier ->
+                parametersOf(qualifier.toString())
+            }
+        }
+    }
+
+    @Test
     fun `check a module with params - auto`() {
         koinApplication {
             printLogger(Level.DEBUG)


### PR DESCRIPTION
## Description
This PR add a new create method with KClass argument instead of reified T type. 
In some cases, using KClass instead of T type directly can enable us to omit implementations classes and expose only its KClass for configuration of parameters in tests.

### Current
```kotlin
		...
		.checkModules {
			// Depends directly of MyViewModel and `user` object
            create<MyViewModel> { parametersOf(user) }
        }
```

### Expected (using KClass)
Could be used "stubs" providing only KClass and DefinitionParameters
```kotlin
		...
		.checkModules {
            create(TestStubs.myViewModelKClass())) { TestStubs.myViewModelParameters() }
        }
```