### PR TITLE
change the id variable in the Module to generateId

### DIFF
--- a/core/koin-core/src/commonMain/kotlin/org/koin/core/module/Module.kt
+++ b/core/koin-core/src/commonMain/kotlin/org/koin/core/module/Module.kt
@@ -39,7 +39,7 @@ class Module(
     @PublishedApi
     internal val _createdAtStart: Boolean = false
 ) {
-    val id = KoinPlatformTools.generateId()
+    val generateId = KoinPlatformTools.generateId()
 
     var eagerInstances = hashSetOf<SingleInstanceFactory<*>>()
         internal set
@@ -179,13 +179,13 @@ class Module(
 
         other as Module
 
-        if (id != other.id) return false
+        if (generateId != other.generateId) return false
 
         return true
     }
 
     override fun hashCode(): Int {
-        return id.hashCode()
+        return generateId.hashCode()
     }
 }
 


### PR DESCRIPTION
when using Koin Annotation, where for the naming of the module to be injected is based on the packageName.

When I use packageName id.*** it causes failure when generating, because it is assumed to be the id of the module