### PR TITLE
Replace LifecycleObserver with DefaultLifecycleObserver

### DIFF
--- a/android/koin-android/src/main/java/org/koin/androidx/scope/LifecycleScopeDelegate.kt
+++ b/android/koin-android/src/main/java/org/koin/androidx/scope/LifecycleScopeDelegate.kt
@@ -1,9 +1,8 @@
 package org.koin.androidx.scope
 
+import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.LifecycleOwner
-import androidx.lifecycle.OnLifecycleEvent
 import org.koin.core.Koin
 import org.koin.core.component.getScopeId
 import org.koin.core.component.getScopeName
@@ -32,14 +31,12 @@ class LifecycleScopeDelegate<T>(
         val logger = koin.logger
 
         logger.debug("setup scope: $_scope for $lifecycleOwner")
-        lifecycleOwner.lifecycle.addObserver(object : LifecycleObserver {
-            @OnLifecycleEvent(Lifecycle.Event.ON_CREATE)
-            fun onCreate(owner: LifecycleOwner) {
+        lifecycleOwner.lifecycle.addObserver(object : DefaultLifecycleObserver {
+            override fun onCreate(owner: LifecycleOwner) {
                 createScope()
             }
 
-            @OnLifecycleEvent(Lifecycle.Event.ON_DESTROY)
-            fun onDestroy(owner: LifecycleOwner) {
+            override fun onDestroy(owner: LifecycleOwner) {
                 logger.debug("Closing scope: $_scope for $lifecycleOwner")
                 if (_scope?.closed == false) {
                     _scope?.close()

--- a/android/koin-android/src/main/java/org/koin/androidx/scope/LifecycleViewModelScopeDelegate.kt
+++ b/android/koin-android/src/main/java/org/koin/androidx/scope/LifecycleViewModelScopeDelegate.kt
@@ -2,15 +2,10 @@ package org.koin.androidx.scope
 
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleObserver
+import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
-import androidx.lifecycle.OnLifecycleEvent
 import org.koin.core.Koin
-import org.koin.core.component.getScopeId
 import org.koin.core.component.getScopeName
-import org.koin.core.context.GlobalContext
-import org.koin.core.context.KoinContext
 import org.koin.core.scope.Scope
 import kotlin.properties.ReadOnlyProperty
 import kotlin.reflect.KProperty
@@ -34,9 +29,8 @@ class LifecycleViewModelScopeDelegate(
         _scope = koin.getScopeOrNull(scopeId) ?: createScope(koin)
         logger.debug("got scope: $_scope for $lifecycleOwner")
 
-        lifecycleOwner.lifecycle.addObserver(object : LifecycleObserver {
-            @OnLifecycleEvent(Lifecycle.Event.ON_CREATE)
-            fun onCreate(owner: LifecycleOwner) {
+        lifecycleOwner.lifecycle.addObserver(object : DefaultLifecycleObserver {
+            override fun onCreate(owner: LifecycleOwner) {
                 logger.debug("Attach ViewModel scope: $_scope to $lifecycleOwner")
                 val scopeViewModel : ScopeHandlerViewModel = (lifecycleOwner as AppCompatActivity).viewModels<ScopeHandlerViewModel>().value
                 if (scopeViewModel.scope == null) {


### PR DESCRIPTION
Minor change. It's better to use DefaultLifecycleObserver instead of OnLifecycleEvent annotation, because LifecycleObserver with annotations uses reflection for method calls. And DefaultLifecycleObserver uses the default interface methods that work in Kotlin on any Java version.
And also in the latest version of androidx.lifecycle, OnLifecycleEvent annotation is considered deprecated https://developer.android.com/jetpack/androidx/releases/lifecycle#2.4.0