### PR TITLE
Add Constructor DSL up to 22 parameters

### DIFF
--- a/android/koin-android/src/main/java/org/koin/androidx/fragment/dsl/FragmentOf.kt
+++ b/android/koin-android/src/main/java/org/koin/androidx/fragment/dsl/FragmentOf.kt
@@ -18,6 +18,9 @@
 package org.koin.androidx.fragment.dsl
 
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.ViewModel
+import org.koin.androidx.viewmodel.dsl.viewModel
+import org.koin.androidx.viewmodel.dsl.viewModelOf
 import org.koin.core.annotation.KoinInternalApi
 import org.koin.core.definition.BeanDefinition
 import org.koin.core.module.KoinDefinition
@@ -25,6 +28,7 @@ import org.koin.core.module.Module
 import org.koin.core.module._factoryInstanceFactory
 import org.koin.core.module.dsl.new
 import org.koin.core.module.dsl.setupInstance
+import org.koin.core.module.dsl.withOptions
 
 /**
  * Fragment Constructor DSL
@@ -34,162 +38,181 @@ import org.koin.core.module.dsl.setupInstance
  */
 inline fun <reified R : Fragment> Module.fragmentOf(
     crossinline constructor: () -> R,
-    options: BeanDefinition<R>.() -> Unit
-): KoinDefinition<R> = setupInstance(_factoryInstanceFactory(definition = { new(constructor) }), options)
-
-/**
- * @see fragmentOf
- */
-inline fun <reified R : Fragment> Module.fragmentOf(
-    crossinline constructor: () -> R,
-): KoinDefinition<R> = fragment { new(constructor) }
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = fragment { new(constructor) }.withOptions(options)
 
 /**
  * @see fragmentOf
  */
 inline fun <reified R : Fragment, reified T1> Module.fragmentOf(
     crossinline constructor: (T1) -> R,
-    options: BeanDefinition<R>.() -> Unit
-): KoinDefinition<R> = setupInstance(_factoryInstanceFactory(definition = { new(constructor) }), options)
-
-/**
- * @see fragmentOf
- */
-inline fun <reified R : Fragment, reified T1> Module.fragmentOf(
-    crossinline constructor: (T1) -> R,
-): KoinDefinition<R> = fragment { new(constructor) }
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = fragment { new(constructor) }.withOptions(options)
 
 /**
  * @see fragmentOf
  */
 inline fun <reified R : Fragment, reified T1, reified T2> Module.fragmentOf(
     crossinline constructor: (T1, T2) -> R,
-    options: BeanDefinition<R>.() -> Unit
-): KoinDefinition<R> = setupInstance(_factoryInstanceFactory(definition = { new(constructor) }), options)
-
-/**
- * @see fragmentOf
- */
-inline fun <reified R : Fragment, reified T1, reified T2> Module.fragmentOf(
-    crossinline constructor: (T1, T2) -> R,
-): KoinDefinition<R> = fragment { new(constructor) }
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = fragment { new(constructor) }.withOptions(options)
 
 /**
  * @see fragmentOf
  */
 inline fun <reified R : Fragment, reified T1, reified T2, reified T3> Module.fragmentOf(
     crossinline constructor: (T1, T2, T3) -> R,
-    options: BeanDefinition<R>.() -> Unit
-): KoinDefinition<R> = setupInstance(_factoryInstanceFactory(definition = { new(constructor) }), options)
-
-/**
- * @see fragmentOf
- */
-inline fun <reified R : Fragment, reified T1, reified T2, reified T3> Module.fragmentOf(
-    crossinline constructor: (T1, T2, T3) -> R,
-): KoinDefinition<R> = fragment { new(constructor) }
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = fragment { new(constructor) }.withOptions(options)
 
 /**
  * @see fragmentOf
  */
 inline fun <reified R : Fragment, reified T1, reified T2, reified T3, reified T4> Module.fragmentOf(
     crossinline constructor: (T1, T2, T3, T4) -> R,
-    options: BeanDefinition<R>.() -> Unit
-): KoinDefinition<R> = setupInstance(_factoryInstanceFactory(definition = { new(constructor) }), options)
-
-/**
- * @see fragmentOf
- */
-inline fun <reified R : Fragment, reified T1, reified T2, reified T3, reified T4> Module.fragmentOf(
-    crossinline constructor: (T1, T2, T3, T4) -> R,
-): KoinDefinition<R> = fragment { new(constructor) }
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = fragment { new(constructor) }.withOptions(options)
 
 /**
  * @see fragmentOf
  */
 inline fun <reified R : Fragment, reified T1, reified T2, reified T3, reified T4, reified T5> Module.fragmentOf(
     crossinline constructor: (T1, T2, T3, T4, T5) -> R,
-    options: BeanDefinition<R>.() -> Unit
-): KoinDefinition<R> = setupInstance(_factoryInstanceFactory(definition = { new(constructor) }), options)
-
-/**
- * @see fragmentOf
- */
-inline fun <reified R : Fragment, reified T1, reified T2, reified T3, reified T4, reified T5> Module.fragmentOf(
-    crossinline constructor: (T1, T2, T3, T4, T5) -> R,
-): KoinDefinition<R> = fragment { new(constructor) }
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = fragment { new(constructor) }.withOptions(options)
 
 /**
  * @see fragmentOf
  */
 inline fun <reified R : Fragment, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6> Module.fragmentOf(
     crossinline constructor: (T1, T2, T3, T4, T5, T6) -> R,
-    options: BeanDefinition<R>.() -> Unit
-): KoinDefinition<R> = setupInstance(_factoryInstanceFactory(definition = { new(constructor) }), options)
-
-/**
- * @see fragmentOf
- */
-inline fun <reified R : Fragment, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6> Module.fragmentOf(
-    crossinline constructor: (T1, T2, T3, T4, T5, T6) -> R,
-): KoinDefinition<R> = fragment { new(constructor) }
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = fragment { new(constructor) }.withOptions(options)
 
 /**
  * @see fragmentOf
  */
 inline fun <reified R : Fragment, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7> Module.fragmentOf(
     crossinline constructor: (T1, T2, T3, T4, T5, T6, T7) -> R,
-    options: BeanDefinition<R>.() -> Unit
-): KoinDefinition<R> = setupInstance(_factoryInstanceFactory(definition = { new(constructor) }), options)
-
-/**
- * @see fragmentOf
- */
-inline fun <reified R : Fragment, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7> Module.fragmentOf(
-    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7) -> R,
-): KoinDefinition<R> = fragment { new(constructor) }
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = fragment { new(constructor) }.withOptions(options)
 
 /**
  * @see fragmentOf
  */
 inline fun <reified R : Fragment, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8> Module.fragmentOf(
     crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8) -> R,
-    options: BeanDefinition<R>.() -> Unit
-): KoinDefinition<R> = setupInstance(_factoryInstanceFactory(definition = { new(constructor) }), options)
-
-/**
- * @see fragmentOf
- */
-inline fun <reified R : Fragment, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8> Module.fragmentOf(
-    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8) -> R,
-): KoinDefinition<R> = fragment { new(constructor) }
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = fragment { new(constructor) }.withOptions(options)
 
 /**
  * @see fragmentOf
  */
 inline fun <reified R : Fragment, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9> Module.fragmentOf(
     crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9) -> R,
-    options: BeanDefinition<R>.() -> Unit
-): KoinDefinition<R> = setupInstance(_factoryInstanceFactory(definition = { new(constructor) }), options)
-
-/**
- * @see fragmentOf
- */
-inline fun <reified R : Fragment, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9> Module.fragmentOf(
-    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9) -> R,
-): KoinDefinition<R> = fragment { new(constructor) }
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = fragment { new(constructor) }.withOptions(options)
 
 /**
  * @see fragmentOf
  */
 inline fun <reified R : Fragment, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10> Module.fragmentOf(
     crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10) -> R,
-    options: BeanDefinition<R>.() -> Unit
-): KoinDefinition<R> = setupInstance(_factoryInstanceFactory(definition = { new(constructor) }), options)
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = fragment { new(constructor) }.withOptions(options)
 
 /**
  * @see fragmentOf
  */
