### PR TITLE
Fix Ktor application _ scope closed problem

### DIFF
--- a/ktor/koin-ktor/src/main/kotlin/org/koin/ktor/ext/KoinFeature.kt
+++ b/ktor/koin-ktor/src/main/kotlin/org/koin/ktor/ext/KoinFeature.kt
@@ -17,7 +17,7 @@ package org.koin.ktor.ext
 
 import io.ktor.application.Application
 import io.ktor.application.ApplicationFeature
-import io.ktor.application.ApplicationStopping
+import io.ktor.application.ApplicationStopped
 import io.ktor.application.featureOrNull
 import io.ktor.application.install
 import io.ktor.util.AttributeKey
@@ -48,7 +48,7 @@ class Koin(internal val koinApplication: KoinApplication) {
             val koinApplication = startKoin(appDeclaration = configure)
             monitor.raise(KoinApplicationStarted, koinApplication)
 
-            monitor.subscribe(ApplicationStopping) {
+            monitor.subscribe(ApplicationStopped) {
                 monitor.raise(KoinApplicationStopPreparing, koinApplication)
                 stopKoin()
                 monitor.raise(KoinApplicationStopped, koinApplication)


### PR DESCRIPTION
While closing the application shutdown gracefully, koin scope can be closed before application stopped so we can get this error:
```
org.koin.core.error.ClosedScopeException: Scope '_' is closed
	at org.koin.core.scope.Scope.resolveInstance(Scope.kt:204)
	at org.koin.core.scope.Scope.get(Scope.kt:193)
```
To solve that issue, I changed listened application monitor event as **ApplicationStopped** instead of **ApplicationStopping**