### PR TITLE
Make `KoinWorkerFactory` match `androidx.work.WorkerFactory` API

### DIFF
--- a/koin-projects/koin-androidx-workmanager/src/main/java/org/koin/androidx/workmanager/factory/KoinWorkerFactory.kt
+++ b/koin-projects/koin-androidx-workmanager/src/main/java/org/koin/androidx/workmanager/factory/KoinWorkerFactory.kt
@@ -21,7 +21,6 @@ import androidx.work.WorkerFactory
 import androidx.work.WorkerParameters
 import org.koin.core.component.KoinApiExtension
 import org.koin.core.component.KoinComponent
-import org.koin.core.component.get
 import org.koin.core.parameter.parametersOf
 import org.koin.core.qualifier.named
 
@@ -30,6 +29,7 @@ import org.koin.core.qualifier.named
  *
  * @author Fabio de Matos
  * @author Arnaud Giuliani
+ * @author Konstantin Mutasov
  **/
 @OptIn(KoinApiExtension::class)
 class KoinWorkerFactory : WorkerFactory(), KoinComponent {
@@ -38,8 +38,8 @@ class KoinWorkerFactory : WorkerFactory(), KoinComponent {
         appContext: Context,
         workerClassName: String,
         workerParameters: WorkerParameters
-    ): ListenableWorker {
-        return get(qualifier = named(workerClassName)) { parametersOf(workerParameters) }
+    ): ListenableWorker? {
+        return getKoin().getOrNull(qualifier = named(workerClassName)) { parametersOf(workerParameters) }
     }
 }
 


### PR DESCRIPTION
Cherry-pick commit from master into 2.2.2   https://github.com/InsertKoinIO/koin/pull/1018 


> Origin `androidx.work.WorkerFactory` has `@Nullable` annotation on
abstract method `createWorker`. Inherited `KoinWorkerFactory` has
overriden return type of `createWorker` with non-null `ListenableWorker`.
In some edge cases that leads to
crash with `org.koin.core.error.NoBeanDefFoundException`.