-inline fun <reified R : Fragment, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10> Module.fragmentOf(
-    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10) -> R,
-): KoinDefinition<R> = fragment { new(constructor) }
+inline fun <reified R : Fragment, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11> Module.viewModelOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11) -> R,
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = fragment { new(constructor) }.withOptions(options)
+
+/**
+ * @see fragmentOf
+ */
+inline fun <reified R : Fragment, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12> Module.viewModelOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12) -> R,
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = fragment { new(constructor) }.withOptions(options)
+
+/**
+ * @see fragmentOf
+ */
+inline fun <reified R : Fragment, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13> Module.viewModelOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13) -> R,
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = fragment { new(constructor) }.withOptions(options)
+
+/**
+ * @see fragmentOf
+ */
+inline fun <reified R : Fragment, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14> Module.viewModelOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14) -> R,
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = fragment { new(constructor) }.withOptions(options)
+
+/**
+ * @see fragmentOf
+ */
+inline fun <reified R : Fragment, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15> Module.viewModelOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15) -> R,
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = fragment { new(constructor) }.withOptions(options)
+
+/**
+ * @see fragmentOf
+ */
+inline fun <reified R : Fragment, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16> Module.viewModelOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16) -> R,
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = fragment { new(constructor) }.withOptions(options)
+
+/**
+ * @see fragmentOf
+ */
+inline fun <reified R : Fragment, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16, reified T17> Module.viewModelOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17) -> R,
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = fragment { new(constructor) }.withOptions(options)
+
+/**
+ * @see fragmentOf
+ */
+inline fun <reified R : Fragment, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16, reified T17, reified T18> Module.viewModelOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18) -> R,
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = fragment { new(constructor) }.withOptions(options)
+
+/**
+ * @see fragmentOf
+ */
+inline fun <reified R : Fragment, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16, reified T17, reified T18, reified T19> Module.viewModelOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19) -> R,
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = fragment { new(constructor) }.withOptions(options)
+
+/**
+ * @see fragmentOf
+ */
+inline fun <reified R : Fragment, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16, reified T17, reified T18, reified T19, reified T20> Module.viewModelOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20) -> R,
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = fragment { new(constructor) }.withOptions(options)
+
+/**
+ * @see fragmentOf
+ */
+inline fun <reified R : Fragment, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16, reified T17, reified T18, reified T19, reified T20, reified T21> Module.viewModelOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21) -> R,
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = fragment { new(constructor) }.withOptions(options)
+
+/**
+ * @see fragmentOf
+ */
+inline fun <reified R : Fragment, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16, reified T17, reified T18, reified T19, reified T20, reified T21, reified T22> Module.viewModelOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22) -> R,
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = fragment { new(constructor) }.withOptions(options)

--- a/android/koin-android/src/main/java/org/koin/androidx/viewmodel/dsl/ViewModelOf.kt
+++ b/android/koin-android/src/main/java/org/koin/androidx/viewmodel/dsl/ViewModelOf.kt
@@ -25,6 +25,8 @@ import org.koin.core.module.Module
 import org.koin.core.module._factoryInstanceFactory
 import org.koin.core.module.dsl.new
 import org.koin.core.module.dsl.setupInstance
+import org.koin.core.module.dsl.singleOf
+import org.koin.core.module.dsl.withOptions
 
 /**
  * Declare a [Module.viewModel] definition by resolving a constructor reference for the dependency.
@@ -45,162 +47,181 @@ import org.koin.core.module.dsl.setupInstance
  */
 inline fun <reified R : ViewModel> Module.viewModelOf(
     crossinline constructor: () -> R,
-    options: BeanDefinition<R>.() -> Unit
-): KoinDefinition<R> = setupInstance(_factoryInstanceFactory(definition = { new(constructor) }), options)
-
-/**
- * @see viewModelOf
- */
-inline fun <reified R : ViewModel> Module.viewModelOf(
-    crossinline constructor: () -> R,
-): KoinDefinition<R> = viewModel { new(constructor) }
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = viewModel { new(constructor) }.withOptions(options)
 
 /**
  * @see viewModelOf
  */
 inline fun <reified R : ViewModel, reified T1> Module.viewModelOf(
     crossinline constructor: (T1) -> R,
-    options: BeanDefinition<R>.() -> Unit
-): KoinDefinition<R> = setupInstance(_factoryInstanceFactory(definition = { new(constructor) }), options)
-
-/**
- * @see viewModelOf
- */
-inline fun <reified R : ViewModel, reified T1> Module.viewModelOf(
-    crossinline constructor: (T1) -> R,
-): KoinDefinition<R> = viewModel { new(constructor) }
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = viewModel { new(constructor) }.withOptions(options)
 
 /**
  * @see viewModelOf
  */
 inline fun <reified R : ViewModel, reified T1, reified T2> Module.viewModelOf(
     crossinline constructor: (T1, T2) -> R,
-    options: BeanDefinition<R>.() -> Unit
-): KoinDefinition<R> = setupInstance(_factoryInstanceFactory(definition = { new(constructor) }), options)
-
-/**
- * @see viewModelOf
- */
-inline fun <reified R : ViewModel, reified T1, reified T2> Module.viewModelOf(
-    crossinline constructor: (T1, T2) -> R,
-): KoinDefinition<R> = viewModel { new(constructor) }
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = viewModel { new(constructor) }.withOptions(options)
 
 /**
  * @see viewModelOf
  */
 inline fun <reified R : ViewModel, reified T1, reified T2, reified T3> Module.viewModelOf(
     crossinline constructor: (T1, T2, T3) -> R,
-    options: BeanDefinition<R>.() -> Unit
-): KoinDefinition<R> = setupInstance(_factoryInstanceFactory(definition = { new(constructor) }), options)
-
-/**
- * @see viewModelOf
- */
-inline fun <reified R : ViewModel, reified T1, reified T2, reified T3> Module.viewModelOf(
-    crossinline constructor: (T1, T2, T3) -> R,
-): KoinDefinition<R> = viewModel { new(constructor) }
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = viewModel { new(constructor) }.withOptions(options)
 
 /**
  * @see viewModelOf
  */
 inline fun <reified R : ViewModel, reified T1, reified T2, reified T3, reified T4> Module.viewModelOf(
     crossinline constructor: (T1, T2, T3, T4) -> R,
-    options: BeanDefinition<R>.() -> Unit
-): KoinDefinition<R> = setupInstance(_factoryInstanceFactory(definition = { new(constructor) }), options)
-
-/**
- * @see viewModelOf
- */
-inline fun <reified R : ViewModel, reified T1, reified T2, reified T3, reified T4> Module.viewModelOf(
-    crossinline constructor: (T1, T2, T3, T4) -> R,
-): KoinDefinition<R> = viewModel { new(constructor) }
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = viewModel { new(constructor) }.withOptions(options)
 
 /**
  * @see viewModelOf
  */
 inline fun <reified R : ViewModel, reified T1, reified T2, reified T3, reified T4, reified T5> Module.viewModelOf(
     crossinline constructor: (T1, T2, T3, T4, T5) -> R,
-    options: BeanDefinition<R>.() -> Unit
-): KoinDefinition<R> = setupInstance(_factoryInstanceFactory(definition = { new(constructor) }), options)
-
-/**
- * @see viewModelOf
- */
-inline fun <reified R : ViewModel, reified T1, reified T2, reified T3, reified T4, reified T5> Module.viewModelOf(
-    crossinline constructor: (T1, T2, T3, T4, T5) -> R,
-): KoinDefinition<R> = viewModel { new(constructor) }
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = viewModel { new(constructor) }.withOptions(options)
 
 /**
  * @see viewModelOf
  */
 inline fun <reified R : ViewModel, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6> Module.viewModelOf(
     crossinline constructor: (T1, T2, T3, T4, T5, T6) -> R,
-    options: BeanDefinition<R>.() -> Unit
-): KoinDefinition<R> = setupInstance(_factoryInstanceFactory(definition = { new(constructor) }), options)
-
-/**
- * @see viewModelOf
- */
-inline fun <reified R : ViewModel, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6> Module.viewModelOf(
-    crossinline constructor: (T1, T2, T3, T4, T5, T6) -> R,
-): KoinDefinition<R> = viewModel { new(constructor) }
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = viewModel { new(constructor) }.withOptions(options)
 
 /**
  * @see viewModelOf
  */
 inline fun <reified R : ViewModel, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7> Module.viewModelOf(
     crossinline constructor: (T1, T2, T3, T4, T5, T6, T7) -> R,
-    options: BeanDefinition<R>.() -> Unit
-): KoinDefinition<R> = setupInstance(_factoryInstanceFactory(definition = { new(constructor) }), options)
-
-/**
- * @see viewModelOf
- */
-inline fun <reified R : ViewModel, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7> Module.viewModelOf(
-    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7) -> R,
-): KoinDefinition<R> = viewModel { new(constructor) }
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = viewModel { new(constructor) }.withOptions(options)
 
 /**
  * @see viewModelOf
  */
 inline fun <reified R : ViewModel, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8> Module.viewModelOf(
     crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8) -> R,
