### PR TITLE
Included modules

### DIFF
--- a/android/koin-android/src/test/java/org/koin/test/android/IncludedModuleTest.kt
+++ b/android/koin-android/src/test/java/org/koin/test/android/IncludedModuleTest.kt
@@ -1,0 +1,45 @@
+package org.koin.test.android
+
+import org.junit.Test
+import org.koin.core.qualifier.named
+import org.koin.dsl.koinApplication
+import org.koin.dsl.module
+
+class IncludedModuleTest {
+
+    private class Person(parent: Person?)
+
+    private val QualifierA = named("a")
+    private val QualifierB = named("b")
+    private val QualifierC = named("c")
+    private val QualifierD = named("d")
+
+    private val ModuleA = module {
+        includes(ModuleB)
+        factory(QualifierA) { Person(parent = null) }
+    }
+
+    private val ModuleB = module {
+        includes(ModuleC)
+        factory(QualifierB) { Person(parent = get(QualifierA)) }
+    }
+
+    private val ModuleC = module {
+        factory(QualifierC) { Person(parent = get(QualifierB)) }
+    }
+
+    private val ModuleD = module {
+        factory(QualifierD) { Person(parent = get(QualifierA)) }
+    }
+
+    @Test(expected = Test.None::class)
+    fun `shouldLoadIncludedModules`() {
+        val koin = koinApplication { modules(ModuleA) }.koin
+
+        // Assert that all included modules are in fact included by retrieving its dependencies.
+        requireNotNull(koin.get<Person>(QualifierA))
+        requireNotNull(koin.get<Person>(QualifierB))
+        requireNotNull(koin.get<Person>(QualifierC))
+        requireNotNull(koin.get<Person>(QualifierD))
+    }
+}

--- a/core/koin-core/src/commonMain/kotlin/org/koin/core/Koin.kt
+++ b/core/koin-core/src/commonMain/kotlin/org/koin/core/Koin.kt
@@ -324,13 +324,35 @@ class Koin {
      * Load module & create eager instances
      */
     fun loadModules(modules: List<Module>, allowOverride : Boolean = true) {
-        instanceRegistry.loadModules(modules, allowOverride)
-        scopeRegistry.loadScopes(modules)
+        val flattedModules = modules.flatten()
+        instanceRegistry.loadModules(flattedModules, allowOverride)
+        scopeRegistry.loadScopes(flattedModules)
     }
 
-
     fun unloadModules(modules: List<Module>) {
-        instanceRegistry.unloadModules(modules)
+        val flattedModules = modules.flatten()
+        instanceRegistry.unloadModules(flattedModules)
+    }
+
+    /**
+     * Returns a single list of all [Module] with their [includedModules] in the given list.
+     * Duplicated modules are ignored.
+     */
+    private fun List<Module>.flatten(): List<Module> {
+        val deque = ArrayDeque(elements = this)
+
+        val allModules = mutableListOf<Module>()
+        while (deque.isNotEmpty()) {
+            val module = deque.removeFirstOrNull()
+
+            // We want to ensure duplicated modules aren't visited more than once.
+            if (module != null && !allModules.contains(module)) {
+                allModules += module
+                deque += module.includedModules
+            }
+        }
+
+        return allModules
     }
 
     /**

--- a/core/koin-core/src/commonMain/kotlin/org/koin/core/Koin.kt
+++ b/core/koin-core/src/commonMain/kotlin/org/koin/core/Koin.kt
@@ -327,7 +327,6 @@ class Koin {
         val flattedModules = modules.flatten()
         instanceRegistry.loadModules(flattedModules, allowOverride)
         scopeRegistry.loadScopes(flattedModules)
-        createEagerInstances()
     }
 
     fun unloadModules(modules: List<Module>) {

--- a/core/koin-core/src/commonMain/kotlin/org/koin/core/Koin.kt
+++ b/core/koin-core/src/commonMain/kotlin/org/koin/core/Koin.kt
@@ -327,6 +327,7 @@ class Koin {
         val flattedModules = modules.flatten()
         instanceRegistry.loadModules(flattedModules, allowOverride)
         scopeRegistry.loadScopes(flattedModules)
+        createEagerInstances()
     }
 
     fun unloadModules(modules: List<Module>) {

--- a/core/koin-core/src/commonMain/kotlin/org/koin/core/module/Module.kt
+++ b/core/koin-core/src/commonMain/kotlin/org/koin/core/module/Module.kt
@@ -44,6 +44,24 @@ class Module(val createdAtStart: Boolean = false) {
     @PublishedApi
     internal val scopes = hashSetOf<Qualifier>()
 
+    internal val includedModules = mutableSetOf<Module>()
+
+    /**
+     * A collection of [Module] from which the current [Module] is compose.
+     * Duplicated modules are ignored.
+     */
+    fun includes(vararg module: Module) {
+        includedModules += module
+    }
+
+    /**
+     * A collection of [Module] from which the current [Module] is compose.
+     * Duplicated modules are ignored.
+     */
+    fun includes(module: List<Module>) {
+        includedModules += module
+    }
+
     /**
      * Declare a group a scoped definition with a given scope qualifier
      * @param qualifier


### PR DESCRIPTION
Initial implementation for "[Module Grouping](https://github.com/InsertKoinIO/koin/issues/1196)" proposal.

It provides an API to include a `Module` as part of another `Module` in a DSL syntax. The implementation requires feedback (see [flatten](https://github.com/InsertKoinIO/koin/pull/1210/files#diff-e772f920a0a8f0cef44eb951fbb66027f8ee3b191a8cd91bc25b5f188ffaf837R342) method) to ensure we won't impact the load module in a negative way.

```kotlin
startKoin {
    modules(featureModule)
}

// Public `koin.Module` of the Gradle module.
public val featureModule = module {
    includes(featureDomainModule, featureDataModule, featurePresentationModule)
    // another name might be "dependsOn"
}

// Private `koin.Module` of the Gradle module.
// Internal details, should not be exposed.
private val featureDomainModule = module {}
private val featureDataModule = module {}
private val featurePresentationModule = module {}
```

Fixes #1196.
Original PR: https://github.com/InsertKoinIO/koin/pull/1210.