### PR TITLE
Use same gradle dependency keywords

### DIFF
--- a/koin-projects/koin-test-junit5/build.gradle
+++ b/koin-projects/koin-test-junit5/build.gradle
@@ -5,10 +5,10 @@ description = 'Koin - simple dependency injection for Kotlin - ' + archivesBaseN
 
 dependencies {
     // Koin
-    implementation project(":koin-core")
-    implementation project(":koin-test-core")
-    implementation "org.junit.jupiter:junit-jupiter-engine:$junit5_version"
-    testImplementation "org.mockito:mockito-inline:$mockito_version"
+    compile project(":koin-core")
+    compile project(":koin-test-core")
+    compile "org.junit.jupiter:junit-jupiter-engine:$junit5_version"
+    testCompile "org.mockito:mockito-inline:$mockito_version"
 }
 
 apply from: '../gradle/publish.gradle'


### PR DESCRIPTION
This fixes: https://github.com/InsertKoinIO/koin/issues/903

Use same gradle dependency inclusion keywords as the rest of the project.

implemeting -> compile
testImplementing -> testCompile

We should make a separate PR on converting all of the deprecated keywords to implementing, api, testImplementing in the future. 