### PR TITLE
Update sidebar github and twitter icons.

### DIFF
--- a/koin-projects/docs/reference/sidebar.md
+++ b/koin-projects/docs/reference/sidebar.md
@@ -32,5 +32,5 @@
 - [Changelog](https://github.com/InsertKoinIO/koin/blob/master/CHANGELOG.md)
 - [WebSite](https://insert-koin.io/)
 - [Getting Started Documentation](https://start.insert-koin.io/)
-- [![Github](https://icongram.jgog.in/simple/github.svg?color=808080&size=16)Github](https://github.com/InsertKoinIO/koin)
-- [![Twitter](https://icongram.jgog.in/simple/twitter.svg?colored&size=16)@insertkoin_io](http://twitter.com/insertkoin_io)
+- [![GitHub](https://icongr.am/simple/github.svg?color=808080&size=16)GitHub](https://github.com/InsertKoinIO/koin)
+- [![Twitter](https://icongr.am/simple/twitter.svg?colored&size=16)@insertkoin_io](http://twitter.com/insertkoin_io)

--- a/koin-projects/docs/start/sidebar.md
+++ b/koin-projects/docs/start/sidebar.md
@@ -20,5 +20,5 @@
 - [Changelog](https://github.com/InsertKoinIO/koin/blob/master/CHANGELOG.md)
 - [WebSite](https://insert-koin.io/)
 - [Reference Documentation](https://doc.insert-koin.io/)
-- [![Github](https://icongram.jgog.in/simple/github.svg?color=808080&size=16)Github](https://github.com/InsertKoinIO/koin)
-- [![Twitter](https://icongram.jgog.in/simple/twitter.svg?colored&size=16)@insertkoin_io](http://twitter.com/insertkoin_io)
+- [![GitHub](https://icongr.am/simple/github.svg?color=808080&size=16)GitHub](https://github.com/InsertKoinIO/koin)
+- [![Twitter](https://icongr.am/simple/twitter.svg?colored&size=16)@insertkoin_io](http://twitter.com/insertkoin_io)


### PR DESCRIPTION
The previous GitHub icon was not working fine. I'm still using the simple API.

Another option can be hosting the icons in this repository, I checked and some libraries like Retrofit and Coil are hosting the icons.