### PR TITLE
Resolving Injected parameters from graph - Doc updated

### DIFF
--- a/core/koin-core/src/commonTest/kotlin/org/koin/core/ParametersInjectionTest.kt
+++ b/core/koin-core/src/commonTest/kotlin/org/koin/core/ParametersInjectionTest.kt
@@ -27,6 +27,40 @@ class ParametersInjectionTest {
     }
 
     @Test
+    fun `can create a single with parameters - resolved in graph`() {
+
+        val app = koinApplication {
+            modules(
+                module {
+                    factory { Simple.MySingle(get()) }
+                })
+        }
+
+        val koin = app.koin
+        val a42: Simple.MySingle = koin.get { parametersOf(42) }
+        assertEquals(42, a42.id)
+        
+        val a24: Simple.MySingle = koin.get { parametersOf(24) }
+        assertEquals(24, a24.id)
+    }
+
+    @Test
+    fun `can create a single with parameters - using param object resolution`() {
+
+        val app = koinApplication {
+            modules(
+                module {
+                    single { params -> Simple.MySingle(params.get()) }
+                })
+        }
+
+        val koin = app.koin
+        val a: Simple.MySingle = koin.get { parametersOf(42) }
+
+        assertEquals(42, a.id)
+    }
+
+    @Test
     fun `can create a single with nullable parameters`() {
 
         val app = koinApplication {

--- a/docs/reference/koin-core/injection-parameters.md
+++ b/docs/reference/koin-core/injection-parameters.md
@@ -4,9 +4,29 @@ title: Injection Parameters
 
 In any definition, you can use injection parameters: parameters that will be injected and used by your definition:
 
-## Defining an injection parameter
+## Defining an injected parameter
 
-Below is an example of injection parameters. We established that we need a `view` parameter to build of `Presenter` class:
+Below is an example of injection parameters. We established that we need a `view` parameter to build of `Presenter` class. We use the `params` function argument  to help retrieve our injected parqmeters:
+
+```kotlin
+class Presenter(val view : View)
+
+val myModule = module {
+    single { params -> Presenter(view = params.get()) }
+}
+```
+
+You can also let the Koin graph resolution find your injected parameter for you. Just use the usual `get()` function:
+
+```kotlin
+class Presenter(val view : View)
+
+val myModule = module {
+    single { Presenter(get()) }
+}
+```
+
+Finally, you can also write your injected parameters directly with the parameters object, as destructured declaration:
 
 ```kotlin
 class Presenter(val view : View)
@@ -16,41 +36,32 @@ val myModule = module {
 }
 ```
 
+:::caution
+ Even if the "destrutured" declaration is more conveient and readable, it's not type safe. Kotlinb won't detect that passed type are in good orders if you have several values
+:::
 
-## Injecting with values
 
-In contrary to resolved dependencies (resolved with with `get()`), injection parameters are *parameters passed through the resolution API*.
-This means that those parameters are values passed with `get()` and `by inject()`, with the `parametersOf()` function:
+## Passing values to inject
 
-```kotlin
-class MyComponent : View, KoinComponent {
-
-    // inject this as View value
-    val presenter : Presenter by inject { parametersOf(this) }
-}
-```
-
-## Multiple parameters
-
-If we want to have multiple parameters in our definition, we can use the *destructured declaration* to list our parameters:
+Given a definition that is using injected parameters:
 
 ```kotlin
-class Presenter(val view : View, id : String)
+class Presenter(val a : A, val b : B)
 
 val myModule = module {
-    single{ (view : View, id : String) -> Presenter(view,id) }
+    single { params -> Presenter(a = params.get(), b = params.get()) }
 }
-```
 
-In a `KoinComponent`, just use the `parametersOf` function with your arguments like below:
+Injection parameters are parameters passed through the resolution API with the `parametersOf()` function (each value seperated by comma): 
 
 ```kotlin
 class MyComponent : View, KoinComponent {
 
-    val id : String ...
+    val a : A ...
+    val b : B ... 
 
-    // inject with view & id
-    val presenter : Presenter by inject { parametersOf(this,id) }
+    // inject this as View value
+    val presenter : Presenter by inject { parametersOf(a, b) }
 }
 ```
 


### PR DESCRIPTION
Add unit test to ensure we can use injected params with `get()` from the resolution graph. Doc is updated