-    options: BeanDefinition<R>.() -> Unit
-): KoinDefinition<R> = setupInstance(_factoryInstanceFactory(definition = { new(constructor) }), options)
-
-/**
- * @see viewModelOf
- */
-inline fun <reified R : ViewModel, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8> Module.viewModelOf(
-    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8) -> R,
-): KoinDefinition<R> = viewModel { new(constructor) }
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = viewModel { new(constructor) }.withOptions(options)
 
 /**
  * @see viewModelOf
  */
 inline fun <reified R : ViewModel, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9> Module.viewModelOf(
     crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9) -> R,
-    options: BeanDefinition<R>.() -> Unit
-): KoinDefinition<R> = setupInstance(_factoryInstanceFactory(definition = { new(constructor) }), options)
-
-/**
- * @see viewModelOf
- */
-inline fun <reified R : ViewModel, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9> Module.viewModelOf(
-    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9) -> R,
-): KoinDefinition<R> = viewModel { new(constructor) }
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = viewModel { new(constructor) }.withOptions(options)
 
 /**
  * @see viewModelOf
  */
 inline fun <reified R : ViewModel, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10> Module.viewModelOf(
     crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10) -> R,
-    options: BeanDefinition<R>.() -> Unit
-): KoinDefinition<R> = setupInstance(_factoryInstanceFactory(definition = { new(constructor) }), options)
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = viewModel { new(constructor) }.withOptions(options)
 
 /**
  * @see viewModelOf
  */
-inline fun <reified R : ViewModel, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10> Module.viewModelOf(
-    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10) -> R,
-): KoinDefinition<R> = viewModel { new(constructor) }
+inline fun <reified R : ViewModel, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11> Module.viewModelOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11) -> R,
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = viewModel { new(constructor) }.withOptions(options)
+
+/**
+ * @see viewModelOf
+ */
+inline fun <reified R : ViewModel, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12> Module.viewModelOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12) -> R,
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = viewModel { new(constructor) }.withOptions(options)
+
+/**
+ * @see viewModelOf
+ */
+inline fun <reified R : ViewModel, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13> Module.viewModelOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13) -> R,
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = viewModel { new(constructor) }.withOptions(options)
+
+/**
+ * @see viewModelOf
+ */
+inline fun <reified R : ViewModel, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14> Module.viewModelOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14) -> R,
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = viewModel { new(constructor) }.withOptions(options)
+
+/**
+ * @see viewModelOf
+ */
+inline fun <reified R : ViewModel, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15> Module.viewModelOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15) -> R,
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = viewModel { new(constructor) }.withOptions(options)
+
+/**
+ * @see viewModelOf
+ */
+inline fun <reified R : ViewModel, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16> Module.viewModelOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16) -> R,
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = viewModel { new(constructor) }.withOptions(options)
+
+/**
+ * @see viewModelOf
+ */
+inline fun <reified R : ViewModel, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16, reified T17> Module.viewModelOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17) -> R,
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = viewModel { new(constructor) }.withOptions(options)
+
+/**
+ * @see viewModelOf
+ */
+inline fun <reified R : ViewModel, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16, reified T17, reified T18> Module.viewModelOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18) -> R,
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = viewModel { new(constructor) }.withOptions(options)
+
+/**
+ * @see viewModelOf
+ */
+inline fun <reified R : ViewModel, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16, reified T17, reified T18, reified T19> Module.viewModelOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19) -> R,
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = viewModel { new(constructor) }.withOptions(options)
+
+/**
+ * @see viewModelOf
+ */
+inline fun <reified R : ViewModel, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16, reified T17, reified T18, reified T19, reified T20> Module.viewModelOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20) -> R,
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = viewModel { new(constructor) }.withOptions(options)
+
+/**
+ * @see viewModelOf
+ */
+inline fun <reified R : ViewModel, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16, reified T17, reified T18, reified T19, reified T20, reified T21> Module.viewModelOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21) -> R,
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = viewModel { new(constructor) }.withOptions(options)
+
+/**
+ * @see viewModelOf
+ */
+inline fun <reified R : ViewModel, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16, reified T17, reified T18, reified T19, reified T20, reified T21, reified T22> Module.viewModelOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22) -> R,
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = viewModel { new(constructor) }.withOptions(options)

--- a/android/koin-androidx-workmanager/src/main/java/org/koin/androidx/workmanager/dsl/WorkerOf.kt
+++ b/android/koin-androidx-workmanager/src/main/java/org/koin/androidx/workmanager/dsl/WorkerOf.kt
@@ -17,7 +17,10 @@
 
 package org.koin.androidx.workmanager.dsl
 
+import androidx.lifecycle.ViewModel
 import androidx.work.ListenableWorker
+import org.koin.androidx.viewmodel.dsl.viewModel
+import org.koin.androidx.viewmodel.dsl.viewModelOf
 import org.koin.core.annotation.KoinInternalApi
 import org.koin.core.definition.BeanDefinition
 import org.koin.core.module.KoinDefinition
@@ -25,6 +28,7 @@ import org.koin.core.module.Module
 import org.koin.core.module._factoryInstanceFactory
 import org.koin.core.module.dsl.new
 import org.koin.core.module.dsl.setupInstance
