### PR TITLE
Fix crashing ScopeFragment.viewModel

### DIFF
--- a/koin-projects/examples/android-samples/src/main/java/org/koin/sample/android/di/AppModule.kt
+++ b/koin-projects/examples/android-samples/src/main/java/org/koin/sample/android/di/AppModule.kt
@@ -56,7 +56,11 @@ val mvvmModule = module {
         viewModel { ExtSimpleViewModel(get()) }
         viewModel<ExtSimpleViewModel>(named("ext"))
     }
-    scope<MVVMFragment> { }
+    scope<MVVMFragment> {
+        scoped { Session() }
+        viewModel { ExtSimpleViewModel(get()) }
+        viewModel(named("ext")) { ExtSimpleViewModel(get()) }
+    }
 }
 
 val scopeModule = module {

--- a/koin-projects/examples/android-samples/src/main/java/org/koin/sample/android/mvvm/MVVMFragment.kt
+++ b/koin-projects/examples/android-samples/src/main/java/org/koin/sample/android/mvvm/MVVMFragment.kt
@@ -4,15 +4,16 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotEquals
+import org.junit.Assert.*
 import org.koin.android.ext.android.getKoin
 import org.koin.android.scope.ScopeFragment
 import org.koin.android.viewmodel.ext.android.sharedViewModel
 import org.koin.android.viewmodel.ext.android.viewModel
 import org.koin.core.parameter.parametersOf
+import org.koin.core.qualifier.named
 import org.koin.sample.android.R
 import org.koin.sample.android.components.ID
+import org.koin.sample.android.components.mvvm.ExtSimpleViewModel
 import org.koin.sample.android.components.mvvm.SimpleViewModel
 import org.koin.sample.android.components.scope.Session
 
@@ -21,6 +22,9 @@ class MVVMFragment : ScopeFragment() {
     val sharedViewModel: SimpleViewModel by sharedViewModel { parametersOf(ID) }
     val simpleViewModel: SimpleViewModel by viewModel { parametersOf(ID) }
     val session: Session? by lazy { scopeActivity?.scope?.get<Session>() }
+
+    val scopeVm: ExtSimpleViewModel by viewModel()
+    val extScopeVm: ExtSimpleViewModel by viewModel(named("ext"))
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -40,5 +44,9 @@ class MVVMFragment : ScopeFragment() {
 
         assertNotEquals(simpleViewModel, (activity as MVVMActivity).simpleViewModel)
         assertEquals(sharedViewModel, (activity as MVVMActivity).simpleViewModel)
+
+        assertNotNull(scopeVm)
+        assertNotNull(extScopeVm)
+        assertEquals(scopeVm.session.id, extScopeVm.session.id)
     }
 }

--- a/koin-projects/examples/androidx-samples/src/main/java/org/koin/sample/androidx/di/AppModule.kt
+++ b/koin-projects/examples/androidx-samples/src/main/java/org/koin/sample/androidx/di/AppModule.kt
@@ -66,6 +66,9 @@ val mvvmModule = module {
     }
     scope<MVVMFragment> {
         scoped { (id: String) -> ScopedPresenter(id, get()) }
+        scoped { Session() }
+        viewModel { ExtSimpleViewModel(get()) }
+        viewModel(named("ext")) { ExtSimpleViewModel(get()) }
     }
 }
 

--- a/koin-projects/examples/androidx-samples/src/main/java/org/koin/sample/androidx/mvvm/MVVMFragment.kt
+++ b/koin-projects/examples/androidx-samples/src/main/java/org/koin/sample/androidx/mvvm/MVVMFragment.kt
@@ -7,6 +7,7 @@ import android.view.ViewGroup
 import org.junit.Assert.*
 import org.koin.android.ext.android.getKoin
 import org.koin.androidx.scope.ScopeFragment
