### PR TITLE
Add support for scope linking in checkModules

### DIFF
--- a/core/koin-test-junit4/src/test/kotlin/org/koin/test/CheckModulesTest.kt
+++ b/core/koin-test-junit4/src/test/kotlin/org/koin/test/CheckModulesTest.kt
@@ -27,6 +27,12 @@ class CheckModulesTest {
             single { p -> Simple.ComponentB(p.get()) }
             single(named("param")) { p -> Simple.MyString(p.get()) }
             single { Simple.MyString(getProperty("aValue")) }
+            scope(named("scope1")) {
+                scoped { Simple.ComponentD() }
+            }
+            scope(named("scope2")) {
+                scoped { Simple.ComponentE(get()) }
+            }
         }
 
         koinApplication {
@@ -36,6 +42,7 @@ class CheckModulesTest {
                 //            withInstance<String>("a_parameter")
                 withParameter<String> { "a_parameter" }
                 withProperty("aValue", "string_value")
+                withScopeLink(named("scope2"), named("scope1"))
             }
         }
     }
@@ -46,12 +53,19 @@ class CheckModulesTest {
             single { p -> Simple.ComponentB(p.get()) }
             single(named("param")) { p -> Simple.MyString(p.get()) }
             single { Simple.MyString(getProperty("aValue")) }
+            scope(named("scope1")) {
+                scoped { Simple.ComponentD() }
+            }
+            scope(named("scope2")) {
+                scoped { Simple.ComponentE(get()) }
+            }
         }
 
         checkKoinModules(listOf(modules)) {
             withInstance<Simple.ComponentA>()
             withParameter<String> { "a_parameter" }
             withProperty("aValue", "string_value")
+            withScopeLink(named("scope2"), named("scope1"))
         }
     }
 
@@ -276,7 +290,7 @@ class CheckModulesTest {
                     }
                 )
             }.checkModules()
-            fail("should not pass with borken definitions")
+            fail("should not pass with broken definitions")
         } catch (e: Exception) {
             e.printStackTrace()
         }
@@ -502,6 +516,26 @@ class CheckModulesTest {
                 withProperty("aValue", "value")
                 withInstance<Simple.ComponentA>()
             }
+        }
+    }
+
+    @Test
+    fun `check a module with linked scopes`() {
+        koinApplication {
+            printLogger(Level.DEBUG)
+            properties(hashMapOf("aValue" to "value"))
+            modules(
+                module {
+                    scope<Simple.ComponentA> {
+                        scoped { Simple.ComponentD() }
+                    }
+                    scope<Simple.ComponentB> {
+                        scoped { Simple.ComponentE(get()) }
+                    }
+                }
+            )
+        }.checkModules {
+            withScopeLink<Simple.ComponentB, Simple.ComponentA>()
         }
     }
 }

--- a/core/koin-test-junit4/src/test/kotlin/org/koin/test/Components.kt
+++ b/core/koin-test-junit4/src/test/kotlin/org/koin/test/Components.kt
@@ -8,11 +8,14 @@ class Simple {
     class ComponentA
     class ComponentB(val a: ComponentA)
     class ComponentC(val b: ComponentB)
+    class ComponentD()
+    class ComponentE(val d: ComponentD)
     class MyString(val s: String)
 
     class UUIDComponent {
         fun getUUID() = UUID.randomUUID().toString()
     }
+
 }
 
 object UpperCase : Qualifier {

--- a/core/koin-test/src/commonMain/kotlin/org/koin/test/check/CheckModulesDSL.kt
+++ b/core/koin-test/src/commonMain/kotlin/org/koin/test/check/CheckModulesDSL.kt
@@ -19,6 +19,7 @@ import org.koin.core.Koin
 import org.koin.core.parameter.ParametersHolder
 import org.koin.core.parameter.parametersOf
 import org.koin.core.qualifier.Qualifier
+import org.koin.core.qualifier.qualifier
 import org.koin.mp.KoinPlatformTools
 import org.koin.test.mock.MockProvider
 import kotlin.reflect.KClass
@@ -29,6 +30,7 @@ class ParametersBinding(val koin: Koin) {
 
     val parametersCreators = mutableMapOf<CheckedComponent, ParametersCreator>()
     val defaultValues = mutableMapOf<String, Any>()
+    val scopeLinks = mutableMapOf<Qualifier, Qualifier>()
 
     @Deprecated("use withParameter() instead", ReplaceWith("withParameters(qualifier,creator)"))
     inline fun <reified T> create(qualifier: Qualifier? = null, noinline creator: ParametersCreator) =
@@ -62,6 +64,9 @@ class ParametersBinding(val koin: Koin) {
         defaultValues.put(KoinPlatformTools.getClassName(T::class), MockProvider.makeMock<T>())
 
     fun withProperty(key: String, value: Any) = koin.setProperty(key, value)
+    inline fun <reified T : Any, reified U : Any> withScopeLink() = withScopeLink(qualifier<T>(), qualifier<U>())
+    inline fun withScopeLink(scopeQualifier: Qualifier, targetScopeQualifier: Qualifier) =
+            scopeLinks.put(scopeQualifier, targetScopeQualifier)
 }
 
 typealias ParametersCreator = (Qualifier?) -> ParametersHolder

--- a/docs/reference/koin-test/checkmodules.md
+++ b/docs/reference/koin-test/checkmodules.md
@@ -226,3 +226,30 @@ fun `test DI modules`(){
     }
 }
 ```
+
+#### Providing Scope Links
+
+You can link scopes by using `withScopeLink` function in`checkModules` block to inject instances from another scope's definitions:
+
+```kotlin
+val myModule = module {
+    scope(named("scope1")) {
+        scoped { ComponentA() }
+    }
+    scope(named("scope2")) {
+        scoped { ComponentB(get()) }
+    }
+}
+```
+
+```kotlin
+@Test
+fun `test DI modules`(){
+    koinApplication {
+        modules(myModule)
+        checkModules(){
+            withScopeLink(named("scope2"), named("scope1"))
+        }
+    }
+}
+```


### PR DESCRIPTION
Enables "simulation" of linked scopes in `checkModules`. Thus, we don't have to explicitly provide default values for all of the injected instances coming from other scopes.

```kotlin
val myModule = module {
    scope(named("scope1")) {
        scoped { ComponentA() }
    }
    scope(named("scope2")) {
        scoped { ComponentB(get()) }
    }
}

scope2.linkTo(scope1)
scope2.get<ComponentB>()
```

```kotlin
@Test
fun `test DI modules`(){
    koinApplication {
        modules(myModule)
        checkModules(){
            withScopeLink(named("scope2"), named("scope1"))
        }
    }
}
```