### PR TITLE
Fix Typo in Docs

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -25,7 +25,7 @@ problem.
 None of these is essential for a pull request, but they will all help.  They can also be
 added after the original pull request but before a merge.
 
-* We use the Kotlin standard formating convention
+* We use the Kotlin standard formatting convention
 * Make sure all new `.kt` files to have a simple Javadoc class comment with at least an
   `@author` tag identifying you, and preferably at least a paragraph on what the class is
   for.
@@ -68,7 +68,7 @@ NOTE: you can use the `test.sh` and `install.sh` scripts to test all modules and
 
 the `koin-test` module gather all test against `koin-core`. Here you'll found most of usecase tests.
 
-The following command scrtip launch all tests from projects:
+The following command script launch all tests from projects:
 
 [indent=0]
 ----

--- a/docs/migration/maven.md
+++ b/docs/migration/maven.md
@@ -4,7 +4,7 @@ title: Maven Central & JCenter
 
 Koin project was hosted in JCenter until this year. The project was located in `org.koin` maven group. 
 
-JCenter is shuting down: https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/
+JCenter is shutting down: https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/
 
 The Koin project is now hosted in MavenCentral, and its maven group  is now `io.insert-koin`. Please check your configuration with modules below.
 

--- a/docs/reference/koin-android/dsl-update.md
+++ b/docs/reference/koin-android/dsl-update.md
@@ -4,7 +4,7 @@ title: Android DSL - 3.1.x Update
 
 ## Compact Definition
 
-Koin DSL can be seen as "manual", while you must fill constructors with "get()" function to resolve needed instances. When your definition don't need any special constructor integration (injection paarameters or special scope Id), we can go with more compact writing style thanks to API below.
+Koin DSL can be seen as "manual", while you must fill constructors with "get()" function to resolve needed instances. When your definition don't need any special constructor integration (injection parameters or special scope Id), we can go with more compact writing style thanks to API below.
 
 All injected parameters are also resolved directly with this compact form of writing.
 
