### PR TITLE
Updated kotlin to 1.4.32

### DIFF
--- a/gradle/versions-android.gradle
+++ b/gradle/versions-android.gradle
@@ -19,6 +19,6 @@ ext {
     androidx_workmanager = '2.5.0'
 
     androidx_compose_gradle_version = "4.2.0-beta03" //"7.0.0-alpha08"
-    androidx_compose_version = "1.0.0-beta01"
+    androidx_compose_version = "1.0.0-beta05"
 
 }

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -4,7 +4,7 @@ ext {
     is_snaptshot = false
 
     // Kotlin
-    kotlin_version = '1.4.30'
+    kotlin_version = '1.4.32'
     coroutines_version = "1.4.2"
     
     // Dokka


### PR DESCRIPTION
By updating kotlin to version 1.4.32, we allow Koin to work with latest compose beta05 that requires kotlin 1.4.32

All test passed successfully by executing
  - core `./test.sh` 👍 
  - android `./test.sh` 👍
  - android-compose `./test.sh` 👍
  - ktor `./test.sh` 👍
  - plugins `./test.sh` 👍
 