+import org.koin.core.module.dsl.withOptions
 
 /**
  * Fragment Constructor DSL
@@ -35,161 +39,180 @@ import org.koin.core.module.dsl.setupInstance
 inline fun <reified R : ListenableWorker> Module.workerOf(
     crossinline constructor: () -> R,
     options: BeanDefinition<R>.() -> Unit
-): KoinDefinition<R> = setupInstance(_factoryInstanceFactory(definition = { new(constructor) }), options)
+): KoinDefinition<*> = worker { new(constructor) }.withOptions(options)
 
 /**
- * @see fragmentOf
- */
-inline fun <reified R : ListenableWorker> Module.workerOf(
-    crossinline constructor: () -> R,
-): KoinDefinition<*> = worker { new(constructor) }
-
-/**
- * @see fragmentOf
+ * @see workerOf
  */
 inline fun <reified R : ListenableWorker, reified T1> Module.workerOf(
     crossinline constructor: (T1) -> R,
     options: BeanDefinition<R>.() -> Unit
-): KoinDefinition<R> = setupInstance(_factoryInstanceFactory(definition = { new(constructor) }), options)
+): KoinDefinition<*> = worker { new(constructor) }.withOptions(options)
 
 /**
- * @see fragmentOf
- */
-inline fun <reified R : ListenableWorker, reified T1> Module.workerOf(
-    crossinline constructor: (T1) -> R,
-): KoinDefinition<*> = worker { new(constructor) }
-
-/**
- * @see fragmentOf
+ * @see workerOf
  */
 inline fun <reified R : ListenableWorker, reified T1, reified T2> Module.workerOf(
     crossinline constructor: (T1, T2) -> R,
     options: BeanDefinition<R>.() -> Unit
-): KoinDefinition<R> = setupInstance(_factoryInstanceFactory(definition = { new(constructor) }), options)
+): KoinDefinition<*> = worker { new(constructor) }.withOptions(options)
 
 /**
- * @see fragmentOf
- */
-inline fun <reified R : ListenableWorker, reified T1, reified T2> Module.workerOf(
-    crossinline constructor: (T1, T2) -> R,
-): KoinDefinition<*> = worker { new(constructor) }
-
-/**
- * @see fragmentOf
+ * @see workerOf
  */
 inline fun <reified R : ListenableWorker, reified T1, reified T2, reified T3> Module.workerOf(
     crossinline constructor: (T1, T2, T3) -> R,
     options: BeanDefinition<R>.() -> Unit
-): KoinDefinition<R> = setupInstance(_factoryInstanceFactory(definition = { new(constructor) }), options)
+): KoinDefinition<*> = worker { new(constructor) }.withOptions(options)
 
 /**
- * @see fragmentOf
- */
-inline fun <reified R : ListenableWorker, reified T1, reified T2, reified T3> Module.workerOf(
-    crossinline constructor: (T1, T2, T3) -> R,
-): KoinDefinition<*> = worker { new(constructor) }
-
-/**
- * @see fragmentOf
+ * @see workerOf
  */
 inline fun <reified R : ListenableWorker, reified T1, reified T2, reified T3, reified T4> Module.workerOf(
     crossinline constructor: (T1, T2, T3, T4) -> R,
     options: BeanDefinition<R>.() -> Unit
-): KoinDefinition<R> = setupInstance(_factoryInstanceFactory(definition = { new(constructor) }), options)
+): KoinDefinition<*> = worker { new(constructor) }.withOptions(options)
 
 /**
- * @see fragmentOf
- */
-inline fun <reified R : ListenableWorker, reified T1, reified T2, reified T3, reified T4> Module.workerOf(
-    crossinline constructor: (T1, T2, T3, T4) -> R,
-): KoinDefinition<*> = worker { new(constructor) }
-
-/**
- * @see fragmentOf
+ * @see workerOf
  */
 inline fun <reified R : ListenableWorker, reified T1, reified T2, reified T3, reified T4, reified T5> Module.workerOf(
     crossinline constructor: (T1, T2, T3, T4, T5) -> R,
     options: BeanDefinition<R>.() -> Unit
-): KoinDefinition<R> = setupInstance(_factoryInstanceFactory(definition = { new(constructor) }), options)
+): KoinDefinition<*> = worker { new(constructor) }.withOptions(options)
 
 /**
- * @see fragmentOf
- */
-inline fun <reified R : ListenableWorker, reified T1, reified T2, reified T3, reified T4, reified T5> Module.workerOf(
-    crossinline constructor: (T1, T2, T3, T4, T5) -> R,
-): KoinDefinition<*> = worker { new(constructor) }
-
-/**
- * @see fragmentOf
+ * @see workerOf
  */
 inline fun <reified R : ListenableWorker, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6> Module.workerOf(
     crossinline constructor: (T1, T2, T3, T4, T5, T6) -> R,
     options: BeanDefinition<R>.() -> Unit
-): KoinDefinition<R> = setupInstance(_factoryInstanceFactory(definition = { new(constructor) }), options)
+): KoinDefinition<*> = worker { new(constructor) }.withOptions(options)
 
 /**
- * @see fragmentOf
- */
-inline fun <reified R : ListenableWorker, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6> Module.workerOf(
-    crossinline constructor: (T1, T2, T3, T4, T5, T6) -> R,
-): KoinDefinition<*> = worker { new(constructor) }
-
-/**
- * @see fragmentOf
+ * @see workerOf
  */
 inline fun <reified R : ListenableWorker, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7> Module.workerOf(
     crossinline constructor: (T1, T2, T3, T4, T5, T6, T7) -> R,
     options: BeanDefinition<R>.() -> Unit
-): KoinDefinition<R> = setupInstance(_factoryInstanceFactory(definition = { new(constructor) }), options)
+): KoinDefinition<*> = worker { new(constructor) }.withOptions(options)
 
 /**
- * @see fragmentOf
- */
-inline fun <reified R : ListenableWorker, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7> Module.workerOf(
-    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7) -> R,
-): KoinDefinition<*> = worker { new(constructor) }
-
-/**
- * @see fragmentOf
+ * @see workerOf
  */
 inline fun <reified R : ListenableWorker, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8> Module.workerOf(
     crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8) -> R,
     options: BeanDefinition<R>.() -> Unit
-): KoinDefinition<R> = setupInstance(_factoryInstanceFactory(definition = { new(constructor) }), options)
+): KoinDefinition<*> = worker { new(constructor) }.withOptions(options)
 
 /**
- * @see fragmentOf
- */
-inline fun <reified R : ListenableWorker, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8> Module.workerOf(
-    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8) -> R,
-): KoinDefinition<*> = worker { new(constructor) }
-
-/**
- * @see fragmentOf
+ * @see workerOf
  */
 inline fun <reified R : ListenableWorker, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9> Module.workerOf(
     crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9) -> R,
     options: BeanDefinition<R>.() -> Unit
-): KoinDefinition<R> = setupInstance(_factoryInstanceFactory(definition = { new(constructor) }), options)
+): KoinDefinition<*> = worker { new(constructor) }.withOptions(options)
 
 /**
- * @see fragmentOf
- */
-inline fun <reified R : ListenableWorker, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9> Module.workerOf(
-    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9) -> R,
-): KoinDefinition<*> = worker { new(constructor) }
-
-/**
- * @see fragmentOf
+ * @see workerOf
  */
 inline fun <reified R : ListenableWorker, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10> Module.workerOf(
     crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10) -> R,
     options: BeanDefinition<R>.() -> Unit
-): KoinDefinition<R> = setupInstance(_factoryInstanceFactory(definition = { new(constructor) }), options)
+): KoinDefinition<*> = worker { new(constructor) }.withOptions(options)
 
 /**
- * @see fragmentOf
+ * @see workerOf
  */
-inline fun <reified R : ListenableWorker, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10> Module.workerOf(
-    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10) -> R,
-): KoinDefinition<*> = worker { new(constructor) }
+inline fun <reified R : ListenableWorker, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11> Module.viewModelOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11) -> R,
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<*> = worker { new(constructor) }.withOptions(options)
+
+/**
+ * @see workerOf
+ */
+inline fun <reified R : ListenableWorker, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12> Module.viewModelOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12) -> R,
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<*> = worker { new(constructor) }.withOptions(options)
+
+/**
+ * @see workerOf
+ */
+inline fun <reified R : ListenableWorker, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13> Module.viewModelOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13) -> R,
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<*> = worker { new(constructor) }.withOptions(options)
+
+/**
+ * @see workerOf
+ */
+inline fun <reified R : ListenableWorker, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14> Module.viewModelOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14) -> R,
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<*> = worker { new(constructor) }.withOptions(options)
+
+/**
+ * @see workerOf
+ */
+inline fun <reified R : ListenableWorker, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15> Module.viewModelOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15) -> R,
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<*> = worker { new(constructor) }.withOptions(options)
+
+/**
+ * @see workerOf
+ */
+inline fun <reified R : ListenableWorker, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16> Module.viewModelOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16) -> R,
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<*> = worker { new(constructor) }.withOptions(options)
+
+/**
+ * @see workerOf
+ */
+inline fun <reified R : ListenableWorker, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16, reified T17> Module.viewModelOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17) -> R,
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<*> = worker { new(constructor) }.withOptions(options)
+
+/**
+ * @see workerOf
+ */
+inline fun <reified R : ListenableWorker, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16, reified T17, reified T18> Module.viewModelOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18) -> R,
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<*> = worker { new(constructor) }.withOptions(options)
+
+/**
+ * @see workerOf
+ */
+inline fun <reified R : ListenableWorker, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16, reified T17, reified T18, reified T19> Module.viewModelOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19) -> R,
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<*> = worker { new(constructor) }.withOptions(options)
+
+/**
+ * @see workerOf
+ */
+inline fun <reified R : ListenableWorker, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16, reified T17, reified T18, reified T19, reified T20> Module.viewModelOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20) -> R,
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<*> = worker { new(constructor) }.withOptions(options)
+
+/**
+ * @see workerOf
+ */
+inline fun <reified R : ListenableWorker, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16, reified T17, reified T18, reified T19, reified T20, reified T21> Module.viewModelOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21) -> R,
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<*> = worker { new(constructor) }.withOptions(options)
+
+/**
+ * @see workerOf
+ */
+inline fun <reified R : ListenableWorker, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16, reified T17, reified T18, reified T19, reified T20, reified T21, reified T22> Module.viewModelOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22) -> R,
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<*> = worker { new(constructor) }.withOptions(options)

--- a/core/koin-core/src/commonMain/kotlin/org/koin/core/module/dsl/FactoryOf.kt
+++ b/core/koin-core/src/commonMain/kotlin/org/koin/core/module/dsl/FactoryOf.kt
@@ -19,12 +19,8 @@ package org.koin.core.module.dsl
 
 import org.koin.core.annotation.KoinInternalApi
 import org.koin.core.definition.BeanDefinition
