### PR TITLE
Kotlin Multiplatform 1.4.0

### DIFF
--- a/koin-projects/gradle.properties
+++ b/koin-projects/gradle.properties
@@ -24,6 +24,7 @@ org.gradle.configureondemand=false
 # Kotlin
 kotlin.incremental=true
 org.gradle.caching=true
+kotlin.mpp.enableGranularSourceSetsMetadata=true
 
 # Bintray
 bintray_repo=koin

--- a/koin-projects/gradle/versions.gradle
+++ b/koin-projects/gradle/versions.gradle
@@ -3,8 +3,8 @@ ext {
     koin_version = '3.0.0-alpha-2'
 
     // Kotlin
-    kotlin_version = '1.3.71'
-    coroutines_version = "1.3.3"
+    kotlin_version = '1.4.0'
+    coroutines_version = "1.3.9"
     
     // Dokka
     dokka_version = '0.10.1'
@@ -13,11 +13,11 @@ ext {
     bintray_version = "1.8.4-jetbrains-3"
 
     // Ktor
-    ktor_version = '1.3.1'
+    ktor_version = '1.4.0'
 
     // MP
-    testhelp_version = "0.3.3"
-    uuid_version = "0.1.0"
+    testhelp_version = "0.4.0"
+    uuid_version = "0.2.2"
 
     // Test
     junit_version = "4.12"

--- a/koin-projects/gradle/wrapper/gradle-wrapper.properties
+++ b/koin-projects/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/koin-projects/koin-core/build.gradle
+++ b/koin-projects/koin-core/build.gradle
@@ -20,9 +20,9 @@ kotlin {
         }
     }*/
 
-    if(ideaActive) {
-        macosX64("native")
-    }else{
+    if (ideaActive) {
+        macosX64("darwin")
+    } else {
         macosX64()
         iosArm32()
         iosArm64()
@@ -83,16 +83,22 @@ kotlin {
         }
 
         nativeMain {
+            dependsOn commonMain
         }
 
         nativeTest {
+            dependsOn commonTest
+        }
+
+        darwinMain {
+            dependsOn nativeMain
+        }
+
+        darwinTest {
+            dependsOn nativeTest
         }
 
         if(!ideaActive) {
-            darwinMain {
-                dependsOn nativeMain
-            }
-
             otherMain {
                 dependsOn nativeMain
             }


### PR DESCRIPTION
This PR is for #874  
There are two issues.

1. The tests can't be run due to 'Name contains illegal chars that can't appear in JavaScript identifier' error in IntelliJ. This error also occurs in Kotlin 1.3.71. I think contributors already know about this.
2. Removed watchosX86 and tvosX64 targets from koin-test module. Please refer to below log.

```
> Task :koin-test:compileTestKotlinTvosX64 FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':koin-test:compileTestKotlinTvosX64'.
> Could not resolve all files for configuration ':koin-test:tvosX64TestCompileKlibraries'.
   > Could not resolve com.benasher44:uuid:0.2.1.
     Required by:
         project :koin-test
      > No matching variant of com.benasher44:uuid:0.2.1 was found. The consumer was configured to find a usage of 'kotlin-api' of a component, as well as attribute 'org.jetbrains.kotlin.platform.type' with value 'native', attribute 'org.jetbrains.kotlin.native.target' with value 'tvos_x64' but:
          - Variant 'iosArm32-api' capability com.benasher44:uuid:0.2.1 declares a usage of 'kotlin-api' of a component, as well as attribute 'org.jetbrains.kotlin.platform.type' with value 'native':
              - Incompatible because this component declares a component, as well as attribute 'org.jetbrains.kotlin.native.target' with value 'ios_arm32' and the consumer needed a component, as well as attribute 'org.jetbrains.kotlin.native.target' with value 'tvos_x64'
          - Variant 'iosArm64-api' capability com.benasher44:uuid:0.2.1 declares a usage of 'kotlin-api' of a component, as well as attribute 'org.jetbrains.kotlin.platform.type' with value 'native':
              - Incompatible because this component declares a component, as well as attribute 'org.jetbrains.kotlin.native.target' with value 'ios_arm64' and the consumer needed a component, as well as attribute 'org.jetbrains.kotlin.native.target' with value 'tvos_x64'
          - Variant 'iosX64-api' capability com.benasher44:uuid:0.2.1 declares a usage of 'kotlin-api' of a component, as well as attribute 'org.jetbrains.kotlin.platform.type' with value 'native':
              - Incompatible because this component declares a component, as well as attribute 'org.jetbrains.kotlin.native.target' with value 'ios_x64' and the consumer needed a component, as well as attribute 'org.jetbrains.kotlin.native.target' with value 'tvos_x64'
          - Variant 'jsIr-api' capability com.benasher44:uuid:0.2.1 declares a usage of 'kotlin-api' of a component:
              - Incompatible because this component declares a component, as well as attribute 'org.jetbrains.kotlin.platform.type' with value 'js' and the consumer needed a component, as well as attribute 'org.jetbrains.kotlin.platform.type' with value 'native'
              - Other compatible attribute:
                  - Doesn't say anything about org.jetbrains.kotlin.native.target (required 'tvos_x64')
          - Variant 'jsIr-runtime' capability com.benasher44:uuid:0.2.1:
              - Incompatible because this component declares a usage of 'kotlin-runtime' of a component, as well as attribute 'org.jetbrains.kotlin.platform.type' with value 'js' and the consumer needed a usage of 'kotlin-api' of a component, as well as attribute 'org.jetbrains.kotlin.platform.type' with value 'native'
              - Other compatible attribute:
                  - Doesn't say anything about org.jetbrains.kotlin.native.target (required 'tvos_x64')
          - Variant 'jsLegacy-api' capability com.benasher44:uuid:0.2.1 declares a usage of 'kotlin-api' of a component:
              - Incompatible because this component declares a component, as well as attribute 'org.jetbrains.kotlin.platform.type' with value 'js' and the consumer needed a component, as well as attribute 'org.jetbrains.kotlin.platform.type' with value 'native'
              - Other compatible attribute:
                  - Doesn't say anything about org.jetbrains.kotlin.native.target (required 'tvos_x64')
          - Variant 'jsLegacy-runtime' capability com.benasher44:uuid:0.2.1:
              - Incompatible because this component declares a usage of 'kotlin-runtime' of a component, as well as attribute 'org.jetbrains.kotlin.platform.type' with value 'js' and the consumer needed a usage of 'kotlin-api' of a component, as well as attribute 'org.jetbrains.kotlin.platform.type' with value 'native'
              - Other compatible attribute:
                  - Doesn't say anything about org.jetbrains.kotlin.native.target (required 'tvos_x64')
          - Variant 'jvm-api' capability com.benasher44:uuid:0.2.1 declares an API of a component:
              - Incompatible because this component declares a component, as well as attribute 'org.jetbrains.kotlin.platform.type' with value 'jvm' and the consumer needed a component, as well as attribute 'org.jetbrains.kotlin.platform.type' with value 'native'
              - Other compatible attribute:
                  - Doesn't say anything about org.jetbrains.kotlin.native.target (required 'tvos_x64')
          - Variant 'jvm-runtime' capability com.benasher44:uuid:0.2.1 declares a runtime of a component:
              - Incompatible because this component declares a component, as well as attribute 'org.jetbrains.kotlin.platform.type' with value 'jvm' and the consumer needed a component, as well as attribute 'org.jetbrains.kotlin.platform.type' with value 'native'
              - Other compatible attribute:
                  - Doesn't say anything about org.jetbrains.kotlin.native.target (required 'tvos_x64')
          - Variant 'linuxArm32Hfp-api' capability com.benasher44:uuid:0.2.1 declares a usage of 'kotlin-api' of a component, as well as attribute 'org.jetbrains.kotlin.platform.type' with value 'native':
              - Incompatible because this component declares a component, as well as attribute 'org.jetbrains.kotlin.native.target' with value 'linux_arm32_hfp' and the consumer needed a component, as well as attribute 'org.jetbrains.kotlin.native.target' with value 'tvos_x64'
          - Variant 'linuxX64-api' capability com.benasher44:uuid:0.2.1 declares a usage of 'kotlin-api' of a component, as well as attribute 'org.jetbrains.kotlin.platform.type' with value 'native':
              - Incompatible because this component declares a component, as well as attribute 'org.jetbrains.kotlin.native.target' with value 'linux_x64' and the consumer needed a component, as well as attribute 'org.jetbrains.kotlin.native.target' with value 'tvos_x64'
          - Variant 'macosX64-api' capability com.benasher44:uuid:0.2.1 declares a usage of 'kotlin-api' of a component, as well as attribute 'org.jetbrains.kotlin.platform.type' with value 'native':
              - Incompatible because this component declares a component, as well as attribute 'org.jetbrains.kotlin.native.target' with value 'macos_x64' and the consumer needed a component, as well as attribute 'org.jetbrains.kotlin.native.target' with value 'tvos_x64'
          - Variant 'metadata-api' capability com.benasher44:uuid:0.2.1 declares a usage of 'kotlin-api' of a component:
              - Incompatible because this component declares a component, as well as attribute 'org.jetbrains.kotlin.platform.type' with value 'common' and the consumer needed a component, as well as attribute 'org.jetbrains.kotlin.platform.type' with value 'native'
              - Other compatible attribute:
                  - Doesn't say anything about org.jetbrains.kotlin.native.target (required 'tvos_x64')
          - Variant 'mingwX64-api' capability com.benasher44:uuid:0.2.1 declares a usage of 'kotlin-api' of a component, as well as attribute 'org.jetbrains.kotlin.platform.type' with value 'native':
              - Incompatible because this component declares a component, as well as attribute 'org.jetbrains.kotlin.native.target' with value 'mingw_x64' and the consumer needed a component, as well as attribute 'org.jetbrains.kotlin.native.target' with value 'tvos_x64'
```