### PR TITLE
update jetpack-compose to 1.0.0-beta08

### DIFF
--- a/android-compose/build.gradle
+++ b/android-compose/build.gradle
@@ -24,7 +24,7 @@ allprojects {
     repositories {
         mavenLocal()
         google()
-        jcenter()
+        mavenCentral()
     }
 
     group = 'io.insert-koin'

--- a/android-compose/gradle/wrapper/gradle-wrapper.properties
+++ b/android-compose/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/android-compose/koin-androidx-compose/build.gradle
+++ b/android-compose/koin-androidx-compose/build.gradle
@@ -1,4 +1,3 @@
-
 plugins {
     id 'com.android.library'
     id 'kotlin-android'
@@ -13,12 +12,11 @@ ext {
 }
 
 android {
-    compileSdkVersion 29
-    buildToolsVersion "29.0.3"
+    compileSdkVersion 30
+    buildToolsVersion "30.0.3"
 
     defaultConfig {
         minSdkVersion 21
-
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
@@ -45,7 +43,7 @@ android {
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
     kotlinOptions {
         jvmTarget = "1.8"
-        freeCompilerArgs += ["-Xallow-jvm-ir-dependencies", "-Xskip-prerelease-check"]
+        freeCompilerArgs += ["-Xskip-prerelease-check"]
     }
 }
 
@@ -54,7 +52,7 @@ dependencies {
     // Koin
     api "io.insert-koin:koin-android:$koin_version"
     testImplementation "io.insert-koin:koin-test-junit4:$koin_version"
-    testImplementation 'junit:junit:4.13.1'
+    testImplementation 'junit:junit:4.13.2'
 
     /* Compose */
     api "androidx.compose.runtime:runtime:$androidx_compose_version"

--- a/android-compose/settings.gradle
+++ b/android-compose/settings.gradle
@@ -1,4 +1,3 @@
 
 include 'koin-androidx-compose'
 
-enableFeaturePreview('GRADLE_METADATA')

--- a/examples-compose/androidx-compose/build.gradle
+++ b/examples-compose/androidx-compose/build.gradle
@@ -39,7 +39,7 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerVersion kotlin_version//"1.4.10"
+        kotlinCompilerVersion kotlin_version //"1.4.10"
         kotlinCompilerExtensionVersion androidx_compose_version //"1.0.0-alpha03"
     }
 }

--- a/gradle/versions-android.gradle
+++ b/gradle/versions-android.gradle
@@ -5,7 +5,7 @@ ext {
 
     android_gradle_version = "4.1.2"
     android_build_tools_version = '30.0.3'
-    
+
     // old
     support_lib_version = "28.0.0"
     androidx_lib_version = "1.2.0"
@@ -15,10 +15,9 @@ ext {
 	androidx_savedstate = '2.3.0'
     androidx_activity_version = "1.2.0"
     androidx_fragment_version = "1.3.0"
-    
+
     androidx_workmanager = '2.5.0'
 
-    androidx_compose_gradle_version = "4.2.0-beta03" //"7.0.0-alpha08"
-    androidx_compose_version = "1.0.0-beta05"
-
+    androidx_compose_gradle_version = "7.1.0-alpha01" //"7.0.0-alpha08"
+    androidx_compose_version = "1.0.0-beta08"
 }

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -4,9 +4,9 @@ ext {
     is_snaptshot = false
 
     // Kotlin
-    kotlin_version = '1.5.0'
-    coroutines_version = "1.4.2"
-    
+    kotlin_version = '1.5.10'
+    coroutines_version = "1.5.10"
+
     // Dokka
     dokka_version = '0.10.1'
 


### PR DESCRIPTION
## Actions
* update all compose dependencies to latest greatest
* rebased against origin/master (3.0.2)
* use `Kotlin` `1.4.32`, in Compose, because `Compose` is not compatible with 1.5
* run tests for android-compose (with ./test.sh)
* composite build with android project using jetpack-compose (seems to work)

## Description

Koin can not be used with newer Compose libraries, because of following issue:

```plain
Note: Libraries dependent on Compose will need to recompile with version 1.0.0‑beta07. Otherwise, libraries may encounter a NoSuchMethodError, such as:
java.lang.NoSuchMethodError: No interface method startReplaceableGroup(ILjava/lang/String;)V in class Landroidx/compose/runtime/Composer; or its super classes. (Ia34e6)
```

https://developer.android.com/jetpack/androidx/releases/compose-compiler#1.0.0-beta07

## Open points
Do not know how semantic versioning is applied in `Koin`, therefore I did not touch the versions. I would say it is a "major", because transitive dependencies changed in an incompatible ABI way. 

Please advice, if I change something which I shouldn't.