### PR TITLE
Fix issue in Android - ViewModel Documentation

### DIFF
--- a/docs/quickstart/android-viewmodel.md
+++ b/docs/quickstart/android-viewmodel.md
@@ -22,7 +22,8 @@ repositories {
 dependencies {
     // Koin for Android - Scope feature
     // include koin-android-scope & koin-android
-    compile "org.koin:koin-android:$koin_version"
+    implementation "org.koin:koin-android:$koin_version"
+    implementation "org.koin:koin-android-viewmodel:$koin_version"
 }
 ```
 


### PR DESCRIPTION
In the current Documents the dependencies do not include the `org.koin:koin-android-viewmodel:$koin_version`.

In this PR we are changing this by including it along side with the `org.koin:koin-android:$koin_version` and we have replaced also the `compile` with `implementation`