### PR TITLE
Use contentLayoutId feature in ScopeActivity and ScopeFragment

### DIFF
--- a/koin-projects/examples/androidx-samples/src/main/java/org/koin/sample/androidx/mvp/MVPActivity.kt
+++ b/koin-projects/examples/androidx-samples/src/main/java/org/koin/sample/androidx/mvp/MVPActivity.kt
@@ -13,7 +13,7 @@ import org.koin.sample.androidx.components.mvp.ScopedPresenter
 import org.koin.sample.androidx.mvvm.MVVMActivity
 import org.koin.sample.androidx.utils.navigateTo
 
-class MVPActivity : ScopeActivity() {
+class MVPActivity : ScopeActivity(contentLayoutId = R.layout.mvp_activity) {
 
     // Inject presenter as Factory
     val factoryPresenter: FactoryPresenter by inject { parametersOf(ID) }
@@ -30,7 +30,6 @@ class MVPActivity : ScopeActivity() {
         assertNotEquals(get<FactoryPresenter> { parametersOf(ID) }, factoryPresenter)
         assertEquals(get<ScopedPresenter>(), scopedPresenter)
 
-        setContentView(R.layout.mvp_activity)
         title = "Android MVP"
 
         mvp_button.setOnClickListener {

--- a/koin-projects/examples/androidx-samples/src/main/java/org/koin/sample/androidx/mvvm/MVVMActivity.kt
+++ b/koin-projects/examples/androidx-samples/src/main/java/org/koin/sample/androidx/mvvm/MVVMActivity.kt
@@ -23,7 +23,7 @@ import org.koin.sample.androidx.components.scope.Session
 import org.koin.sample.androidx.scope.ScopedActivityA
 import org.koin.sample.androidx.utils.navigateTo
 
-class MVVMActivity : ScopeActivity() {
+class MVVMActivity : ScopeActivity(contentLayoutId = R.layout.mvvm_activity) {
 
     val simpleViewModel: SimpleViewModel by viewModel(clazz = SimpleViewModel::class) { parametersOf(ID) }
 
@@ -57,7 +57,6 @@ class MVVMActivity : ScopeActivity() {
         assertNotEquals(vm1, vm2)
 
         title = "Android MVVM"
-        setContentView(R.layout.mvvm_activity)
 
         assertNotNull(scopeVm)
         assertNotNull(extScopeVm)

--- a/koin-projects/examples/androidx-samples/src/main/java/org/koin/sample/androidx/mvvm/MVVMFragment.kt
+++ b/koin-projects/examples/androidx-samples/src/main/java/org/koin/sample/androidx/mvvm/MVVMFragment.kt
@@ -1,9 +1,7 @@
 package org.koin.sample.androidx.mvvm
 
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import org.junit.Assert.*
 import org.koin.android.ext.android.getKoin
 import org.koin.androidx.scope.ScopeFragment
@@ -17,7 +15,7 @@ import org.koin.sample.androidx.components.mvvm.SavedStateViewModel
 import org.koin.sample.androidx.components.mvvm.SimpleViewModel
 import org.koin.sample.androidx.components.scope.Session
 
-class MVVMFragment(val session: Session) : ScopeFragment() {
+class MVVMFragment(val session: Session) : ScopeFragment(contentLayoutId = R.layout.mvvm_fragment) {
 
     val simpleViewModel: SimpleViewModel by viewModel { parametersOf(ID) }
 
@@ -26,14 +24,6 @@ class MVVMFragment(val session: Session) : ScopeFragment() {
 
     val saved by viewModel<SavedStateViewModel>(state = emptyState()) { parametersOf(ID) }
     val saved2 by viewModel<SavedStateViewModel>(state = emptyState()) { parametersOf(ID) }
-
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View? {
-        return inflater.inflate(R.layout.mvvm_fragment, container, false)
-    }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)

--- a/koin-projects/examples/androidx-samples/src/main/java/org/koin/sample/androidx/scope/ScopedActivityA.kt
+++ b/koin-projects/examples/androidx-samples/src/main/java/org/koin/sample/androidx/scope/ScopedActivityA.kt
@@ -11,7 +11,7 @@ import org.koin.sample.androidx.components.scope.Session
 import org.koin.sample.androidx.components.scope.SessionActivity
 import org.koin.sample.androidx.utils.navigateTo
 
-class ScopedActivityA : ScopeActivity() {
+class ScopedActivityA : ScopeActivity(contentLayoutId = R.layout.scoped_activity_a) {
 
     // Inject from current scope
     val currentSession by inject<Session>()
@@ -35,7 +35,6 @@ class ScopedActivityA : ScopeActivity() {
         session.id = ID
 
         title = "Scope Activity A"
-        setContentView(R.layout.scoped_activity_a)
 
         scoped_a_button.setOnClickListener {
             navigateTo<ScopedActivityB>(isRoot = true)

--- a/koin-projects/koin-androidx-scope/src/main/java/org/koin/androidx/scope/ScopeActivity.kt
+++ b/koin-projects/koin-androidx-scope/src/main/java/org/koin/androidx/scope/ScopeActivity.kt
@@ -17,6 +17,7 @@
 package org.koin.androidx.scope
 
 import android.os.Bundle
+import androidx.annotation.LayoutRes
 import androidx.appcompat.app.AppCompatActivity
 import org.koin.android.ext.android.getKoin
 import org.koin.core.parameter.ParametersDefinition
@@ -32,7 +33,9 @@ import org.koin.core.scope.ScopeID
  *
  * @author Arnaud Giuliani
  */
-abstract class ScopeActivity : AppCompatActivity(), KoinScopeComponent {
+abstract class ScopeActivity(
+        @LayoutRes private val contentLayoutId: Int = 0
+) : AppCompatActivity(contentLayoutId), KoinScopeComponent {
 
     private val scopeID: ScopeID by lazy { getScopeId() }
     override val koin by lazy { getKoin() }
@@ -58,8 +61,8 @@ abstract class ScopeActivity : AppCompatActivity(), KoinScopeComponent {
      * @param parameters - injection parameters
      */
     inline fun <reified T : Any> inject(
-        qualifier: Qualifier? = null,
-        noinline parameters: ParametersDefinition? = null
+            qualifier: Qualifier? = null,
+            noinline parameters: ParametersDefinition? = null
     ) = lazy(LazyThreadSafetyMode.NONE) { get<T>(qualifier, parameters) }
 
     /**
@@ -69,7 +72,7 @@ abstract class ScopeActivity : AppCompatActivity(), KoinScopeComponent {
      * @param parameters - injection parameters
      */
     inline fun <reified T : Any> get(
-        qualifier: Qualifier? = null,
-        noinline parameters: ParametersDefinition? = null
+            qualifier: Qualifier? = null,
+            noinline parameters: ParametersDefinition? = null
     ): T = scope.get(qualifier, parameters)
 }

--- a/koin-projects/koin-androidx-scope/src/main/java/org/koin/androidx/scope/ScopeActivity.kt
+++ b/koin-projects/koin-androidx-scope/src/main/java/org/koin/androidx/scope/ScopeActivity.kt
@@ -34,7 +34,7 @@ import org.koin.core.scope.ScopeID
  * @author Arnaud Giuliani
  */
 abstract class ScopeActivity(
-        @LayoutRes private val contentLayoutId: Int = 0
+        @LayoutRes contentLayoutId: Int = 0
 ) : AppCompatActivity(contentLayoutId), KoinScopeComponent {
 
     private val scopeID: ScopeID by lazy { getScopeId() }

--- a/koin-projects/koin-androidx-scope/src/main/java/org/koin/androidx/scope/ScopeFragment.kt
+++ b/koin-projects/koin-androidx-scope/src/main/java/org/koin/androidx/scope/ScopeFragment.kt
@@ -23,9 +23,9 @@ import androidx.fragment.app.Fragment
 import org.koin.android.ext.android.getKoin
 import org.koin.core.parameter.ParametersDefinition
 import org.koin.core.qualifier.Qualifier
+import org.koin.core.scope.KoinScopeComponent
 import org.koin.core.scope.Scope
 import org.koin.core.scope.ScopeID
-import org.koin.core.scope.KoinScopeComponent
 
 /**
  * ScopeFragment
@@ -35,7 +35,7 @@ import org.koin.core.scope.KoinScopeComponent
  * @author Arnaud Giuliani
  */
 abstract class ScopeFragment(
-        @LayoutRes private val contentLayoutId: Int = 0
+        @LayoutRes contentLayoutId: Int = 0
 ) : Fragment(contentLayoutId), KoinScopeComponent {
 
     private val scopeID: ScopeID by lazy { getScopeId() }

--- a/koin-projects/koin-androidx-scope/src/main/java/org/koin/androidx/scope/ScopeFragment.kt
+++ b/koin-projects/koin-androidx-scope/src/main/java/org/koin/androidx/scope/ScopeFragment.kt
@@ -18,6 +18,7 @@ package org.koin.androidx.scope
 
 import android.os.Bundle
 import android.view.View
+import androidx.annotation.LayoutRes
 import androidx.fragment.app.Fragment
 import org.koin.android.ext.android.getKoin
 import org.koin.core.parameter.ParametersDefinition
@@ -33,7 +34,9 @@ import org.koin.core.scope.KoinScopeComponent
  *
  * @author Arnaud Giuliani
  */
-abstract class ScopeFragment : Fragment(), KoinScopeComponent {
+abstract class ScopeFragment(
+        @LayoutRes private val contentLayoutId: Int = 0
+) : Fragment(contentLayoutId), KoinScopeComponent {
 
     private val scopeID: ScopeID by lazy { getScopeId() }
     override val koin by lazy { getKoin() }


### PR DESCRIPTION
Due to androidX fragment and activity able to pass layout id in the constructor, it will be nice to have the same functionality in `ScopeActivity` and `ScopeFragment`.

Thanks for the koin 2.2.0 👍 