### PR TITLE
change JDK version to 11

### DIFF
--- a/.github/workflows/github-actions-ci-cd.yml
+++ b/.github/workflows/github-actions-ci-cd.yml
@@ -9,10 +9,10 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v2
 
-      - name: Set up JDK 1.8
+      - name: Set up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@v2


### PR DESCRIPTION
to fix failing CI
`Android Gradle plugin requires Java 11 to run. You are currently using Java 1.8.`