### PR TITLE
[WorkManager] Remove dangling curly brace from documentation

### DIFF
--- a/docs/reference/koin-android/workmanager.md
+++ b/docs/reference/koin-android/workmanager.md
@@ -90,8 +90,6 @@ val workerFactoryModule = module {
    factory<WorkFactory> { WorkFactory1() }
    factory<WorkFactory> { WorkFactory2() }
 }
-
-}
 ```
 
 then have koin internals do something like


### PR DESCRIPTION
I was poking through the [WorkManager](https://insert-koin.io/docs/reference/koin-android/workmanager/#dsl-improvement-option) documentation and noticed a dangling curly brace