+import org.koin.androidx.viewmodel.ext.android.getSharedViewModel
 import org.koin.androidx.viewmodel.ext.android.sharedViewModel
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import org.koin.androidx.viewmodel.scope.emptyState
@@ -56,6 +57,10 @@ class MVVMFragment(val session: Session) : ScopeFragment() {
 
         assertNotEquals((requireActivity() as MVVMActivity).savedVm, saved)
         assertNotEquals((requireActivity() as MVVMActivity).savedVm, saved2)
+        val shared2 = getSharedViewModel<SimpleViewModel> { parametersOf(ID) }
+        val shared3 = getSharedViewModel(clazz = SimpleViewModel::class) { parametersOf(ID) }
+        assertEquals(shared, shared2)
+        assertEquals(shared2, shared3)
 
         assertEquals(saved, saved2)
 

--- a/koin-projects/examples/androidx-samples/src/main/java/org/koin/sample/androidx/mvvm/MVVMFragment.kt
+++ b/koin-projects/examples/androidx-samples/src/main/java/org/koin/sample/androidx/mvvm/MVVMFragment.kt
@@ -11,8 +11,10 @@ import org.koin.androidx.viewmodel.ext.android.sharedViewModel
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import org.koin.androidx.viewmodel.scope.emptyState
 import org.koin.core.parameter.parametersOf
+import org.koin.core.qualifier.named
 import org.koin.sample.android.R
 import org.koin.sample.androidx.components.ID
+import org.koin.sample.androidx.components.mvvm.ExtSimpleViewModel
 import org.koin.sample.androidx.components.mvvm.SavedStateViewModel
 import org.koin.sample.androidx.components.mvvm.SimpleViewModel
 import org.koin.sample.androidx.components.scope.Session
@@ -20,6 +22,9 @@ import org.koin.sample.androidx.components.scope.Session
 class MVVMFragment(val session: Session) : ScopeFragment() {
 
     val simpleViewModel: SimpleViewModel by viewModel { parametersOf(ID) }
+
+    val scopeVm: ExtSimpleViewModel by viewModel()
+    val extScopeVm: ExtSimpleViewModel by viewModel(named("ext"))
 
     val shared: SimpleViewModel by sharedViewModel { parametersOf(ID) }
     val sharedSaved: SavedStateViewModel by sharedViewModel { parametersOf(ID) }
@@ -41,6 +46,10 @@ class MVVMFragment(val session: Session) : ScopeFragment() {
         assertNotNull(session)
 
         assertNotEquals(shared, simpleViewModel)
+
+        assertNotNull(scopeVm)
+        assertNotNull(extScopeVm)
+        assertEquals(scopeVm.session.id, extScopeVm.session.id)
 
         assertEquals((requireActivity() as MVVMActivity).simpleViewModel, shared)
         assertEquals((requireActivity() as MVVMActivity).savedVm, sharedSaved)

--- a/koin-projects/koin-android-viewmodel/src/main/java/org/koin/android/viewmodel/ext/android/ScopeFragmentExt.kt
+++ b/koin-projects/koin-android-viewmodel/src/main/java/org/koin/android/viewmodel/ext/android/ScopeFragmentExt.kt
@@ -19,7 +19,7 @@ import android.arch.lifecycle.ViewModel
 import org.koin.android.scope.ScopeFragment
 import org.koin.android.viewmodel.ViewModelOwner.Companion.from
 import org.koin.android.viewmodel.ViewModelOwnerDefinition
-import org.koin.android.viewmodel.koin.getViewModel
+import org.koin.android.viewmodel.scope.getViewModel
 import org.koin.core.parameter.ParametersDefinition
 import org.koin.core.qualifier.Qualifier
 import kotlin.reflect.KClass
@@ -62,5 +62,5 @@ fun <T : ViewModel> ScopeFragment.getViewModel(
     clazz: KClass<T>,
     parameters: ParametersDefinition? = null
 ): T {
-    return koin.getViewModel(qualifier, owner, clazz, parameters)
+    return scope.getViewModel(qualifier, owner, clazz, parameters)
 }

--- a/koin-projects/koin-androidx-viewmodel/src/main/java/org/koin/androidx/viewmodel/ext/android/ScopeFragmentExt.kt
+++ b/koin-projects/koin-androidx-viewmodel/src/main/java/org/koin/androidx/viewmodel/ext/android/ScopeFragmentExt.kt
@@ -16,12 +16,11 @@
 package org.koin.androidx.viewmodel.ext.android
 
 import androidx.lifecycle.ViewModel
-import org.koin.android.ext.android.getKoin
 import org.koin.androidx.scope.ScopeFragment
 import org.koin.androidx.viewmodel.ViewModelOwner.Companion.from
 import org.koin.androidx.viewmodel.ViewModelOwnerDefinition
-import org.koin.androidx.viewmodel.koin.getViewModel
 import org.koin.androidx.viewmodel.scope.BundleDefinition
+import org.koin.androidx.viewmodel.scope.getViewModel
 import org.koin.core.parameter.ParametersDefinition
 import org.koin.core.qualifier.Qualifier
 import kotlin.reflect.KClass
@@ -68,5 +67,5 @@ fun <T : ViewModel> ScopeFragment.getViewModel(
     clazz: KClass<T>,
     parameters: ParametersDefinition? = null
 ): T {
-    return getKoin().getViewModel(qualifier, state, owner, clazz, parameters)
+    return scope.getViewModel(qualifier, state, owner, clazz, parameters)
 }


### PR DESCRIPTION
Fixes #886 
-   Koin 2.2.0-alpha-1
-   Fix crashing when declaring `viewModel` in `scope` and retrieve it via `ScopeFragment.viewModel()`