-import org.koin.core.instance.InstanceFactory
 import org.koin.core.module.KoinDefinition
 import org.koin.core.module.Module
-import org.koin.core.module._factoryInstanceFactory
-import org.koin.core.module._singleInstanceFactory
-import org.koin.core.qualifier.Qualifier
 
 /**
  * Declare a [Module.factory] definition by resolving a constructor reference for the dependency.
@@ -45,162 +41,182 @@ import org.koin.core.qualifier.Qualifier
  */
 inline fun <reified R> Module.factoryOf(
     crossinline constructor: () -> R,
-    options: BeanDefinition<R>.() -> Unit
-): KoinDefinition<R> = setupInstance(_factoryInstanceFactory(definition = { new(constructor) }), options)
-
-/**
- * @see factoryOf
- */
-inline fun <reified R> Module.factoryOf(
-    crossinline constructor: () -> R,
-): Pair<Module, InstanceFactory<R>> = factory { new(constructor) }
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = factory { new(constructor) }.withOptions(options)
 
 /**
  * @see factoryOf
  */
 inline fun <reified R, reified T1> Module.factoryOf(
     crossinline constructor: (T1) -> R,
-    options: BeanDefinition<R>.() -> Unit
-): KoinDefinition<R> = setupInstance(_factoryInstanceFactory(definition = { new(constructor) }), options)
-
-/**
- * @see factoryOf
- */
-inline fun <reified R, reified T1> Module.factoryOf(
-    crossinline constructor: (T1) -> R,
-): Pair<Module, InstanceFactory<R>> = factory { new(constructor) }
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = factory { new(constructor) }.withOptions(options)
 
 /**
  * @see factoryOf
  */
 inline fun <reified R, reified T1, reified T2> Module.factoryOf(
     crossinline constructor: (T1, T2) -> R,
-    options: BeanDefinition<R>.() -> Unit
-): KoinDefinition<R> = setupInstance(_factoryInstanceFactory(definition = { new(constructor) }), options)
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = factory { new(constructor) }.withOptions(options)
 
-/**
- * @see factoryOf
- */
-inline fun <reified R, reified T1, reified T2> Module.factoryOf(
-    crossinline constructor: (T1, T2) -> R,
-): Pair<Module, InstanceFactory<R>> = factory { new(constructor) }
 
 /**
  * @see factoryOf
  */
 inline fun <reified R, reified T1, reified T2, reified T3> Module.factoryOf(
     crossinline constructor: (T1, T2, T3) -> R,
-    options: BeanDefinition<R>.() -> Unit
-): KoinDefinition<R> = setupInstance(_factoryInstanceFactory(definition = { new(constructor) }), options)
-
-/**
- * @see factoryOf
- */
-inline fun <reified R, reified T1, reified T2, reified T3> Module.factoryOf(
-    crossinline constructor: (T1, T2, T3) -> R,
-): Pair<Module, InstanceFactory<R>> = factory { new(constructor) }
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = factory { new(constructor) }.withOptions(options)
 
 /**
  * @see factoryOf
  */
 inline fun <reified R, reified T1, reified T2, reified T3, reified T4> Module.factoryOf(
     crossinline constructor: (T1, T2, T3, T4) -> R,
-    options: BeanDefinition<R>.() -> Unit
-): KoinDefinition<R> = setupInstance(_factoryInstanceFactory(definition = { new(constructor) }), options)
-
-/**
- * @see factoryOf
- */
-inline fun <reified R, reified T1, reified T2, reified T3, reified T4> Module.factoryOf(
-    crossinline constructor: (T1, T2, T3, T4) -> R,
-): Pair<Module, InstanceFactory<R>> = factory { new(constructor) }
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = factory { new(constructor) }.withOptions(options)
 
 /**
  * @see factoryOf
  */
 inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5> Module.factoryOf(
     crossinline constructor: (T1, T2, T3, T4, T5) -> R,
-    options: BeanDefinition<R>.() -> Unit
-): KoinDefinition<R> = setupInstance(_factoryInstanceFactory(definition = { new(constructor) }), options)
-
-/**
- * @see factoryOf
- */
-inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5> Module.factoryOf(
-    crossinline constructor: (T1, T2, T3, T4, T5) -> R,
-): Pair<Module, InstanceFactory<R>> = factory { new(constructor) }
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = factory { new(constructor) }.withOptions(options)
 
 /**
  * @see factoryOf
  */
 inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6> Module.factoryOf(
     crossinline constructor: (T1, T2, T3, T4, T5, T6) -> R,
-    options: BeanDefinition<R>.() -> Unit
-): KoinDefinition<R> = setupInstance(_factoryInstanceFactory(definition = { new(constructor) }), options)
-
-/**
- * @see factoryOf
- */
-inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6> Module.factoryOf(
-    crossinline constructor: (T1, T2, T3, T4, T5, T6) -> R,
-): Pair<Module, InstanceFactory<R>> = factory { new(constructor) }
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = factory { new(constructor) }.withOptions(options)
 
 /**
  * @see factoryOf
  */
 inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7> Module.factoryOf(
     crossinline constructor: (T1, T2, T3, T4, T5, T6, T7) -> R,
-    options: BeanDefinition<R>.() -> Unit
-): KoinDefinition<R> = setupInstance(_factoryInstanceFactory(definition = { new(constructor) }), options)
-
-/**
- * @see factoryOf
- */
-inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7> Module.factoryOf(
-    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7) -> R,
-): Pair<Module, InstanceFactory<R>> = factory { new(constructor) }
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = factory { new(constructor) }.withOptions(options)
 
 /**
  * @see factoryOf
  */
 inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8> Module.factoryOf(
     crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8) -> R,
-    options: BeanDefinition<R>.() -> Unit
-): KoinDefinition<R> = setupInstance(_factoryInstanceFactory(definition = { new(constructor) }), options)
-
-/**
- * @see factoryOf
- */
-inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8> Module.factoryOf(
-    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8) -> R,
-): Pair<Module, InstanceFactory<R>> = factory { new(constructor) }
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = factory { new(constructor) }.withOptions(options)
 
 /**
  * @see factoryOf
  */
 inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9> Module.factoryOf(
     crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9) -> R,
-    options: BeanDefinition<R>.() -> Unit
-): KoinDefinition<R> = setupInstance(_factoryInstanceFactory(definition = { new(constructor) }), options)
-
-/**
- * @see factoryOf
- */
-inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9> Module.factoryOf(
-    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9) -> R,
-): Pair<Module, InstanceFactory<R>> = factory { new(constructor) }
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = factory { new(constructor) }.withOptions(options)
 
 /**
  * @see factoryOf
  */
 inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10> Module.factoryOf(
     crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10) -> R,
-    options: BeanDefinition<R>.() -> Unit
-): KoinDefinition<R> = setupInstance(_factoryInstanceFactory(definition = { new(constructor) }), options)
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = factory { new(constructor) }.withOptions(options)
 
 /**
  * @see factoryOf
  */
-inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10> Module.factoryOf(
-    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10) -> R,
-): Pair<Module, InstanceFactory<R>> = factory { new(constructor) }
+inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11> Module.factoryOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11) -> R,
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = factory { new(constructor) }.withOptions(options)
+
+/**
+ * @see factoryOf
+ */
+inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12> Module.factoryOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12) -> R,
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = factory { new(constructor) }.withOptions(options)
+
+/**
+ * @see factoryOf
+ */
+inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13> Module.factoryOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13) -> R,
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = factory { new(constructor) }.withOptions(options)
+
+/**
+ * @see factoryOf
+ */
+inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14> Module.factoryOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14) -> R,
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = factory { new(constructor) }.withOptions(options)
+
+/**
+ * @see factoryOf
+ */
+inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15> Module.factoryOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15) -> R,
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = factory { new(constructor) }.withOptions(options)
+
+/**
+ * @see factoryOf
+ */
+inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16> Module.factoryOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16) -> R,
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = factory { new(constructor) }.withOptions(options)
+
+/**
+ * @see factoryOf
+ */
+inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16, reified T17> Module.factoryOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17) -> R,
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = factory { new(constructor) }.withOptions(options)
+
+/**
+ * @see factoryOf
+ */
+inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16, reified T17, reified T18> Module.factoryOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18) -> R,
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = factory { new(constructor) }.withOptions(options)
+
+/**
+ * @see factoryOf
+ */
+inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16, reified T17, reified T18, reified T19> Module.factoryOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19) -> R,
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = factory { new(constructor) }.withOptions(options)
+
+/**
+ * @see factoryOf
+ */
+inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16, reified T17, reified T18, reified T19, reified T20> Module.factoryOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20) -> R,
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = factory { new(constructor) }.withOptions(options)
+
+/**
+ * @see factoryOf
+ */
+inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16, reified T17, reified T18, reified T19, reified T20, reified T21> Module.factoryOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21) -> R,
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = factory { new(constructor) }.withOptions(options)
+
+/**
+ * @see factoryOf
+ */
+inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16, reified T17, reified T18, reified T19, reified T20, reified T21, reified T22> Module.factoryOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22) -> R,
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = factory { new(constructor) }.withOptions(options)

