### PR TITLE
Fix concurrency issue for Single definitions

### DIFF
--- a/koin-projects/koin-core/src/main/kotlin/org/koin/core/instance/SingleInstanceFactory.kt
+++ b/koin-projects/koin-core/src/main/kotlin/org/koin/core/instance/SingleInstanceFactory.kt
@@ -44,8 +44,10 @@ class SingleInstanceFactory<T>(koin: Koin, beanDefinition: BeanDefinition<T>) :
 
     @Suppress("UNCHECKED_CAST")
     override fun get(context: InstanceContext): T {
-        if (!isCreated()) {
-            value = create(context)
+        synchronized(this) {
+            if (!isCreated()) {
+                value = create(context)
+            }
         }
         return value ?: error("Single instance created couldn't return value")
     }

--- a/koin-projects/koin-core/src/main/kotlin/org/koin/core/instance/SingleInstanceFactory.kt
+++ b/koin-projects/koin-core/src/main/kotlin/org/koin/core/instance/SingleInstanceFactory.kt
@@ -35,11 +35,9 @@ class SingleInstanceFactory<T>(koin: Koin, beanDefinition: BeanDefinition<T>) :
     }
 
     override fun create(context: InstanceContext): T {
-        return synchronized(this) {
-            if (value == null) {
-                super.create(context)
-            } else value ?: error("Single instance created couldn't return value")
-        }
+        return if (value == null) {
+            super.create(context)
+        } else value ?: error("Single instance created couldn't return value")
     }
 
     @Suppress("UNCHECKED_CAST")

--- a/koin-projects/koin-core/src/test/java/org/koin/core/SingleConcurrencyTest.kt
+++ b/koin-projects/koin-core/src/test/java/org/koin/core/SingleConcurrencyTest.kt
@@ -1,0 +1,43 @@
+package org.koin.core
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.koin.Simple
+import org.koin.dsl.koinApplication
+import org.koin.dsl.module
+import java.util.concurrent.Callable
+import java.util.concurrent.Executors
+
+class SingleConcurrencyTest {
+
+    @Test
+    fun `never creates two instances from different threads`() {
+        val executor = Executors.newFixedThreadPool(8)
+        // This test is repeated many times, because it only fails a very small % of times
+        repeat(3000) { repetition ->
+            val app = koinApplication {
+                modules(module {
+                    single { createComponent() }
+                })
+            }
+
+            val numberOfInstances = (1..50)
+                    .map { executor.submit(Callable { app.koin.get<Simple.ComponentA>() }) }
+                    .map { it.get() }
+                    .distinctBy { it.toString() }
+                    .count()
+
+
+            assertEquals(
+                    "More than one instance created concurrently for a `single` definition. Failed in repetition $repetition of the test.",
+                    1,
+                    numberOfInstances,
+            )
+        }
+    }
+
+    private fun createComponent(): Simple.ComponentA {
+        Thread.sleep(1) // Simulates a more expensive instance creation
+        return Simple.ComponentA()
+    }
+}


### PR DESCRIPTION
# The bug
We were having some crashes in our production app when injecting a Segment SDK (analytics tracker). This SDK has the particularity that only one instance can be created with the same tag. ([Source for reference](https://github.com/segmentio/analytics-android/blob/master/analytics/src/main/java/com/segment/analytics/Analytics.java#L1376))

We are constructing this SDK inside a Koin's `single` definition. In theory, `single` only creates one instance of the bean, even in multi-threaded environments. But in our millions of daily sessions we get a few hundred crashes where this assumption fails.

We managed to reproduce the issue consistently in a unit test by simulating concurrent injections a few thousands of times. 🤯 
I'm submitting in the PR the most simple version of the test that I could write (our initial test was way more complicated 😂 ). The number of repetitions and threads come from trial and error, with lower numbers the test would sometime give a false positive. I'm not sure if you want to keep the test, or if this is the right place to put it. Let me know.

![Screenshot 2020-10-08 at 10 49 17](https://user-images.githubusercontent.com/545251/95438798-15f34000-0957-11eb-9b7b-e13032a5b1c6.png)


# The cause
After some research, I came to the conclusion that the issue lies in the concurrency code from `SingleInstanceFactory`. 
The synchronization code in the `create()` function works fine, but there's one little operation that happens outside the `synchronized` block: the `value =` assignment.
The bug is so hard to reproduce because the affected code is such a tiny part! 
![Screenshot 2020-10-08 at 11 17 24](https://user-images.githubusercontent.com/545251/95439403-e1cc4f00-0957-11eb-983f-896fbe566573.png)


# The fix
I surrounded the code in `get()` with another `synchronized`, and that seems to fix the issue. 🎉 
I'm no concurrency expert myself, but I can't think of any problems with this solution. 