### PR TITLE
Use qualified name of KClass to get class name in native

### DIFF
--- a/core/koin-core/src/jsMain/kotlin/org/koin/mp/PlatformToolsJS.kt
+++ b/core/koin-core/src/jsMain/kotlin/org/koin/mp/PlatformToolsJS.kt
@@ -26,7 +26,7 @@ import kotlin.reflect.KClass
 
 actual object KoinPlatformTools {
     actual fun getStackTrace(e: Exception): String = e.toString() + Exception().toString().split("\n")
-    actual fun getClassName(kClass: KClass<*>): String = kClass.simpleName ?: "KClass@${hashCode()}"
+    actual fun getClassName(kClass: KClass<*>): String = kClass.simpleName ?: "KClass@${kClass.hashCode()}"
     // TODO Better Id generation?
     actual fun generateId(): String = Random.nextDouble().hashCode().toString()
     actual fun defaultLazyMode(): LazyThreadSafetyMode = LazyThreadSafetyMode.NONE

--- a/core/koin-core/src/nativeMain/kotlin/org/koin/mp/PlatformToolsNative.kt
+++ b/core/koin-core/src/nativeMain/kotlin/org/koin/mp/PlatformToolsNative.kt
@@ -34,7 +34,7 @@ import kotlin.reflect.KClass
 
 actual object KoinPlatformTools {
     actual fun getStackTrace(e: Exception): String = e.toString() + Exception().toString().split("\n")
-    actual fun getClassName(kClass: KClass<*>): String = kClass.simpleName ?: "KClass@${hashCode()}"
+    actual fun getClassName(kClass: KClass<*>): String = kClass.qualifiedName ?: "KClass@${kClass.hashCode()}"
 
     // TODO Better Id generation?
     actual fun generateId(): String = Random.nextDouble().hashCode().toString()


### PR DESCRIPTION
Getting class name only by using simple name causes problems with duplicates when saving definitions into InstanceRegistry in multiplatform projects containing multiple classes with same simple name.