--- a/core/koin-core/src/commonMain/kotlin/org/koin/core/module/dsl/New.kt
+++ b/core/koin-core/src/commonMain/kotlin/org/koin/core/module/dsl/New.kt
@@ -103,3 +103,87 @@ inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T
 inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10> Scope.new(
     constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10) -> R,
 ): R = constructor(get(), get(), get(), get(), get(), get(), get(), get(), get(), get())
+
+/**
+ * @see new
+ */
+inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11> Scope.new(
+    constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11) -> R,
+): R = constructor(get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get())
+
+/**
+ * @see new
+ */
+inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12> Scope.new(
+    constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12) -> R,
+): R = constructor(get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(),get())
+
+/**
+ * @see new
+ */
+inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13> Scope.new(
+    constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13) -> R,
+): R = constructor(get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(),get(), get())
+
+/**
+ * @see new
+ */
+inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14> Scope.new(
+    constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14) -> R,
+): R = constructor(get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(),get(), get(), get())
+
+/**
+ * @see new
+ */
+inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15> Scope.new(
+    constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15) -> R,
+): R = constructor(get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(),get(), get(), get(), get())
+
+/**
+ * @see new
+ */
+inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16> Scope.new(
+    constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16) -> R,
+): R = constructor(get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(),get(), get(), get(), get(), get())
+
+/**
+ * @see new
+ */
+inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16, reified T17> Scope.new(
+    constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17) -> R,
+): R = constructor(get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(),get(), get(), get(), get(), get(), get())
+
+/**
+ * @see new
+ */
+inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16, reified T17, reified T18> Scope.new(
+    constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18) -> R,
+): R = constructor(get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(),get(), get(), get(), get(), get(), get(), get())
+
+/**
+ * @see new
+ */
+inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16, reified T17, reified T18, reified T19> Scope.new(
+    constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19) -> R,
+): R = constructor(get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(),get(), get(), get(), get(), get(), get(), get(), get())
+
+/**
+ * @see new
+ */
+inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16, reified T17, reified T18, reified T19, reified T20> Scope.new(
+    constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20) -> R,
+): R = constructor(get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(),get(), get(), get(), get(), get(), get(), get(), get(), get())
+
+/**
+ * @see new
+ */
+inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16, reified T17, reified T18, reified T19, reified T20, reified T21> Scope.new(
+    constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21) -> R,
+): R = constructor(get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(),get(), get(), get(), get(), get(), get(), get(), get(), get(), get())
+
+/**
+ * @see new
+ */
+inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16, reified T17, reified T18, reified T19, reified T20, reified T21, reified T22> Scope.new(
+    constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22) -> R,
+): R = constructor(get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get(),get(), get(), get(), get(), get(), get(), get(), get(), get(), get(), get())

--- a/core/koin-core/src/commonMain/kotlin/org/koin/core/module/dsl/OptionDSL.kt
+++ b/core/koin-core/src/commonMain/kotlin/org/koin/core/module/dsl/OptionDSL.kt
@@ -19,8 +19,7 @@ import kotlin.reflect.KClass
  *
  * @author Arnaud Giuliani
  */
-
-infix fun <T> KoinDefinition<T>.withOptions(
+inline infix fun <T> KoinDefinition<T>.withOptions(
     options: BeanDefinition<T>.() -> Unit
 ): KoinDefinition<T> {
     val factory = second
@@ -28,7 +27,7 @@ infix fun <T> KoinDefinition<T>.withOptions(
     val def = second.beanDefinition
     val primary = def.qualifier
     def.also(options)
-    if (def.qualifier != primary){
+    if (def.qualifier != primary) {
         module.indexPrimaryType(factory)
     }
     module.indexSecondaryTypes(factory)

--- a/core/koin-core/src/commonMain/kotlin/org/koin/core/module/dsl/ScopedOf.kt
+++ b/core/koin-core/src/commonMain/kotlin/org/koin/core/module/dsl/ScopedOf.kt
@@ -44,162 +44,181 @@ import org.koin.dsl.ScopeDSL
  */
 inline fun <reified R> ScopeDSL.scopedOf(
     crossinline constructor: () -> R,
-    options: BeanDefinition<R>.() -> Unit
-): KoinDefinition<R> = module.setupInstance(_scopedInstanceFactory(definition = { new(constructor) }, scopeQualifier = scopeQualifier), options)
-
-/**
- * @see scopedOf
- */
-inline fun <reified R> ScopeDSL.scopedOf(
-    crossinline constructor: () -> R,
-): KoinDefinition<R> = scoped { new(constructor) }
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = scoped { new(constructor) }.withOptions(options)
 
 /**
  * @see scopedOf
  */
 inline fun <reified R, reified T1> ScopeDSL.scopedOf(
     crossinline constructor: (T1) -> R,
-    options: BeanDefinition<R>.() -> Unit
-): KoinDefinition<R> = module.setupInstance(_scopedInstanceFactory(definition = { new(constructor) }, scopeQualifier = scopeQualifier), options)
-
-/**
- * @see scopedOf
- */
-inline fun <reified R, reified T1> ScopeDSL.scopedOf(
-    crossinline constructor: (T1) -> R,
-): KoinDefinition<R> = scoped { new(constructor) }
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = scoped { new(constructor) }.withOptions(options)
 
 /**
  * @see scopedOf
  */
 inline fun <reified R, reified T1, reified T2> ScopeDSL.scopedOf(
     crossinline constructor: (T1, T2) -> R,
-    options: BeanDefinition<R>.() -> Unit
-): KoinDefinition<R> = module.setupInstance(_scopedInstanceFactory(definition = { new(constructor) }, scopeQualifier = scopeQualifier), options)
-
-/**
- * @see scopedOf
- */
-inline fun <reified R, reified T1, reified T2> ScopeDSL.scopedOf(
-    crossinline constructor: (T1, T2) -> R,
-): KoinDefinition<R> = scoped { new(constructor) }
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = scoped { new(constructor) }.withOptions(options)
 
 /**
  * @see scopedOf
  */
 inline fun <reified R, reified T1, reified T2, reified T3> ScopeDSL.scopedOf(
     crossinline constructor: (T1, T2, T3) -> R,
-    options: BeanDefinition<R>.() -> Unit
-): KoinDefinition<R> = module.setupInstance(_scopedInstanceFactory(definition = { new(constructor) }, scopeQualifier = scopeQualifier), options)
-
-/**
- * @see scopedOf
- */
-inline fun <reified R, reified T1, reified T2, reified T3> ScopeDSL.scopedOf(
-    crossinline constructor: (T1, T2, T3) -> R,
-): KoinDefinition<R> = scoped { new(constructor) }
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = scoped { new(constructor) }.withOptions(options)
 
 /**
  * @see scopedOf
  */
 inline fun <reified R, reified T1, reified T2, reified T3, reified T4> ScopeDSL.scopedOf(
     crossinline constructor: (T1, T2, T3, T4) -> R,
-    options: BeanDefinition<R>.() -> Unit
-): KoinDefinition<R> = module.setupInstance(_scopedInstanceFactory(definition = { new(constructor) }, scopeQualifier = scopeQualifier), options)
-
-/**
- * @see scopedOf
- */
-inline fun <reified R, reified T1, reified T2, reified T3, reified T4> ScopeDSL.scopedOf(
-    crossinline constructor: (T1, T2, T3, T4) -> R,
-): KoinDefinition<R> = scoped { new(constructor) }
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = scoped { new(constructor) }.withOptions(options)
 
 /**
  * @see scopedOf
  */
 inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5> ScopeDSL.scopedOf(
     crossinline constructor: (T1, T2, T3, T4, T5) -> R,
-    options: BeanDefinition<R>.() -> Unit
-): KoinDefinition<R> = module.setupInstance(_scopedInstanceFactory(definition = { new(constructor) }, scopeQualifier = scopeQualifier), options)
-
-/**
- * @see scopedOf
- */
-inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5> ScopeDSL.scopedOf(
-    crossinline constructor: (T1, T2, T3, T4, T5) -> R,
-): KoinDefinition<R> = scoped { new(constructor) }
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = scoped { new(constructor) }.withOptions(options)
 
 /**
  * @see scopedOf
  */
 inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6> ScopeDSL.scopedOf(
     crossinline constructor: (T1, T2, T3, T4, T5, T6) -> R,
-    options: BeanDefinition<R>.() -> Unit
-): KoinDefinition<R> = module.setupInstance(_scopedInstanceFactory(definition = { new(constructor) }, scopeQualifier = scopeQualifier), options)
-
-/**
- * @see scopedOf
- */
-inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6> ScopeDSL.scopedOf(
-    crossinline constructor: (T1, T2, T3, T4, T5, T6) -> R,
-): KoinDefinition<R> = scoped { new(constructor) }
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = scoped { new(constructor) }.withOptions(options)
 
 /**
  * @see scopedOf
  */
 inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7> ScopeDSL.scopedOf(
     crossinline constructor: (T1, T2, T3, T4, T5, T6, T7) -> R,
-    options: BeanDefinition<R>.() -> Unit
-): KoinDefinition<R> = module.setupInstance(_scopedInstanceFactory(definition = { new(constructor) }, scopeQualifier = scopeQualifier), options)
-
-/**
- * @see scopedOf
- */
-inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7> ScopeDSL.scopedOf(
-    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7) -> R,
-): KoinDefinition<R> = scoped { new(constructor) }
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = scoped { new(constructor) }.withOptions(options)
 
 /**
  * @see scopedOf
  */
 inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8> ScopeDSL.scopedOf(
     crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8) -> R,
-    options: BeanDefinition<R>.() -> Unit
-): KoinDefinition<R> = module.setupInstance(_scopedInstanceFactory(definition = { new(constructor) }, scopeQualifier = scopeQualifier), options)
-
-/**
- * @see scopedOf
- */
-inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8> ScopeDSL.scopedOf(
-    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8) -> R,
-): KoinDefinition<R> = scoped { new(constructor) }
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = scoped { new(constructor) }.withOptions(options)
 
 /**
  * @see scopedOf
  */
 inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9> ScopeDSL.scopedOf(
     crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9) -> R,
-    options: BeanDefinition<R>.() -> Unit
-): KoinDefinition<R> = module.setupInstance(_scopedInstanceFactory(definition = { new(constructor) }, scopeQualifier = scopeQualifier), options)
-
-/**
- * @see scopedOf
- */
-inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9> ScopeDSL.scopedOf(
-    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9) -> R,
-): KoinDefinition<R> = scoped { new(constructor) }
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = scoped { new(constructor) }.withOptions(options)
 
 /**
  * @see scopedOf
  */
 inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10> ScopeDSL.scopedOf(
     crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10) -> R,