@@ -39,7 +39,7 @@ val appModule = module {
 }
 
 val mvpModule = module {
-    // Simple Presenter with injected parameyers
+    // Simple Presenter with injected parameters
     factory { (id: String) -> FactoryPresenter(id, get()) }
     // also declared like this
     factory<FactoryPresenter>()

--- a/docs/reference/koin-core/context-isolation.md
+++ b/docs/reference/koin-core/context-isolation.md
@@ -27,7 +27,7 @@ val myApp = koinApplication {
 }
 ```
 
-You will have to keep your `myApp` instance avilable in your library and pass it to your custom KoinComponent implementation:
+You will have to keep your `myApp` instance available in your library and pass it to your custom KoinComponent implementation:
 
 ```kotlin
 // Get a Context for your Koin instance
@@ -41,7 +41,7 @@ MyKoinContext.koinApp = KoinApp
 
 ```kotlin
 abstract class CustomKoinComponent : KoinComponent {
-    // Override default Koin instance, intially target on GlobalContext to yours
+    // Override default Koin instance, initially target on GlobalContext to yours
     override fun getKoin(): Koin = MyKoinContext?.koinApp.koin
 }
 ```

--- a/docs/reference/koin-core/dsl-update.md
+++ b/docs/reference/koin-core/dsl-update.md
@@ -4,7 +4,7 @@ title: Koin DSL - 3.1.x update
 
 ## Compact definition declaration - no more "get()"
 
-Koin DSL can be seen as "manual", while you must fill constructors with "get()" function to resolve needed instances. When your definition don't need any special constructor integration (injection paarameters or special scope Id), we can go with more compact writing style thanks to API below.
+Koin DSL can be seen as "manual", while you must fill constructors with "get()" function to resolve needed instances. When your definition don't need any special constructor integration (injection parameters or special scope Id), we can go with more compact writing style thanks to API below.
 
 :::note
  Using reflection is not costless, even if here it's really minimal. it replaces what you don"t want to write with reflection code (finding primary constructors, injecting parameters...). Mind it before using it, if you are on performances constraints platform (Android for example)
@@ -14,7 +14,7 @@ Just use the single function without any expression:
 
 ```kotlin
 module {
-    single<ComponentA>() // will be quivalent to single { ComponentA() }
+    single<ComponentA>() // will be equivalent to single { ComponentA() }
 }
 ```
 

--- a/docs/reference/koin-core/dsl.md
+++ b/docs/reference/koin-core/dsl.md
@@ -84,5 +84,5 @@ val myModule = module {
 }
 ```
 
-In this module, you can declare components as decribed below.
+In this module, you can declare components as described below.
 

--- a/docs/reference/koin-core/injection-parameters.md
+++ b/docs/reference/koin-core/injection-parameters.md
@@ -6,7 +6,7 @@ In any definition, you can use injection parameters: parameters that will be inj
 
 ## Defining an injected parameter
 
-Below is an example of injection parameters. We established that we need a `view` parameter to build of `Presenter` class. We use the `params` function argument  to help retrieve our injected parqmeters:
+Below is an example of injection parameters. We established that we need a `view` parameter to build of `Presenter` class. We use the `params` function argument  to help retrieve our injected parameters:
 
 ```kotlin
 class Presenter(val view : View)
@@ -27,7 +27,7 @@ val myModule = module {
 ```
 
 :::caution
- Even if the "destrutured" declaration is more conveient and readable, it's not type safe. Kotlin won't detect that passed type are in good orders if you have several values
+ Even if the "destructured" declaration is more convenient and readable, it's not type safe. Kotlin won't detect that passed type are in good orders if you have several values
 :::
 
 ## Parameters injection from the Graph resolution
@@ -54,7 +54,7 @@ val myModule = module {
 }
 ```
 
-Injection parameters are parameters passed through the resolution API with the `parametersOf()` function (each value seperated by comma): 
+Injection parameters are parameters passed through the resolution API with the `parametersOf()` function (each value separated by comma):
 
 ```kotlin
 class MyComponent : View, KoinComponent {

--- a/docs/reference/koin-core/koin-component.md
+++ b/docs/reference/koin-core/koin-component.md
@@ -6,7 +6,7 @@ Koin is a DSL to help describe your modules & definitions, a container to make d
 an API to retrieve our instances outside of the container. That's the goal of Koin components.
 
 :::info
- The `KoinComponent` interface is here to help you retrieve instances directly from Koin. Be careful, this links your class to the Koin container API. Avoid to use it on classes that you can declare in `modules`, and prefer cosntructor injection
+ The `KoinComponent` interface is here to help you retrieve instances directly from Koin. Be careful, this links your class to the Koin container API. Avoid to use it on classes that you can declare in `modules`, and prefer constructor injection
 :::
 
 ## Create a Koin Component

--- a/docs/reference/koin-core/modules.md
+++ b/docs/reference/koin-core/modules.md
@@ -38,7 +38,7 @@ val moduleB = module {
 ```
 
 :::info 
-Koin does't have any import concept. Koin definitions are lazy: a Koin definition is started with Koin container but is not instantiated. An instance is created only a request for its type has been done.
+Koin doesn't have any import concept. Koin definitions are lazy: a Koin definition is started with Koin container but is not instantiated. An instance is created only a request for its type has been done.
 :::
 
 We just have to declare list of used modules when we start our Koin container:
@@ -54,7 +54,7 @@ Koin will then resolve dependencies from all given modules.
 
 ## Overriding definition or module (3.1.0+)
 
-New Koin override strategy allow to override any definition by default. You don't need to specify `oevrride = true` anymore in your module.
+New Koin override strategy allow to override any definition by default. You don't need to specify `override = true` anymore in your module.
 
 If you have 2 definitions in different modules, that have the same mapping, the last will override the current definition.
 

--- a/docs/reference/koin-core/properties.md
+++ b/docs/reference/koin-core/properties.md
@@ -26,7 +26,7 @@ startKoin {
 
 In a Koin module, you can get a property by its key:
 
-in /src/main/resoucres/koin.properties file
+in /src/main/resources/koin.properties file
 ```java
 // Key - value
 server_url=http://service_url

--- a/docs/reference/koin-core/scopes.md
+++ b/docs/reference/koin-core/scopes.md
@@ -200,7 +200,7 @@ module {
 }
 ```
 
-With scope linking API, we can allow to resolve B's scope instance C, directly from A'scope. For this we use `linkTo()` on scope instance:
+With scope linking API, we can allow to resolve B's scope instance C, directly from A's scope. For this we use `linkTo()` on scope instance:
 
 ```kotlin
 val a = koin.get<A>()

--- a/docs/reference/koin-core/start-koin.md
+++ b/docs/reference/koin-core/start-koin.md
@@ -83,7 +83,7 @@ val myApp = koinApplication {
 }
 ```
 
-You will have to keep your `myApp` instance avilable in your library and pass it to your custom KoinComponent implementation:
+You will have to keep your `myApp` instance available in your library and pass it to your custom KoinComponent implementation:
 
 ```kotlin
 // Get a Context for your Koin instance
@@ -97,7 +97,7 @@ MyKoinContext.koinApp = KoinApp
 
 ```kotlin
 abstract class CustomKoinComponent : KoinComponent {
-    // Override default Koin instance, intially target on GlobalContext to yours
+    // Override default Koin instance, initially target on GlobalContext to yours
     override fun getKoin(): Koin = MyKoinContext?.koinApp.koin
 }
 ```

--- a/docs/reference/koin-test/checkmodules.md
+++ b/docs/reference/koin-test/checkmodules.md
@@ -23,11 +23,11 @@ class CheckModulesTest : KoinTest {
 
 #### CheckKoinModules DSL
 
-For any definition that is using injected parameters, properties or dynamic instances, the `checkKoinModules` DSL allow to specify how to wotk with the following case:
+For any definition that is using injected parameters, properties or dynamic instances, the `checkKoinModules` DSL allow to specify how to work with the following case:
 
-* `withInstance(value)` - will add `value` instance to Koin graph (can be used in depednency or parameter)
+* `withInstance(value)` - will add `value` instance to Koin graph (can be used in dependency or parameter)
 
-* `withInstance<MyType>()` - will add a mocked instance of `MyType`. Use MockProviderRule. (can be used in depednency or parameter)
+* `withInstance<MyType>()` - will add a mocked instance of `MyType`. Use MockProviderRule. (can be used in dependency or parameter)
 
 * `withParameter<Type>(qualifier){ qualifier -> value }` - will add `value` instance to be injected as parameter
 
@@ -41,7 +41,7 @@ To use mocks with `checkKoinModules`, you need to provide a `MockProviderRule`
 ```kotlin
 @get:Rule
 val mockProvider = MockProviderRule.create { clazz ->
-    // Mock with your framwork here given clazz 
+    // Mock with your framework here given clazz
 }
 ```
 

--- a/docs/reference/koin-test/testing.md
+++ b/docs/reference/koin-test/testing.md
@@ -6,7 +6,7 @@ title: Injecting in Tests
 
 By tagging your class `KoinTest`, your class become a `KoinComponent` and bring you:
 
-* `by inject()` & `get()` - function to retrieve yoru instances from Koin
+* `by inject()` & `get()` - function to retrieve your instances from Koin
 * `checkModules` - help you check your configuration
 * `declareMock` & `declare` - to declare a mock or a new definition in the current context
 


### PR DESCRIPTION
Fix typos across .md files for better documentation. No technical change here since this is purely documentation improvement.