### PR TITLE
Prepare for api 31

### DIFF
--- a/gradle/versions-android.gradle
+++ b/gradle/versions-android.gradle
@@ -10,7 +10,7 @@ ext {
     androidx_arch_version = '2.2.0'
     androidx_activity_version = "1.3.1"
 
-    androidx_workmanager = '2.6.0'
+    androidx_workmanager = '2.7.1'
     androidx_nav = '2.3.5'
 
     // when using in AS

--- a/gradle/versions-examples.gradle
+++ b/gradle/versions-examples.gradle
@@ -3,7 +3,7 @@ ext {
     support_lib_version = "28.0.0"
     constraint_layout_version = "1.1.3"
     room_version = "1.1.1"
-    work_manager_version = "2.6.0"
+    work_manager_version = "2.7.1"
 
     leak_canary_version = "1.6.1"
 


### PR DESCRIPTION
When you use 

`implementation "io.insert-koin:koin-android:3.1.3" `

with api 31

```
android {
    compileSdkVersion 31

    defaultConfig {
        targetSdkVersion 31
    }
}
```

on a api 31 device, you'll run into

```
java.lang.IllegalArgumentException: info.abc.org: Targeting S+ (version 31 and above) requires that one of 
FLAG_IMMUTABLE or FLAG_MUTABLE be specified when creating a PendingIntent.
    Strongly consider using FLAG_IMMUTABLE, only use FLAG_MUTABLE if some functionality depends on the PendingIntent being mutable, e.g. if it needs to be used with inline replies or bubbles.
        at android.app.PendingIntent.checkFlags(PendingIntent.java:375)
        at android.app.PendingIntent.getBroadcastAsUser(PendingIntent.java:645)
        at android.app.PendingIntent.getBroadcast(PendingIntent.java:632)
        at androidx.work.impl.utils.ForceStopRunnable.getPendingIntent(ForceStopRunnable.java:285)
        at androidx.work.impl.utils.ForceStopRunnable.isForceStopped(ForceStopRunnable.java:158)
        at androidx.work.impl.utils.ForceStopRunnable.forceStopRunnable(ForceStopRunnable.java:185)
        at androidx.work.impl.utils.ForceStopRunnable.run(ForceStopRunnable.java:103)
        at androidx.work.impl.utils.SerialExecutor$Task.run(SerialExecutor.java:91)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
```

You can solve it either by adding

    def work_version = "2.7.1"
    implementation "androidx.work:work-runtime:$work_version"
    implementation "androidx.work:work-runtime-ktx:$work_version"

or with this pull reuqest