### PR TITLE
KClass based instance builder function

### DIFF
--- a/core/koin-core-ext/src/main/kotlin/org/koin/experimental/builder/InstanceBuilder.kt
+++ b/core/koin-core-ext/src/main/kotlin/org/koin/experimental/builder/InstanceBuilder.kt
@@ -5,12 +5,13 @@ import org.koin.core.scope.Scope
 import org.koin.core.time.measureDurationForResult
 import org.koin.ext.getFullName
 import java.lang.reflect.Constructor
+import kotlin.reflect.KClass
 
 /**
  * Create instance for type T and inject dependencies into 1st constructor
  */
-inline fun <reified T : Any> Scope.create(): T {
-    val kClass = T::class
+inline fun <reified T : Any> Scope.create(): T = create(T::class)
+fun <T : Any> Scope.create(kClass: KClass<T>): T {
     val instance: Any
 
     if (logger.level == Level.DEBUG) {


### PR DESCRIPTION
This PR enables KClass based instance creation, solving #475 
When working with application configuration files, dependency types are often not known at compile-time, which makes the use of generics not possible.
Instead, with this pull request, users can do as follows:
```
single {
    create(
        when (config.database) {
            Database.MEMORY -> InMemoryUserRepository::class
            Database.SQL -> SQLUserRepository::class
        }
    ) as UserRepository 
}
```