### PR TITLE
Inline log function with message lambda

### DIFF
--- a/core/koin-core/src/commonMain/kotlin/org/koin/core/logger/Logger.kt
+++ b/core/koin-core/src/commonMain/kotlin/org/koin/core/logger/Logger.kt
@@ -24,10 +24,8 @@ abstract class Logger(var level: Level = Level.INFO) {
 
     abstract fun log(level: Level, msg: MESSAGE)
 
-    private fun canLog(level: Level): Boolean = this.level <= level
-
     private fun doLog(level: Level, msg: MESSAGE) {
-        if (canLog(level)) {
+        if (isAt(level)) {
             log(level, msg)
         }
     }
@@ -44,10 +42,12 @@ abstract class Logger(var level: Level = Level.INFO) {
         doLog(Level.ERROR, msg)
     }
 
-    fun isAt(lvl: Level): Boolean = this.level <= lvl
+    fun isAt(level: Level): Boolean = this.level <= level
 
-    fun log(lvl: Level, msg : () -> String){
-        if (isAt(lvl)) doLog(lvl,msg())
+    inline fun log(level: Level, msg: () -> MESSAGE) {
+        if (isAt(level)) {
+            log(level, msg())
+        }
     }
 }
 


### PR DESCRIPTION
Minor improvement.
When calling `log(level: Level, msg: () -> MESSAGE)` function with an **inline** modifier, no lambda object is created. This will slightly improve performance.
I also removed canLog(...) function, because it is completely similar to the isAt(...) function.