### PR TITLE
Fix WorkManager docs

### DIFF
--- a/docs/reference/koin-android/workmanager.md
+++ b/docs/reference/koin-android/workmanager.md
@@ -6,9 +6,9 @@ The `koin-androidx-workmanager` project is dedicated to bring Android WorkManage
 
 ## WorkManager DSL
 
-## Setup Fragment Factory
+## Setup WorkManager
 
-At start, in your KoinApplication declaration, use the `fragmentFactory()` keyword to setup a default `KoinFragmentFactory` instance:
+At start, in your KoinApplication declaration, use the `workManagerFactory()` keyword to a setup custom WorkManager instance:
 
 ```kotlin
 class MainApplication : Application(), KoinComponent {


### PR DESCRIPTION
Fix wrong documentation for koin-androidx-workmanager

- Rewritten FragmentFactory to WorkManager