### PR TITLE
remove `override` param in factory

### DIFF
--- a/core/koin-core/src/commonMain/kotlin/org/koin/core/module/Module.kt
+++ b/core/koin-core/src/commonMain/kotlin/org/koin/core/module/Module.kt
@@ -94,7 +94,6 @@ class Module(val createdAtStart: Boolean = false) {
     /**
      * Declare a Factory definition
      * @param qualifier
-     * @param override
      * @param definition - definition function
      */
     inline fun <reified T> factory(


### PR DESCRIPTION
removed due to non-existent param with `override` name