### PR TITLE
Fix comment for KoinApplication.workManagerFactory

### DIFF
--- a/koin-projects/koin-androidx-workmanager/src/main/java/org/koin/androidx/workmanager/koin/KoinApplicationExt.kt
+++ b/koin-projects/koin-androidx-workmanager/src/main/java/org/koin/androidx/workmanager/koin/KoinApplicationExt.kt
@@ -23,7 +23,7 @@ import org.koin.core.KoinApplication
 import org.koin.core.KoinExperimentalAPI
 
 /**
- * Setup the KoinFragmentFactory instance
+ * Setup the KoinWorkerFactory instance
  *
  * @author Arnaud Giuliani
  */


### PR DESCRIPTION
This PR updates a comment in KoinApplicationExt to correctly reference KoinWorkerFactory instead of KoinFragmentFactory.