-    options: BeanDefinition<R>.() -> Unit
-): KoinDefinition<R> = module.setupInstance(_scopedInstanceFactory(definition = { new(constructor) }, scopeQualifier = scopeQualifier), options)
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = scoped { new(constructor) }.withOptions(options)
 
 /**
  * @see scopedOf
  */
-inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10> ScopeDSL.scopedOf(
-    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10) -> R,
-): KoinDefinition<R> = scoped { new(constructor) }
+inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16, reified T17, reified T18, reified T19, reified T20, reified T21, reified T22> ScopeDSL.scopedOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11) -> R,
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = scoped { new(constructor) }.withOptions(options)
+
+/**
+ * @see scopedOf
+ */
+inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16, reified T17, reified T18, reified T19, reified T20, reified T21, reified T22> ScopeDSL.scopedOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12) -> R,
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = scoped { new(constructor) }.withOptions(options)
+
+/**
+ * @see scopedOf
+ */
+inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16, reified T17, reified T18, reified T19, reified T20, reified T21, reified T22> ScopeDSL.scopedOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13) -> R,
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = scoped { new(constructor) }.withOptions(options)
+
+/**
+ * @see scopedOf
+ */
+inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16, reified T17, reified T18, reified T19, reified T20, reified T21, reified T22> ScopeDSL.scopedOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14) -> R,
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = scoped { new(constructor) }.withOptions(options)
+
+/**
+ * @see scopedOf
+ */
+inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16, reified T17, reified T18, reified T19, reified T20, reified T21, reified T22> ScopeDSL.scopedOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15) -> R,
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = scoped { new(constructor) }.withOptions(options)
+
+/**
+ * @see scopedOf
+ */
+inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16, reified T17, reified T18, reified T19, reified T20, reified T21, reified T22> ScopeDSL.scopedOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16) -> R,
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = scoped { new(constructor) }.withOptions(options)
+
+/**
+ * @see scopedOf
+ */
+inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16, reified T17, reified T18, reified T19, reified T20, reified T21, reified T22> ScopeDSL.scopedOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17) -> R,
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = scoped { new(constructor) }.withOptions(options)
+
+/**
+ * @see scopedOf
+ */
+inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16, reified T17, reified T18, reified T19, reified T20, reified T21, reified T22> ScopeDSL.scopedOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18) -> R,
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = scoped { new(constructor) }.withOptions(options)
+
+/**
+ * @see scopedOf
+ */
+inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16, reified T17, reified T18, reified T19, reified T20, reified T21, reified T22> ScopeDSL.scopedOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19) -> R,
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = scoped { new(constructor) }.withOptions(options)
+
+/**
+ * @see scopedOf
+ */
+inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16, reified T17, reified T18, reified T19, reified T20, reified T21, reified T22> ScopeDSL.scopedOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20) -> R,
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = scoped { new(constructor) }.withOptions(options)
+
+/**
+ * @see scopedOf
+ */
+inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16, reified T17, reified T18, reified T19, reified T20, reified T21, reified T22> ScopeDSL.scopedOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21) -> R,
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = scoped { new(constructor) }.withOptions(options)
+
+/**
+ * @see scopedOf
+ */
+inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16, reified T17, reified T18, reified T19, reified T20, reified T21, reified T22> ScopeDSL.scopedOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22) -> R,
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = scoped { new(constructor) }.withOptions(options)

--- a/core/koin-core/src/commonMain/kotlin/org/koin/core/module/dsl/SingleOf.kt
+++ b/core/koin-core/src/commonMain/kotlin/org/koin/core/module/dsl/SingleOf.kt
@@ -19,10 +19,8 @@ package org.koin.core.module.dsl
 
 import org.koin.core.annotation.KoinInternalApi
 import org.koin.core.definition.BeanDefinition
-import org.koin.core.instance.InstanceFactory
 import org.koin.core.module.KoinDefinition
 import org.koin.core.module.Module
-import org.koin.core.module._singleInstanceFactory
 
 /**
  * Declare a [Module.single] definition by resolving a constructor reference for the dependency.
@@ -41,191 +39,183 @@ import org.koin.core.module._singleInstanceFactory
  *
  * @see new
  */
