### PR TITLE
Fixed eager instances not working on native targets

### DIFF
--- a/core/koin-core/src/nativeMain/kotlin/org/koin/core/context/GlobalContext.kt
+++ b/core/koin-core/src/nativeMain/kotlin/org/koin/core/context/GlobalContext.kt
@@ -56,6 +56,7 @@ internal class StrictGlobalContext: KoinContext {
 
     override fun startKoin(koinApplication: KoinApplication): KoinApplication {
         register(koinApplication)
+        koinApplication.createEagerInstances()
         return koinApplication
     }
 
@@ -63,6 +64,7 @@ internal class StrictGlobalContext: KoinContext {
         val koinApplication = KoinApplication.init()
         register(koinApplication)
         appDeclaration(koinApplication)
+        koinApplication.createEagerInstances()
         return koinApplication
     }
 
@@ -111,12 +113,14 @@ internal class MutableGlobalContext:KoinContext {
     }
 
     override fun startKoin(koinApplication: KoinApplication): KoinApplication = lock.withLock {
+        println("yooooooooooooo we here2")
         register(koinApplication)
         koinApplication.createEagerInstances()
         return koinApplication
     }
 
     override fun startKoin(appDeclaration: KoinAppDeclaration): KoinApplication = lock.withLock {
+        println("yooooooooooooo we here")
         val koinApplication = KoinApplication.init()
         register(koinApplication)
         appDeclaration(koinApplication)

--- a/core/koin-core/src/nativeMain/kotlin/org/koin/core/context/GlobalContext.kt
+++ b/core/koin-core/src/nativeMain/kotlin/org/koin/core/context/GlobalContext.kt
@@ -113,14 +113,12 @@ internal class MutableGlobalContext:KoinContext {
     }
 
     override fun startKoin(koinApplication: KoinApplication): KoinApplication = lock.withLock {
-        println("yooooooooooooo we here2")
         register(koinApplication)
         koinApplication.createEagerInstances()
         return koinApplication
     }
 
     override fun startKoin(appDeclaration: KoinAppDeclaration): KoinApplication = lock.withLock {
-        println("yooooooooooooo we here")
         val koinApplication = KoinApplication.init()
         register(koinApplication)
         appDeclaration(koinApplication)


### PR DESCRIPTION
Noticed this while testing with Kotlin multiplatform. This should fix tests on CI (been failing for a while it seems)