### PR TITLE
Refactors Scope.resolveValue() scope source resolve function.

### DIFF
--- a/core/koin-core/src/commonMain/kotlin/org/koin/core/scope/Scope.kt
+++ b/core/koin-core/src/commonMain/kotlin/org/koin/core/scope/Scope.kt
@@ -249,7 +249,7 @@ data class Scope(
             _koin.logger.log(Level.DEBUG) { "'${clazz.getFullName()}' - q:'$qualifier' look at scope source" }
             _source?.let {
                 if (clazz.isInstance(it)) {
-                    _source as? T
+                    it
                 } else null
             }
         }


### PR DESCRIPTION
Returns `it` instead of `_source` to avoid unchecked cast warning.