### PR TITLE
[Proposal] New API for Jetpack Compose

### DIFF
--- a/android-compose/gradle/wrapper/gradle-wrapper.properties
+++ b/android-compose/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/android-compose/koin-androidx-compose/build.gradle
+++ b/android-compose/koin-androidx-compose/build.gradle
@@ -13,8 +13,8 @@ ext {
 }
 
 android {
-    compileSdkVersion 29
-    buildToolsVersion "29.0.3"
+    compileSdkVersion 30
+    buildToolsVersion "30.0.3"
 
     defaultConfig {
         minSdkVersion 21
@@ -40,6 +40,7 @@ android {
         kotlinCompilerVersion kotlin_version
         kotlinCompilerExtensionVersion androidx_compose_version
     }
+
 }
 
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
@@ -61,7 +62,9 @@ dependencies {
     api "androidx.compose.ui:ui:$androidx_compose_version"
     api "androidx.lifecycle:lifecycle-viewmodel-compose:1.0.0-alpha07"
 
-    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
+    debugImplementation "androidx.compose.ui:ui-test-manifest:$androidx_compose_version"
+    androidTestImplementation "androidx.compose.material:material:$androidx_compose_version"
+    androidTestImplementation "androidx.compose.ui:ui-test-junit4:$androidx_compose_version"
 }
 
 apply from: '../../gradle/publish-to-central.gradle'

--- a/android-compose/koin-androidx-compose/build.gradle
+++ b/android-compose/koin-androidx-compose/build.gradle
@@ -40,7 +40,19 @@ android {
         kotlinCompilerVersion kotlin_version
         kotlinCompilerExtensionVersion androidx_compose_version
     }
-
+    packagingOptions {
+        exclude 'META-INF/DEPENDENCIES'
+        exclude 'META-INF/LICENSE'
+        exclude 'META-INF/LICENSE.txt'
+        exclude 'META-INF/license.txt'
+        exclude 'META-INF/NOTICE'
+        exclude 'META-INF/NOTICE.txt'
+        exclude 'META-INF/notice.txt'
+        exclude 'META-INF/ASL2.0'
+        exclude 'META-INF/AL2.0'
+        exclude 'META-INF/LGPL2.1'
+        exclude 'META-INF/*.kotlin_module'
+    }
 }
 
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {

--- a/android-compose/koin-androidx-compose/src/androidTest/java/org/koin/androidx/compose/KoinComposeTest.kt
+++ b/android-compose/koin-androidx-compose/src/androidTest/java/org/koin/androidx/compose/KoinComposeTest.kt
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2017-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.koin.androidx.compose
+
+import androidx.compose.material.Text
+import androidx.compose.ui.test.assertTextEquals
+import androidx.compose.ui.test.isRoot
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onChildAt
+import org.junit.Rule
+import org.junit.Test
+import org.koin.core.component.inject
+import org.koin.dsl.module
+
+private object TestScopeA
+private object TestScopeB
+
+class KoinComposeTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun displayTextFromKoin() {
+        val module = module {
+            factory { "testString" }
+        }
+        composeTestRule.setContent {
+            Koin(appDeclaration = { modules(module) }) {
+                val string = get<String>()
+                Text(string)
+            }
+        }
+        assertTextDisplayed("testString")
+    }
+
+    @Test
+    fun useKoinFromClosestParent() {
+        val outerModule = module {
+            factory { "outerString" }
+        }
+        val innerModule = module {
+            factory { "innerString" }
+        }
+        composeTestRule.setContent {
+            Koin(appDeclaration = { modules(outerModule) }) {
+                Koin(appDeclaration = { modules(innerModule) }) {
+                    val string = get<String>()
+                    Text(string)
+                }
+            }
+        }
+        assertTextDisplayed("innerString")
+    }
+
+    @Test
+    fun useScopes() {
+        val module = module {
+            scope<TestScopeA> {
+                scoped { "ScopeA" }
+            }
+            scope<TestScopeB> {
+                scoped { "ScopeB" }
+            }
+        }
+        composeTestRule.setContent {
+            Koin(appDeclaration = { modules(module) }) {
+                KoinScope(getScope = { createScope<TestScopeA>() }) {
+                    val string = get<String>()
+                    Text(string)
+                }
+                KoinScope(getScope = { createScope<TestScopeB>() }) {
+                    val string = get<String>()
+                    Text(string)
+                }
+            }
+        }
+        assertTextDisplayed("ScopeA", index = 0)
+        assertTextDisplayed("ScopeB", index = 1)
+    }
+
+    @Test
+    fun useInjectWithKoinComponent() {
+        val module = module {
+            factory { "testString" }
+        }
+        composeTestRule.setContent {
+            Koin(appDeclaration = { modules(module) }) {
+                getKoinComponent().run {
+                    val string: String by inject()
+                    Text(string)
+                }
+            }
+        }
+        assertTextDisplayed("testString")
+    }
+
+    private fun assertTextDisplayed(text: String, index: Int = 0) {
+        composeTestRule.onNode(isRoot()).onChildAt(index).assertTextEquals(text)
+    }
+}

