### PR TITLE
Add navigation args to `SavedStateHandle`

### DIFF
--- a/android/koin-android/build.gradle
+++ b/android/koin-android/build.gradle
@@ -22,6 +22,7 @@ android {
 
 dependencies {
     api "io.insert-koin:koin-core:$koin_version"
+    api "androidx.navigation:navigation-runtime-ktx:$androidx_nav"
 
     implementation "androidx.appcompat:appcompat:$androidx_lib_version"
 

--- a/android/koin-android/src/main/java/org/koin/androidx/viewmodel/ViewModelOwner.kt
+++ b/android/koin-android/src/main/java/org/koin/androidx/viewmodel/ViewModelOwner.kt
@@ -1,7 +1,9 @@
 package org.koin.androidx.viewmodel
 
+import android.os.Bundle
 import androidx.lifecycle.ViewModelStore
 import androidx.lifecycle.ViewModelStoreOwner
+import androidx.navigation.NavBackStackEntry
 import androidx.savedstate.SavedStateRegistryOwner
 
 typealias ViewModelOwnerDefinition = () -> ViewModelOwner
@@ -9,14 +11,24 @@ typealias ViewModelOwnerDefinition = () -> ViewModelOwner
 class ViewModelOwner(
         val store: ViewModelStore,
         val stateRegistry: SavedStateRegistryOwner? = null,
+        val defaultArgs: Bundle? = null
 ) {
     companion object {
         fun from(storeOwner: ViewModelStoreOwner, stateRegistry: SavedStateRegistryOwner? = null) = ViewModelOwner(
-                storeOwner.viewModelStore, stateRegistry)
+            storeOwner.viewModelStore,
+            stateRegistry,
+            if (storeOwner is NavBackStackEntry) storeOwner.arguments else null
+        )
 
-        fun from(storeOwner: ViewModelStoreOwner) = ViewModelOwner(storeOwner.viewModelStore)
+        fun from(storeOwner: ViewModelStoreOwner) = ViewModelOwner(
+            storeOwner.viewModelStore,
+            defaultArgs = if (storeOwner is NavBackStackEntry) storeOwner.arguments else null
+        )
 
-        fun fromAny(owner: Any) = ViewModelOwner((owner as ViewModelStoreOwner).viewModelStore,
-                owner as? SavedStateRegistryOwner)
+        fun fromAny(owner: Any) = ViewModelOwner(
+            (owner as ViewModelStoreOwner).viewModelStore,
+            owner as? SavedStateRegistryOwner,
+            if (owner is NavBackStackEntry) owner.arguments else null
+        )
     }
 }

--- a/android/koin-android/src/main/java/org/koin/androidx/viewmodel/ViewModelParameter.kt
+++ b/android/koin-android/src/main/java/org/koin/androidx/viewmodel/ViewModelParameter.kt
@@ -1,5 +1,6 @@
 package org.koin.androidx.viewmodel
 
+import android.os.Bundle
 import androidx.lifecycle.ViewModelStore
 import androidx.savedstate.SavedStateRegistryOwner
 import org.koin.androidx.viewmodel.scope.BundleDefinition
@@ -13,5 +14,6 @@ class ViewModelParameter<T : Any>(
     val state: BundleDefinition? = null,
     val parameters: ParametersDefinition? = null,
     val viewModelStore: ViewModelStore,
-    val registryOwner: SavedStateRegistryOwner? = null
+    val registryOwner: SavedStateRegistryOwner? = null,
+    val defaultArgs: Bundle? = null
 )

--- a/android/koin-android/src/main/java/org/koin/androidx/viewmodel/factory/StateViewModelFactory.kt
+++ b/android/koin-android/src/main/java/org/koin/androidx/viewmodel/factory/StateViewModelFactory.kt
@@ -13,6 +13,11 @@ class StateViewModelFactory<T : ViewModel>(
     parameters.state?.invoke()
 ) {
     override fun <T : ViewModel> create(key: String, modelClass: Class<T>, handle: SavedStateHandle): T {
+        parameters.defaultArgs?.let { args ->
+            args.keySet().forEach {
+                handle[it] = args.get(it)
+            }
+        }
         val params: ParametersDefinition = addHandle(handle)
         return scope.get(
             parameters.clazz,

--- a/android/koin-android/src/main/java/org/koin/androidx/viewmodel/scope/ScopeExt.kt
+++ b/android/koin-android/src/main/java/org/koin/androidx/viewmodel/scope/ScopeExt.kt
@@ -57,7 +57,8 @@ fun <T : ViewModel> Scope.getViewModel(
                     state,
                     parameters,
                     ownerDef.store,
-                    ownerDef.stateRegistry
+                    ownerDef.stateRegistry,
+                    ownerDef.defaultArgs
             )
     )
 }


### PR DESCRIPTION
Navigation arguments can be passed when navigating to a destination. These arguments can be passed down to `SavedStateHandle` which can be accessed directly in the `ViewModel`.