### PR TITLE
Don't cast to AppCompatActivity to support FragmentScenario

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Badges: `[UPDATED]`, `[FIXED]`, `[NEW]`, `[DEPRECATED]`, `[REMOVED]`,  `[BREAKING]`
 
+* `[FIXED]` `[android]` - Require ComponentActivity instead of AppCompatActivity in LifecycleViewModelScopeDelegate for FragmentScenario support
 
 ## [3.1.5]()
 * `[FIXED]` `[android]` - #1240 - ViewModel scope instance creation fixed

--- a/android/koin-android/src/main/java/org/koin/androidx/scope/LifecycleViewModelScopeDelegate.kt
+++ b/android/koin-android/src/main/java/org/koin/androidx/scope/LifecycleViewModelScopeDelegate.kt
@@ -1,7 +1,7 @@
 package org.koin.androidx.scope
 
+import androidx.activity.ComponentActivity
 import androidx.activity.viewModels
-import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import org.koin.core.Koin
@@ -21,7 +21,7 @@ class LifecycleViewModelScopeDelegate(
     private val scopeId = lifecycleOwner.getScopeName().value
 
     init {
-        assert(lifecycleOwner is AppCompatActivity){ "$lifecycleOwner should be an AppCompatActivity" }
+        assert(lifecycleOwner is ComponentActivity){ "$lifecycleOwner should be a ComponentActivity" }
 
         val logger = koin.logger
 
@@ -32,7 +32,7 @@ class LifecycleViewModelScopeDelegate(
         lifecycleOwner.lifecycle.addObserver(object : DefaultLifecycleObserver {
             override fun onCreate(owner: LifecycleOwner) {
                 logger.debug("Attach ViewModel scope: $_scope to $lifecycleOwner")
-                val scopeViewModel : ScopeHandlerViewModel = (lifecycleOwner as AppCompatActivity).viewModels<ScopeHandlerViewModel>().value
+                val scopeViewModel : ScopeHandlerViewModel = (lifecycleOwner as ComponentActivity).viewModels<ScopeHandlerViewModel>().value
                 if (scopeViewModel.scope == null) {
                     scopeViewModel.scope = _scope
                 }


### PR DESCRIPTION
Using ComponentActivity instead of AppCompatActivity in the
LifecycleViewModelDelegate is sufficient.
This makes it possible to use other Activity types like FragmentActivity
and thus supports testing fragments with the FragmentScenario API.