--- a/android-compose/koin-androidx-compose/src/main/java/org/koin/androidx/compose/Koin.kt
+++ b/android-compose/koin-androidx-compose/src/main/java/org/koin/androidx/compose/Koin.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.koin.androidx.compose
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.compositionLocalOf
+import org.koin.core.Koin
+import org.koin.core.context.GlobalContext
+import org.koin.dsl.KoinAppDeclaration
+import org.koin.dsl.koinApplication
+
+@PublishedApi
+internal val LocalKoin = compositionLocalOf { GlobalContext.get() }
+
+@Composable
+fun Koin(
+    appDeclaration: KoinAppDeclaration? = null,
+    content: @Composable () -> Unit
+) {
+    val koinApplication = koinApplication(appDeclaration)
+    CompositionLocalProvider(LocalKoin provides koinApplication.koin) {
+        content()
+    }
+}
+
+@Composable
+fun getKoin(): Koin = LocalKoin.current

--- a/android-compose/koin-androidx-compose/src/main/java/org/koin/androidx/compose/Scope.kt
+++ b/android-compose/koin-androidx-compose/src/main/java/org/koin/androidx/compose/Scope.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.koin.androidx.compose
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.remember
+import org.koin.core.Koin
+import org.koin.core.scope.Scope
+
+@PublishedApi
+internal val LocalScope = compositionLocalOf<Scope?> { null }
+
+@Composable
+fun KoinScope(
+    getScope: Koin.() -> Scope,
+    content: @Composable () -> Unit
+) {
+    val koin = getKoin()
+    val scope = remember {
+        koin.getScope()
+    }
+    CompositionLocalProvider(LocalScope provides scope) {
+        content()
+    }
+}
+
+@Composable
+fun getScope() = LocalScope.current

--- a/android-compose/koin-androidx-compose/src/main/java/org/koin/androidx/compose/ViewModelComposeExt.kt
+++ b/android-compose/koin-androidx-compose/src/main/java/org/koin/androidx/compose/ViewModelComposeExt.kt
@@ -41,6 +41,7 @@ inline fun <reified T : ViewModel> getViewModel(
     noinline parameters: ParametersDefinition? = null,
 ): T {
     val owner = LocalViewModelStoreOwner.current
+        ?: error("ViewModel in LocalViewModelStoreOwner is null")
     return remember(qualifier,parameters) {
         owner.getViewModel(qualifier, parameters)
     }

--- a/gradle/versions-android.gradle
+++ b/gradle/versions-android.gradle
@@ -23,6 +23,5 @@ ext {
     // for global build
     androidx_compose_gradle_version = "4.2.0-beta03"
 
-    androidx_compose_version = "1.0.0-beta09"
-
+    androidx_compose_version = "1.0.0"
 }


### PR DESCRIPTION
I'm starting a discussion on `#koin-dev` - feel free to join  if you have any feedback or questions regarding this PR.

### Motivation
I’ve been working with Koin for Compose for a while now and have a proposal to improve how `KoinContext` management works in `@Composable` functions. I believe the configuration of the application should be done in the top level composable. This way it is not dependent on Koin initialization in the `Application` class, which allows for easy `KoinContext` replacement in `@Preview` composables and tests. It introduces a new API - `Koin` and `KoinScope` composables.

### Usage example (with scopes and @Preview):
```kotlin

object ScopeTypeA
object ScopeTypeB

data class A(val value: String)

val scopedModule = module {
    scope<ScopeTypeA> {
        scoped { A("scopeA") }
    }
    scope<ScopeTypeB> {
        scoped { A("scopeB") }
    }
}

@Preview
@Composable
fun Test() {
    Koin(appDeclaration = { modules(scopedModule) }) {
        Column {
            KoinScope(getScope = { createScope<ScopeTypeA>() }) {
                Text(get<A>().value)
            }
            KoinScope(getScope = { createScope<ScopeTypeB>() }) {
                Text(get<A>().value)
            }
        }
    }
}
```

### Pros:
- scopes works
- easy `KoinContext` replacement in tests
- easy `KoinContext` replacement in `@Preview` composables
- no need to use `Application` class (which may help with Compose Multiplatform support in the future)
- backward compatibility (using `GlobalContext` as default value)

### This PR includes:
- new API implementation
- instrumented tests
- necessary library updates
- fix of nullability issue in `ViewModelComposeExt.kt`

### Problems
- I couldn't update Compose to 1.0.2 because it uses newer version of Kotlin (1.5.21) than Koin
- to run the project I had to update `androidx_compose_gradle_version` to `7.0+`

### Issues fixed with this PR:
- https://github.com/InsertKoinIO/koin/issues/1177
- https://github.com/InsertKoinIO/koin/issues/1119
- https://github.com/InsertKoinIO/koin/issues/1072
- https://github.com/InsertKoinIO/koin/issues/823 (partially by `getKoinComponent().run { /* inject works here /* }`)

### TODO
- javadocs if proposal is accepted