### PR TITLE
Avoid using ExperimentalTime API

### DIFF
--- a/core/koin-core/src/commonMain/kotlin/org/koin/core/time/Measure.kt
+++ b/core/koin-core/src/commonMain/kotlin/org/koin/core/time/Measure.kt
@@ -15,28 +15,38 @@
  */
 package org.koin.core.time
 
-import kotlin.time.DurationUnit
-import kotlin.time.ExperimentalTime
 import kotlin.time.measureTime
 import kotlin.time.measureTimedValue
 
-
 /**
- * Measure functions
+ * Executes the [code] and returns the duration of execution in milliseconds.
  *
- * @author Arnaud Giuliani
+ * TODO: Use [measureTime] when it becomes stable.
  */
+internal fun measureDuration(code: () -> Unit): Double {
+    val timeSource = getTimeSource()
 
-@OptIn(ExperimentalTime::class)
-fun measureDuration(code: () -> Unit): Double {
-    return measureTime(code).toDouble(DurationUnit.MILLISECONDS)
+    val start = timeSource.mark()
+    code()
+    val end = timeSource.mark()
+
+    return (end - start) / 1_000_000.0
 }
 
 /**
- * Measure code execution and get result
+ * Executes the [code] and returns a pair of values - the result of the function execution
+ * and the duration of execution in milliseconds.
+ *
+ * TODO: Use [measureTimedValue] when it becomes stable.
  */
-@OptIn(ExperimentalTime::class)
-fun <T> measureDurationForResult(code: () -> T): Pair<T, Double> {
-    val result = measureTimedValue(code)
-    return Pair(result.value, result.duration.toDouble(DurationUnit.MILLISECONDS))
+internal fun <T> measureDurationForResult(code: () -> T): Pair<T, Double> {
+    val timeSource = getTimeSource()
+
+    val start = timeSource.mark()
+    val result = code()
+    val end = timeSource.mark()
+
+    val duration = (end - start) / 1_000_000.0
+
+    return Pair(result, duration)
 }

--- a/core/koin-core/src/commonMain/kotlin/org/koin/core/time/Measure.kt
+++ b/core/koin-core/src/commonMain/kotlin/org/koin/core/time/Measure.kt
@@ -15,14 +15,10 @@
  */
 package org.koin.core.time
 
-import kotlin.time.measureTime
-import kotlin.time.measureTimedValue
-
 /**
  * Executes the [code] and returns the duration of execution in milliseconds.
- *
- * TODO: Use [measureTime] when it becomes stable.
  */
+// TODO: Use kotlin.time API when it becomes stable
 internal fun measureDuration(code: () -> Unit): Double {
     val timeSource = getTimeSource()
 
@@ -36,9 +32,8 @@ internal fun measureDuration(code: () -> Unit): Double {
 /**
  * Executes the [code] and returns a pair of values - the result of the function execution
  * and the duration of execution in milliseconds.
- *
- * TODO: Use [measureTimedValue] when it becomes stable.
  */
+// TODO: Use kotlin.time API when it becomes stable
 internal fun <T> measureDurationForResult(code: () -> T): Pair<T, Double> {
     val timeSource = getTimeSource()
 

--- a/core/koin-core/src/commonMain/kotlin/org/koin/core/time/TimeSource.kt
+++ b/core/koin-core/src/commonMain/kotlin/org/koin/core/time/TimeSource.kt
@@ -1,0 +1,10 @@
+package org.koin.core.time
+
+internal abstract class TimeSource {
+    /**
+     * Marks a point in time on this time source in nanoseconds.
+     */
+    abstract fun mark(): Long
+}
+
+internal expect fun getTimeSource(): TimeSource

--- a/core/koin-core/src/darwinMain/kotlin/org/koin/core/time/TimeSource.kt
+++ b/core/koin-core/src/darwinMain/kotlin/org/koin/core/time/TimeSource.kt
@@ -1,0 +1,9 @@
+package org.koin.core.time
+
+import kotlin.system.getTimeNanos
+
+internal actual fun getTimeSource() = object: TimeSource() {
+    override fun mark(): Long {
+        return getTimeNanos()
+    }
+}

--- a/core/koin-core/src/jsMain/kotlin/org/koin/core/time/TimeSource.kt
+++ b/core/koin-core/src/jsMain/kotlin/org/koin/core/time/TimeSource.kt
@@ -1,0 +1,45 @@
+package org.koin.core.time
+
+import kotlin.js.Date
+import kotlin.math.roundToLong
+
+internal actual fun getTimeSource(): TimeSource {
+    val isNode = js(
+        "typeof process !== 'undefined' " +
+                "&& process.versions " +
+                "&& !!process.versions.node"
+    ) as Boolean
+
+    return if (isNode) {
+        NodeJsHrTimeSource()
+    } else {
+        val isPerformanceNowSupported = js("self.performance && !!self.performance.now") as Boolean
+        if (isPerformanceNowSupported) {
+            PerformanceNowTimeSource()
+        } else {
+            DateNowTimeSource()
+        }
+    }
+}
+
+// https://nodejs.org/api/process.html#processhrtimetime
+private class NodeJsHrTimeSource : TimeSource() {
+    override fun mark(): Long {
+        val (seconds, nanos) = js("process.hrtime()") as Array<Double>
+        return (seconds * 1_000_000_000 + nanos).roundToLong()
+    }
+}
+
+// https://developer.mozilla.org/en-US/docs/Web/API/Performance/now
+private class PerformanceNowTimeSource : TimeSource() {
+    override fun mark(): Long {
+        return (js("self.performance.now()") as Double * 1_000_000).roundToLong()
+    }
+}
+
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/now
+private class DateNowTimeSource : TimeSource() {
+    override fun mark(): Long {
+        return (Date.now() * 1_000_000).roundToLong()
+    }
+}

--- a/core/koin-core/src/jvmMain/kotlin/org/koin/core/time/TimeSource.kt
+++ b/core/koin-core/src/jvmMain/kotlin/org/koin/core/time/TimeSource.kt
@@ -1,0 +1,7 @@
+package org.koin.core.time
+
+internal actual fun getTimeSource() = object: TimeSource() {
+    override fun mark(): Long {
+        return System.nanoTime()
+    }
+}

--- a/examples/android-perfs/build.gradle
+++ b/examples/android-perfs/build.gradle
@@ -21,6 +21,10 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    kotlinOptions {
+        freeCompilerArgs += "-Xopt-in=kotlin.time.ExperimentalTime"
+    }
 }
 
 dependencies {

--- a/examples/android-perfs/src/main/java/org/koin/sample/android/main/MainActivity.kt
+++ b/examples/android-perfs/src/main/java/org/koin/sample/android/main/MainActivity.kt
@@ -6,14 +6,15 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
-import org.koin.core.time.measureDurationForResult
 import org.koin.dsl.koinApplication
 import org.koin.perfs.Perfs
 import org.koin.perfs.perfModule400
 //import org.koin.perfs.perfModule400
-import org.koin.perfs.perfModule400Ext
 //import org.koin.perfs.perfModule400Ext
 import org.koin.sample.android.R
+import kotlin.time.DurationUnit
+import kotlin.time.measureTime
+import kotlin.time.measureTimedValue
 
 class MainActivity : AppCompatActivity() {
 
@@ -38,23 +39,27 @@ class MainActivity : AppCompatActivity() {
     }
 
     fun runPerf(count: Int): Pair<Double, Double> {
-        val (app, duration) = measureDurationForResult {
+        val (app, duration) = measureTimedValue {
             koinApplication {
                 modules(perfModule400())
             }
         }
-        println("[$count] started in $duration ms")
+
+        val durationInMillis = duration.toDouble(DurationUnit.MILLISECONDS)
+        println("[$count] started in $durationInMillis ms")
 
         val koin = app.koin
 
-        val (_, executionDuration) = measureDurationForResult {
+        val executionDuration = measureTime {
             koin.get<Perfs.A27>()
             koin.get<Perfs.A31>()
             koin.get<Perfs.A12>()
             koin.get<Perfs.A42>()
         }
-        println("[$count] measured executed in $executionDuration ms")
+        val executionDurationInMillis = executionDuration.toDouble(DurationUnit.MILLISECONDS)
+
+        println("[$count] measured executed in $executionDurationInMillis ms")
         app.close()
-        return Pair(duration, executionDuration)
+        return Pair(durationInMillis, executionDurationInMillis)
     }
 }

--- a/examples/coffee-maker/build.gradle
+++ b/examples/coffee-maker/build.gradle
@@ -12,6 +12,10 @@ buildscript {
 apply plugin: 'kotlin'
 //apply plugin: 'koin'
 
+compileKotlin {
+    kotlinOptions.freeCompilerArgs += "-Xopt-in=kotlin.time.ExperimentalTime"
+}
+
 archivesBaseName = 'example-coffee-maker'
 
 dependencies {

--- a/examples/coffee-maker/src/main/kotlin/org/koin/example/CoffeeApp.kt
+++ b/examples/coffee-maker/src/main/kotlin/org/koin/example/CoffeeApp.kt
@@ -4,7 +4,8 @@ import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import org.koin.core.context.startKoin
 import org.koin.core.logger.Level
-import org.koin.core.time.measureDuration
+import kotlin.time.DurationUnit
+import kotlin.time.measureTime
 
 class CoffeeApp : KoinComponent {
     val maker: CoffeeMaker by inject()
@@ -22,8 +23,9 @@ fun main() {
     }
 }
 
-fun measureDuration(msg : String, code: () -> Unit): Double {
-    val duration = measureDuration(code)
-    println("$msg in $duration ms")
-    return duration
+fun measureDuration(msg : String, code: () -> Unit) {
+    val duration = measureTime(code)
+    val durationInMillis = duration.toDouble(DurationUnit.MILLISECONDS)
+
+    println("$msg in $durationInMillis ms")
 }


### PR DESCRIPTION
Koin breaks down after every minor update of Kotlin because of the use of the experimental time api in logging, it's just ridiculous.

Here is a fix that replaces the use of experimental functions with the use of stable ones.

Prevents the recurrence of issues like:
- https://github.com/InsertKoinIO/koin/issues/1242
- https://github.com/InsertKoinIO/koin/issues/1216
- https://github.com/InsertKoinIO/koin/issues/1188
- https://github.com/InsertKoinIO/koin/issues/1076
- https://github.com/InsertKoinIO/koin/issues/917
- https://github.com/InsertKoinIO/koin/issues/871
- https://github.com/InsertKoinIO/koin/issues/847