### PR TITLE
Fix a bug where source jar for koin-ktor and other kotlin projects is empty 

### DIFF
--- a/gradle/publish-to-central.gradle
+++ b/gradle/publish-to-central.gradle
@@ -19,7 +19,7 @@ if (!project.tasks.findByName('sourcesJar')) {
         if (pluginManager.hasPlugin('com.android.library')) {
             from android.sourceSets.main.java.srcDirs
         } else {
-            from sourceSets.main.java.srcDirs
+            from sourceSets.main.allSource.srcDirs
         }
     }
 }


### PR DESCRIPTION
Check the sources jar below.  It's empty as the source code for `koin-ktor` is in `src/main/kotlin` and not `src/main/java`
https://repo1.maven.org/maven2/io/insert-koin/koin-ktor/3.2.0-beta-1/koin-ktor-3.2.0-beta-1-sources.jar
this means we can't attach sources for `koin-ktor` in the ide 