### PR TITLE
update koin-androidx-compose to be compatible with compose-rc01

### DIFF
--- a/android-compose/koin-androidx-compose/build.gradle
+++ b/android-compose/koin-androidx-compose/build.gradle
@@ -59,9 +59,10 @@ dependencies {
     /* Compose */
     api "androidx.compose.runtime:runtime:$androidx_compose_version"
     api "androidx.compose.ui:ui:$androidx_compose_version"
-    api "androidx.lifecycle:lifecycle-viewmodel-compose:1.0.0-alpha02"
+    api "androidx.lifecycle:lifecycle-viewmodel-compose:1.0.0-alpha07"
 
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
 }
 
-apply from: '../../gradle/publish-to-central.gradle'
+//TODO
+//apply from: '../../gradle/publish-to-central.gradle'

--- a/android-compose/koin-androidx-compose/src/main/java/org/koin/androidx/compose/ViewModelComposeExt.kt
+++ b/android-compose/koin-androidx-compose/src/main/java/org/koin/androidx/compose/ViewModelComposeExt.kt
@@ -40,7 +40,7 @@ inline fun <reified T : ViewModel> getViewModel(
     qualifier: Qualifier? = null,
     noinline parameters: ParametersDefinition? = null,
 ): T {
-    val owner = LocalViewModelStoreOwner.current
+    val owner = requireNotNull(LocalViewModelStoreOwner.current)
     return remember(qualifier,parameters) {
         owner.getViewModel(qualifier, parameters)
     }

--- a/examples-compose/androidx-compose/build.gradle
+++ b/examples-compose/androidx-compose/build.gradle
@@ -5,7 +5,7 @@ apply from: '../../gradle/versions-examples.gradle'
 apply from: "../../gradle/versions.gradle"
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 30
     buildToolsVersion android_build_tools_version
 
     defaultConfig {
@@ -54,7 +54,9 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
 dependencies {
 
     // Koin
-    implementation "org.koin:koin-androidx-compose:$koin_version"
+//    implementation "io.insert-koin:koin-androidx-compose:$koin_version" //TODO：need to publish a new version
+    implementation project(":koin-androidx-compose")
+
 
     // Compose
     implementation "androidx.compose.runtime:runtime:$androidx_compose_version"
@@ -66,10 +68,11 @@ dependencies {
     implementation "androidx.compose.animation:animation:$androidx_compose_version"
 //    implementation "androidx.ui:ui-tooling:$androidx_compose_version"
     implementation "androidx.compose.runtime:runtime-livedata:$androidx_compose_version"
+    implementation "androidx.activity:activity-compose:1.3.0-rc01"
 
-    implementation 'androidx.appcompat:appcompat:1.3.0-alpha02'
-    implementation 'androidx.activity:activity-ktx:1.1.0'
-    implementation 'androidx.core:core-ktx:1.5.0-alpha02'
+    implementation 'androidx.appcompat:appcompat:1.4.0-alpha03'
+    implementation 'androidx.activity:activity-ktx:1.2.3'
+    implementation 'androidx.core:core-ktx:1.7.0-alpha01'
 
     testImplementation 'junit:junit:4.13'
 }

--- a/examples-compose/androidx-compose/src/main/java/org/koin/sample/androidx/compose/ui/MainActivity.kt
+++ b/examples-compose/androidx-compose/src/main/java/org/koin/sample/androidx/compose/ui/MainActivity.kt
@@ -1,15 +1,15 @@
 package org.koin.sample.androidx.compose.ui
 
 import android.os.Bundle
+import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
-import androidx.compose.foundation.Text
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.setContent
 import androidx.compose.ui.unit.dp
 import org.koin.androidx.compose.getViewModel
 import org.koin.sample.androidx.compose.data.User

--- a/examples-compose/build.gradle
+++ b/examples-compose/build.gradle
@@ -4,7 +4,7 @@ buildscript {
 
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         // Kotlin
@@ -22,6 +22,6 @@ allprojects {
     repositories {
         mavenLocal()
         google()
-        jcenter()
+        mavenCentral()
     }
 }

--- a/examples-compose/settings.gradle
+++ b/examples-compose/settings.gradle
@@ -2,3 +2,7 @@
 // Main
 include 'androidx-compose'
 //include 'androidx-compose-jetnews'
+include 'koin-androidx-compose'
+project(":koin-androidx-compose").projectDir = new File("../android-compose/koin-androidx-compose")
+
+

--- a/gradle/versions-android.gradle
+++ b/gradle/versions-android.gradle
@@ -21,8 +21,8 @@ ext {
     // when using in AS
     // androidx_compose_gradle_version = "7.0.0-beta01"
     // for global build
-    androidx_compose_gradle_version = "4.2.0-beta03"
+    androidx_compose_gradle_version = '4.2.2'
 
-    androidx_compose_version = "1.0.0-beta09"
+    androidx_compose_version = "1.0.0-rc01"
 
 }


### PR DESCRIPTION
The current androidx-compose example has build error cause some APIs used in example  out of date with the latest version of compose. After updating the APIs, although the compilation passed, there was an error at runtime. And it needs to upgrade the dependency library version of Koin-androidx-compose：

lifecycle-viewmodel-compose:  1.0.0-alpha02  =>  1.0.0-alpha07

