### PR TITLE
ref |> impl koinComponent.inject by koin.inject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Badges: `[UPDATED]`, `[FIXED]`, `[ADDED]`, `[DEPRECATED]`, `[REMOVED]`,  `[BREAK
 
 ## [2.2.0]()
 
+### [2.2.0-beta-1]()
+
 _koin-androidx-scope_
 
 * `[ADDED]` New `ScopeActivity`. `ScopeFragment`, `ScopeService` to enable Scope API direclty into Android components. Offers injection directly from tied Scope.

--- a/koin-projects/koin-core/src/main/kotlin/org/koin/core/KoinComponent.kt
+++ b/koin-projects/koin-core/src/main/kotlin/org/koin/core/KoinComponent.kt
@@ -52,7 +52,7 @@ inline fun <reified T> KoinComponent.inject(
     qualifier: Qualifier? = null,
     noinline parameters: ParametersDefinition? = null
 ): Lazy<T> =
-    lazy(LazyThreadSafetyMode.NONE) { getKoin().get<T>(qualifier, parameters) }
+    getKoin().inject(qualifier, parameters)
 
 /**
  * Get instance instance from Koin by Primary Type P, as secondary type S


### PR DESCRIPTION
Use `getKoin().inject` to keep inject implementation logic consistent with get and bind.

```kotlin
inline fun <reified T> KoinComponent.get(
    qualifier: Qualifier? = null,
    noinline parameters: ParametersDefinition? = null
): T =
    getKoin().get(qualifier, parameters)
```