-
-
 inline fun <reified R> Module.singleOf(
     crossinline constructor: () -> R,
-    options: BeanDefinition<R>.() -> Unit
-): KoinDefinition<R> {
-    return setupInstance(_singleInstanceFactory(definition = { new(constructor) }), options)
-}
-
-/**
- * @see singleOf
- */
-inline fun <reified R> Module.singleOf(
-    crossinline constructor: () -> R,
-): KoinDefinition<R> = single { new(constructor) }
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = single { new(constructor) }.withOptions(options)
 
 /**
  * @see singleOf
  */
 inline fun <reified R, reified T1> Module.singleOf(
     crossinline constructor: (T1) -> R,
-    options: BeanDefinition<R>.() -> Unit
-): KoinDefinition<R> {
-    return setupInstance(_singleInstanceFactory(definition = { new(constructor) }), options)
-}
-
-/**
- * @see singleOf
- */
-inline fun <reified R, reified T1> Module.singleOf(
-    crossinline constructor: (T1) -> R,
-): Pair<Module, InstanceFactory<R>> = single { new(constructor) }
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = single { new(constructor) }.withOptions(options)
 
 /**
  * @see singleOf
  */
 inline fun <reified R, reified T1, reified T2> Module.singleOf(
     crossinline constructor: (T1, T2) -> R,
-    options: BeanDefinition<R>.() -> Unit
-): KoinDefinition<R> {
-    return setupInstance(_singleInstanceFactory(definition = { new(constructor) }), options)
-}
-
-/**
- * @see singleOf
- */
-inline fun <reified R, reified T1, reified T2> Module.singleOf(
-    crossinline constructor: (T1, T2) -> R,
-): Pair<Module, InstanceFactory<R>> = single { new(constructor) }
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = single { new(constructor) }.withOptions(options)
 
 /**
  * @see singleOf
  */
 inline fun <reified R, reified T1, reified T2, reified T3> Module.singleOf(
     crossinline constructor: (T1, T2, T3) -> R,
-    options: BeanDefinition<R>.() -> Unit
-): KoinDefinition<R> {
-    return setupInstance(_singleInstanceFactory(definition = { new(constructor) }), options)
-}
-
-/**
- * @see singleOf
- */
-inline fun <reified R, reified T1, reified T2, reified T3> Module.singleOf(
-    crossinline constructor: (T1, T2, T3) -> R,
-): Pair<Module, InstanceFactory<R>> = single { new(constructor) }
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = single { new(constructor) }.withOptions(options)
 
 /**
  * @see singleOf
  */
 inline fun <reified R, reified T1, reified T2, reified T3, reified T4> Module.singleOf(
     crossinline constructor: (T1, T2, T3, T4) -> R,
-    options: BeanDefinition<R>.() -> Unit
-): KoinDefinition<R> {
-    return setupInstance(_singleInstanceFactory(definition = { new(constructor) }), options)
-}
-
-/**
- * @see singleOf
- */
-inline fun <reified R, reified T1, reified T2, reified T3, reified T4> Module.singleOf(
-    crossinline constructor: (T1, T2, T3, T4) -> R,
-): Pair<Module, InstanceFactory<R>> = single { new(constructor) }
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = single { new(constructor) }.withOptions(options)
 
 /**
  * @see singleOf
  */
 inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5> Module.singleOf(
     crossinline constructor: (T1, T2, T3, T4, T5) -> R,
-    options: BeanDefinition<R>.() -> Unit
-): KoinDefinition<R> {
-    return setupInstance(_singleInstanceFactory(definition = { new(constructor) }), options)
-}
-
-/**
- * @see singleOf
- */
-inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5> Module.singleOf(
-    crossinline constructor: (T1, T2, T3, T4, T5) -> R,
-): Pair<Module, InstanceFactory<R>> = single { new(constructor) }
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = single { new(constructor) }.withOptions(options)
 
 /**
  * @see singleOf
  */
 inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6> Module.singleOf(
     crossinline constructor: (T1, T2, T3, T4, T5, T6) -> R,
-    options: BeanDefinition<R>.() -> Unit
-): KoinDefinition<R> {
-    return setupInstance(_singleInstanceFactory(definition = { new(constructor) }), options)
-}
-
-/**
- * @see singleOf
- */
-inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6> Module.singleOf(
-    crossinline constructor: (T1, T2, T3, T4, T5, T6) -> R,
-): Pair<Module, InstanceFactory<R>> = single { new(constructor) }
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = single { new(constructor) }.withOptions(options)
 
 /**
  * @see singleOf
  */
 inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7> Module.singleOf(
     crossinline constructor: (T1, T2, T3, T4, T5, T6, T7) -> R,
-    options: BeanDefinition<R>.() -> Unit
-): KoinDefinition<R> {
-    return setupInstance(_singleInstanceFactory(definition = { new(constructor) }), options)
-}
-
-/**
- * @see singleOf
- */
-inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7> Module.singleOf(
-    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7) -> R,
-): Pair<Module, InstanceFactory<R>> = single { new(constructor) }
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = single { new(constructor) }.withOptions(options)
 
 /**
  * @see singleOf
  */
 inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8> Module.singleOf(
     crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8) -> R,
-    options: BeanDefinition<R>.() -> Unit
-): KoinDefinition<R> {
-    return setupInstance(_singleInstanceFactory(definition = { new(constructor) }), options)
-}
-
-
-/**
- * @see singleOf
- */
-inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8> Module.singleOf(
-    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8) -> R,
-): Pair<Module, InstanceFactory<R>> = single { new(constructor) }
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = single { new(constructor) }.withOptions(options)
 
 /**
  * @see singleOf
  */
 inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9> Module.singleOf(
     crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9) -> R,
-    options: BeanDefinition<R>.() -> Unit
-): KoinDefinition<R> {
-    return setupInstance(_singleInstanceFactory(definition = { new(constructor) }), options)
-}
-
-
-/**
- * @see singleOf
- */
-inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9> Module.singleOf(
-    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9) -> R,
-): Pair<Module, InstanceFactory<R>> = single { new(constructor) }
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = single { new(constructor) }.withOptions(options)
 
 /**
  * @see singleOf
  */
 inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10> Module.singleOf(
     crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10) -> R,
-    options: BeanDefinition<R>.() -> Unit
-): KoinDefinition<R> {
-    return setupInstance(_singleInstanceFactory(definition = { new(constructor) }), options)
-}
-
+    options: (BeanDefinition<R>.() -> Unit) = {},
+): KoinDefinition<R> = single { new(constructor) }.withOptions(options)
 
 /**
  * @see singleOf
  */
-inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10> Module.singleOf(
-    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10) -> R,
-): Pair<Module, InstanceFactory<R>> = single { new(constructor) }
+inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11> Module.singleOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11) -> R,
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = single { new(constructor) }.withOptions(options)
+
+/**
+ * @see singleOf
+ */
+inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12> Module.singleOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12) -> R,
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = single { new(constructor) }.withOptions(options)
+
+/**
+ * @see singleOf
+ */
+inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13> Module.singleOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13) -> R,
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = single { new(constructor) }.withOptions(options)
+
+/**
+ * @see singleOf
+ */
+inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14> Module.singleOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14) -> R,
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = single { new(constructor) }.withOptions(options)
+
+/**
+ * @see singleOf
+ */
+inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15> Module.singleOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15) -> R,
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = single { new(constructor) }.withOptions(options)
+
+/**
+ * @see singleOf
+ */
+inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16> Module.singleOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16) -> R,
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = single { new(constructor) }.withOptions(options)
+
+/**
+ * @see singleOf
+ */
+inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16, reified T17> Module.singleOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17) -> R,
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = single { new(constructor) }.withOptions(options)
+
+/**
+ * @see singleOf
+ */
+inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16, reified T17, reified T18> Module.singleOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18) -> R,
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = single { new(constructor) }.withOptions(options)
+
+/**
+ * @see singleOf
+ */
+inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16, reified T17, reified T18, reified T19> Module.singleOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19) -> R,
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = single { new(constructor) }.withOptions(options)
+
+/**
+ * @see singleOf
+ */
+inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16, reified T17, reified T18, reified T19, reified T20> Module.singleOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20) -> R,
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = single { new(constructor) }.withOptions(options)
+
+/**
+ * @see singleOf
+ */
+inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16, reified T17, reified T18, reified T19, reified T20, reified T21> Module.singleOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21) -> R,
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = single { new(constructor) }.withOptions(options)
+
+/**
+ * @see singleOf
+ */
+inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16, reified T17, reified T18, reified T19, reified T20, reified T21, reified T22> Module.singleOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22) -> R,
+    crossinline options: BeanDefinition<R>.() -> Unit = {},
+): KoinDefinition<R> = single { new(constructor) }.withOptions(options)


### PR DESCRIPTION
Add constructor DSL up to 22 parameters for: `new`, `singleOf`, `factoryOf`, `scopedOf`, `viewModelOf`, `workerOf`, `fragmentOf`. It also simplifies the constructor's internal implementation by inlining `withOptions` (if empty, the inlined `options` parameter should not create an instance and thus performance should not be impacted).

Note 22 was chosed due to the Kotlin STD Lib using that number. To keep it synchronized with the STD Lib, we won't be adding more than 22.

Fixes #1342.