### PR TITLE
Update the comment for `declare`

### DIFF
--- a/core/koin-core/src/commonMain/kotlin/org/koin/core/Koin.kt
+++ b/core/koin-core/src/commonMain/kotlin/org/koin/core/Koin.kt
@@ -152,7 +152,7 @@ class Koin {
      * @param instance The instance you're declaring.
      * @param qualifier Qualifier for this declaration
      * @param secondaryTypes List of secondary bound types
-     * @param override Allows to override a previous declaration of the same type (default to false).
+     * @param override Allows to override a previous declaration of the same type (default to true).
      */
     inline fun <reified T> declare(
             instance: T,

--- a/core/koin-core/src/commonMain/kotlin/org/koin/core/Koin.kt
+++ b/core/koin-core/src/commonMain/kotlin/org/koin/core/Koin.kt
@@ -152,7 +152,7 @@ class Koin {
      * @param instance The instance you're declaring.
      * @param qualifier Qualifier for this declaration
      * @param secondaryTypes List of secondary bound types
-     * @param override Allows to override a previous declaration of the same type (default to true).
+     * @param allowOverride Allows to override a previous declaration of the same type (default to true).
      */
     inline fun <reified T> declare(
             instance: T,


### PR DESCRIPTION
### What?
The comment for the `declare` function was updated to indicate the actual default value of the `allowOverride` parameter.

### Why?
The default value was changed to `true` by this [PR](https://github.com/InsertKoinIO/koin/commit/c3fdd69612f239a9f5e5f2e16d1a1b75fc443139), but the comment was accidentally left intact. 