### PR TITLE
Fix: calling "".clearQuotes() causes ArrayIndexOutOfBoundsException

### DIFF
--- a/core/koin-core/src/commonMain/kotlin/org/koin/ext/StringExt.kt
+++ b/core/koin-core/src/commonMain/kotlin/org/koin/ext/StringExt.kt
@@ -18,7 +18,7 @@ package org.koin.ext
 fun String.clearQuotes(): String {
     val chars = this.toCharArray()
     val quoteChar = '"'
-    return if (chars[0] == quoteChar && chars[chars.lastIndex] == quoteChar) {
+    return if (chars.isNotEmpty() && chars[0] == quoteChar && chars[chars.lastIndex] == quoteChar) {
         chars.copyOfRange(1, chars.lastIndex).concatToString()
     } else this
 }

--- a/core/koin-core/src/commonTest/kotlin/org/koin/ext/StringExtTest.kt
+++ b/core/koin-core/src/commonTest/kotlin/org/koin/ext/StringExtTest.kt
@@ -1,0 +1,19 @@
+package org.koin.ext
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class StringExtTest {
+
+    @Test
+    fun `stripping quotes when only quotes present`() {
+        val quotes = "\"\""
+        assertEquals("", quotes.clearQuotes())
+    }
+
+    @Test
+    fun `stripping quotes from an empty string`() {
+        val empty = ""
+        assertEquals("", empty.clearQuotes())
+    }
+}


### PR DESCRIPTION
To reproduce the problem:

```
    System.setProperty("key", "")
    startKoin {
        environmentProperties()
    }
```