### PR TITLE
Make `KoinWorkerFactory` match `androidx.work.WorkerFactory` API

### DIFF
--- a/android/koin-androidx-workmanager/src/main/java/org/koin/androidx/workmanager/factory/KoinWorkerFactory.kt
+++ b/android/koin-androidx-workmanager/src/main/java/org/koin/androidx/workmanager/factory/KoinWorkerFactory.kt
@@ -29,6 +29,7 @@ import org.koin.core.qualifier.named
  *
  * @author Fabio de Matos
  * @author Arnaud Giuliani
+ * @author Konstantin Mutasov
  **/
 class KoinWorkerFactory : WorkerFactory(), KoinComponent {
 
@@ -36,8 +37,8 @@ class KoinWorkerFactory : WorkerFactory(), KoinComponent {
         appContext: Context,
         workerClassName: String,
         workerParameters: WorkerParameters,
-    ): ListenableWorker {
-        return get(qualifier = named(workerClassName)) { parametersOf(workerParameters) }
+    ): ListenableWorker? {
+        return getKoin().getOrNull(qualifier = named(workerClassName)) { parametersOf(workerParameters) }
     }
 }
 


### PR DESCRIPTION
Origin `androidx.work.WorkerFactory` has `@Nullable` annotation on
abstract method `createWorker`. Inherited `KoinWorkerFactory` has
overriden return type of `createWorker` with non-null `ListenableWorker`.
In some edge cases that leads to
crash with `org.koin.core.error.NoBeanDefFoundException`.

Work Managers framework uses reflection to retrieve scheduled workers. 
It stores worker fully qualified name in database. If your application 
scheduled some work and you changed name or package of that work 
in new version of application, `WorkerFactory` couldn't build scheduled 
worker, because of not found stored worker name. Default implementation 
will skip that case with `null` worker. 