### PR TITLE
Add watchosX64

### DIFF
--- a/core/koin-core/build.gradle
+++ b/core/koin-core/build.gradle
@@ -26,6 +26,7 @@ kotlin {
         watchosArm32()
         watchosArm64()
         watchosX86()
+        watchosX64()
         tvosArm64()
         tvosX64()
         //    androidNativeArm32()
@@ -101,6 +102,7 @@ kotlin {
                     targets.watchosArm32,
                     targets.watchosArm64,
                     targets.watchosX86,
+                    targets.watchosX64,
                     targets.tvosArm64,
                     targets.tvosX64,
                     targets.iosX64,

--- a/core/koin-test/build.gradle
+++ b/core/koin-test/build.gradle
@@ -24,6 +24,7 @@ kotlin {
         watchosArm32()
         watchosArm64()
         watchosX86()
+        watchosX64()
         tvosArm64()
         tvosX64()
         //    androidNativeArm32()


### PR DESCRIPTION
Spinning up a simulator in XCode now uses a new architecture: X64
Added watchosX64 to the target, but probably needs checking for support