### PR TITLE
Add viewmodel get key to koin, and add KoinViewModelLazy class

### DIFF
--- a/android/koin-android-compat/src/main/java/org/koin/android/compat/ScopeCompat.kt
+++ b/android/koin-android-compat/src/main/java/org/koin/android/compat/ScopeCompat.kt
@@ -16,8 +16,8 @@
 package org.koin.android.compat
 
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.ViewModelLazy
 import androidx.lifecycle.ViewModelStoreOwner
+import org.koin.androidx.viewmodel.KoinViewModelLazy
 import org.koin.androidx.viewmodel.ViewModelParameter
 import org.koin.androidx.viewmodel.pickFactory
 import org.koin.core.annotation.KoinInternalApi
@@ -49,11 +49,12 @@ object ScopeCompat {
         scope: Scope,
         owner: ViewModelStoreOwner,
         clazz: Class<T>,
+        key: String? = null,
         qualifier: Qualifier? = null,
         parameters: ParametersDefinition? = null
-    ): ViewModelLazy<T> {
+    ): KoinViewModelLazy<T> {
         val viewModelClass = clazz.kotlin
-        return ViewModelLazy(viewModelClass, { owner.viewModelStore }){
+        return KoinViewModelLazy(viewModelClass, key, { owner.viewModelStore }){
             val viewModelParameters = ViewModelParameter(
                 clazz = viewModelClass,
                 qualifier = qualifier,
@@ -78,9 +79,10 @@ object ScopeCompat {
         scope: Scope,
         owner: ViewModelStoreOwner,
         clazz: Class<T>,
+        key: String? = null,
         qualifier: Qualifier? = null,
         parameters: ParametersDefinition? = null
     ): T {
-        return viewModel(scope, owner, clazz, qualifier,parameters).value
+        return viewModel(scope, owner, clazz, key, qualifier,parameters).value
     }
 }

--- a/android/koin-android-compat/src/main/java/org/koin/android/compat/SharedViewModelCompat.kt
+++ b/android/koin-android-compat/src/main/java/org/koin/android/compat/SharedViewModelCompat.kt
@@ -43,10 +43,11 @@ object SharedViewModelCompat {
     fun <T : ViewModel> sharedViewModel(
         fragment: Fragment,
         clazz: Class<T>,
+        key: String? = null,
         qualifier: Qualifier? = null,
         parameters: ParametersDefinition? = null,
     ): Lazy<T> =
-        ViewModelCompat.viewModel(lazy(LazyThreadSafetyMode.NONE) { fragment.requireActivity() }, clazz, qualifier, parameters)
+        ViewModelCompat.viewModel(lazy(LazyThreadSafetyMode.NONE) { fragment.requireActivity() }, clazz, key, qualifier, parameters)
 
     /**
      * Get a shared viewModel instance from underlying Activity
@@ -62,9 +63,10 @@ object SharedViewModelCompat {
     fun <T : ViewModel> getSharedViewModel(
         fragment: Fragment,
         clazz: Class<T>,
+        key: String? = null,
         qualifier: Qualifier? = null,
         parameters: ParametersDefinition? = null,
     ): T {
-        return sharedViewModel(fragment, clazz, qualifier, parameters).value
+        return sharedViewModel(fragment, clazz, key, qualifier, parameters).value
     }
 }

--- a/android/koin-android-compat/src/main/java/org/koin/android/compat/ViewModelCompat.kt
+++ b/android/koin-android-compat/src/main/java/org/koin/android/compat/ViewModelCompat.kt
@@ -16,8 +16,8 @@
 package org.koin.android.compat
 
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.ViewModelLazy
 import androidx.lifecycle.ViewModelStoreOwner
+import org.koin.androidx.viewmodel.KoinViewModelLazy
 import org.koin.androidx.viewmodel.ViewModelParameter
 import org.koin.androidx.viewmodel.pickFactory
 import org.koin.core.annotation.KoinInternalApi
@@ -48,12 +48,14 @@ object ViewModelCompat {
     fun <T : ViewModel> viewModel(
         owner: Lazy<ViewModelStoreOwner>,
         clazz: Class<T>,
+        key: String? = null,
         qualifier: Qualifier? = null,
         parameters: ParametersDefinition? = null
     ): Lazy<T>{
         val scope = GlobalContext.get().scopeRegistry.rootScope
         val viewModelClass = clazz.kotlin
-        return ViewModelLazy(viewModelClass, { owner.value.viewModelStore }){
+
+        return KoinViewModelLazy(viewModelClass, key, { owner.value.viewModelStore }){
             val viewModelParameters = ViewModelParameter(
                 clazz = viewModelClass,
                 qualifier = qualifier,
@@ -78,7 +80,8 @@ object ViewModelCompat {
     fun <T : ViewModel> getViewModel(
         owner: Lazy<ViewModelStoreOwner>,
         clazz: Class<T>,
+        key: String? = null,
         qualifier: Qualifier? = null,
         parameters: ParametersDefinition? = null
-    ): T = viewModel(owner, clazz, qualifier, parameters).value
+    ): T = viewModel(owner, clazz, key, qualifier, parameters).value
 }

--- a/android/koin-android/src/main/java/org/koin/androidx/viewmodel/KoinViewModelLazy.kt
+++ b/android/koin-android/src/main/java/org/koin/androidx/viewmodel/KoinViewModelLazy.kt
@@ -1,0 +1,37 @@
+package org.koin.androidx.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.ViewModelStore
+import kotlin.reflect.KClass
+
+class KoinViewModelLazy<VM : ViewModel> (
+    private val viewModelClass: KClass<VM>,
+    private val viewModelKey: String? = null,
+    private val storeProducer: () -> ViewModelStore,
+    private val factoryProducer: () -> ViewModelProvider.Factory,
+) : Lazy<VM> {
+    private var cached: VM? = null
+
+    override val value: VM
+        get() {
+            val viewModel = cached
+            return if (viewModel == null) {
+                val factory = factoryProducer()
+                val store = storeProducer()
+                if (viewModelKey != null) {
+                    ViewModelProvider(store, factory)[viewModelKey, viewModelClass.java].also {
+                        cached = it
+                    }
+                } else {
+                    ViewModelProvider(store, factory)[viewModelClass.java].also {
+                        cached = it
+                    }
+                }
+            } else {
+                viewModel
+            }
+        }
+
+    override fun isInitialized(): Boolean = cached != null
+}

--- a/android/koin-android/src/main/java/org/koin/androidx/viewmodel/ext/android/ActivityStateVM.kt
+++ b/android/koin-android/src/main/java/org/koin/androidx/viewmodel/ext/android/ActivityStateVM.kt
@@ -16,10 +16,9 @@
 package org.koin.androidx.viewmodel.ext.android
 
 import androidx.activity.ComponentActivity
-import androidx.activity.viewModels
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.ViewModelLazy
 import org.koin.android.ext.android.getKoinScope
+import org.koin.androidx.viewmodel.KoinViewModelLazy
 import org.koin.androidx.viewmodel.scope.BundleDefinition
 import org.koin.androidx.viewmodel.scope.emptyState
 import org.koin.core.annotation.KoinInternalApi
@@ -35,11 +34,12 @@ import kotlin.reflect.KClass
 @OptIn(KoinInternalApi::class)
 inline fun <reified T : ViewModel> ComponentActivity.stateViewModel(
     qualifier: Qualifier? = null,
+    key: String? = null,
     noinline state: BundleDefinition = emptyState(),
     noinline parameters: ParametersDefinition? = null,
 ): Lazy<T> {
     val scope = getKoinScope()
-    return viewModels {
+    return KoinViewModelLazy(T::class, key, { viewModelStore }){
         getViewModelFactory<T>(this, qualifier, parameters, state = state, scope = scope)
     }
 }
@@ -47,30 +47,33 @@ inline fun <reified T : ViewModel> ComponentActivity.stateViewModel(
 @OptIn(KoinInternalApi::class)
 fun <T : ViewModel> ComponentActivity.stateViewModel(
     qualifier: Qualifier? = null,
+    key: String? = null,
     state: BundleDefinition = emptyState(),
     clazz: KClass<T>,
     parameters: ParametersDefinition? = null,
 ): Lazy<T> {
     val scope = getKoinScope()
-    return ViewModelLazy(clazz, { viewModelStore }){
+    return KoinViewModelLazy(clazz, key, { viewModelStore }){
         getViewModelFactory(this, clazz, qualifier, parameters, state = state, scope = scope)
     }
 }
 
 inline fun <reified T : ViewModel> ComponentActivity.getStateViewModel(
     qualifier: Qualifier? = null,
+    key: String? = null,
     noinline state: BundleDefinition = emptyState(),
     noinline parameters: ParametersDefinition? = null,
 ): T {
-    return stateViewModel<T>(qualifier, state, parameters).value
+    return stateViewModel<T>(qualifier, key, state, parameters).value
 }
 
 @OptIn(KoinInternalApi::class)
 fun <T : ViewModel> ComponentActivity.getStateViewModel(
     qualifier: Qualifier? = null,
+    key: String? = null,
     state: BundleDefinition = emptyState(),
     clazz: KClass<T>,
     parameters: ParametersDefinition? = null,
 ): T {
-    return stateViewModel(qualifier, state,clazz, parameters).value
+    return stateViewModel(qualifier, key, state, clazz, parameters).value
 }

--- a/android/koin-android/src/main/java/org/koin/androidx/viewmodel/ext/android/ActivityVM.kt
+++ b/android/koin-android/src/main/java/org/koin/androidx/viewmodel/ext/android/ActivityVM.kt
@@ -16,10 +16,10 @@
 package org.koin.androidx.viewmodel.ext.android
 
 import androidx.activity.ComponentActivity
-import androidx.activity.viewModels
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelStoreOwner
 import org.koin.android.ext.android.getKoinScope
+import org.koin.androidx.viewmodel.KoinViewModelLazy
 import org.koin.core.annotation.KoinInternalApi
 import org.koin.core.parameter.ParametersDefinition
 import org.koin.core.qualifier.Qualifier
@@ -35,19 +35,21 @@ import org.koin.core.qualifier.Qualifier
 @OptIn(KoinInternalApi::class)
 inline fun <reified T : ViewModel> ComponentActivity.viewModel(
         qualifier: Qualifier? = null,
-        owner : ViewModelStoreOwner = this,
+        key: String? = null,
+        owner: ViewModelStoreOwner = this,
         noinline parameters: ParametersDefinition? = null
 ): Lazy<T> {
         val scope = getKoinScope()
-        return viewModels {
+        return KoinViewModelLazy(T::class, key, { viewModelStore }) {
                 getViewModelFactory<T>(owner, qualifier, parameters, scope = scope)
         }
 }
 
 inline fun <reified T : ViewModel> ComponentActivity.getViewModel(
         qualifier: Qualifier? = null,
-        owner : ViewModelStoreOwner = this,
+        key: String? = null,
+        owner: ViewModelStoreOwner = this,
         noinline parameters: ParametersDefinition? = null,
 ): T {
-        return viewModel<T>(qualifier, owner, parameters).value
+        return viewModel<T>(qualifier, key, owner, parameters).value
 }

--- a/android/koin-android/src/main/java/org/koin/androidx/viewmodel/ext/android/FragmentSharedStateVM.kt
+++ b/android/koin-android/src/main/java/org/koin/androidx/viewmodel/ext/android/FragmentSharedStateVM.kt
@@ -16,10 +16,9 @@
 package org.koin.androidx.viewmodel.ext.android
 
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.viewModels
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.ViewModelLazy
 import org.koin.android.ext.android.getKoinScope
+import org.koin.androidx.viewmodel.KoinViewModelLazy
 import org.koin.androidx.viewmodel.ViewModelStoreOwnerProducer
 import org.koin.androidx.viewmodel.scope.BundleDefinition
 import org.koin.androidx.viewmodel.scope.emptyState
@@ -36,12 +35,13 @@ import kotlin.reflect.KClass
 @OptIn(KoinInternalApi::class)
 inline fun <reified T : ViewModel> Fragment.sharedStateViewModel(
     qualifier: Qualifier? = null,
+    key: String? = null,
     noinline state: BundleDefinition = emptyState(),
     noinline owner: ViewModelStoreOwnerProducer = { requireActivity() },
     noinline parameters: ParametersDefinition? = null,
 ): Lazy<T> {
     val scope = getKoinScope()
-    return viewModels(ownerProducer = owner) {
+    return KoinViewModelLazy(T::class, key, { owner().viewModelStore }) {
         getViewModelFactory<T>(owner(), qualifier, parameters, state = state, scope = scope)
     }
 }
@@ -49,6 +49,7 @@ inline fun <reified T : ViewModel> Fragment.sharedStateViewModel(
 @OptIn(KoinInternalApi::class)
 fun <T : ViewModel> Fragment.sharedStateViewModel(
     qualifier: Qualifier? = null,
+    key: String? = null,
     state: BundleDefinition = emptyState(),
     //TODO Clean up
     owner: ViewModelStoreOwnerProducer = { requireActivity() },
@@ -56,27 +57,29 @@ fun <T : ViewModel> Fragment.sharedStateViewModel(
     parameters: ParametersDefinition? = null,
 ): Lazy<T> {
     val scope = getKoinScope()
-    return ViewModelLazy(clazz, { viewModelStore }) {
+    return KoinViewModelLazy(clazz, key, { viewModelStore }) {
         getViewModelFactory(owner(), clazz, qualifier, parameters, state = state, scope = scope)
     }
 }
 
 inline fun <reified T : ViewModel> Fragment.getSharedStateViewModel(
     qualifier: Qualifier? = null,
+    key: String? = null,
     noinline state: BundleDefinition = emptyState(),
     noinline owner: ViewModelStoreOwnerProducer = { requireActivity() },
     noinline parameters: ParametersDefinition? = null,
 ): T {
-    return sharedStateViewModel<T>(qualifier, state, owner, parameters).value
+    return sharedStateViewModel<T>(qualifier, key, state, owner, parameters).value
 }
 
 @OptIn(KoinInternalApi::class)
 fun <T : ViewModel> Fragment.getSharedStateViewModel(
     qualifier: Qualifier? = null,
+    key: String? = null,
     state: BundleDefinition = emptyState(),
     owner: ViewModelStoreOwnerProducer = { requireActivity() },
     clazz: KClass<T>,
     parameters: ParametersDefinition? = null,
 ): T {
-    return sharedStateViewModel(qualifier, state, owner, clazz, parameters).value
+    return sharedStateViewModel(qualifier, key, state, owner, clazz, parameters).value
 }

--- a/android/koin-android/src/main/java/org/koin/androidx/viewmodel/ext/android/FragmentSharedVM.kt
+++ b/android/koin-android/src/main/java/org/koin/androidx/viewmodel/ext/android/FragmentSharedVM.kt
@@ -28,16 +28,18 @@ import org.koin.core.qualifier.Qualifier
  */
 inline fun <reified T : ViewModel> Fragment.sharedViewModel(
     qualifier: Qualifier? = null,
+    key: String? = null,
     noinline owner: ViewModelStoreOwnerProducer = { requireActivity() },
     noinline parameters: ParametersDefinition? = null,
 ): Lazy<T> {
-    return viewModel(qualifier, owner, parameters)
+    return viewModel(qualifier, key, owner, parameters)
 }
 
 inline fun <reified T : ViewModel> Fragment.getSharedViewModel(
     qualifier: Qualifier? = null,
+    key: String? = null,
     noinline owner: ViewModelStoreOwnerProducer = { requireActivity() },
     noinline parameters: ParametersDefinition? = null,
 ): T {
-    return sharedViewModel<T>(qualifier, owner, parameters).value
+    return sharedViewModel<T>(qualifier, key, owner, parameters).value
 }

--- a/android/koin-android/src/main/java/org/koin/androidx/viewmodel/ext/android/FragmentStateVM.kt
+++ b/android/koin-android/src/main/java/org/koin/androidx/viewmodel/ext/android/FragmentStateVM.kt
@@ -16,10 +16,9 @@
 package org.koin.androidx.viewmodel.ext.android
 
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.createViewModelLazy
-import androidx.fragment.app.viewModels
 import androidx.lifecycle.ViewModel
 import org.koin.android.ext.android.getKoinScope
+import org.koin.androidx.viewmodel.KoinViewModelLazy
 import org.koin.androidx.viewmodel.ViewModelStoreOwnerProducer
 import org.koin.androidx.viewmodel.scope.BundleDefinition
 import org.koin.androidx.viewmodel.scope.emptyState
@@ -36,12 +35,13 @@ import kotlin.reflect.KClass
 @OptIn(KoinInternalApi::class)
 inline fun <reified T : ViewModel> Fragment.stateViewModel(
     qualifier: Qualifier? = null,
+    key: String? = null,
     noinline state: BundleDefinition = emptyState(),
     noinline owner: ViewModelStoreOwnerProducer = { this },
     noinline parameters: ParametersDefinition? = null,
 ): Lazy<T> {
     val scope = getKoinScope()
-    return viewModels(ownerProducer = owner) {
+    return KoinViewModelLazy(T::class, key, { owner().viewModelStore }) {
         getViewModelFactory<T>(owner(), qualifier, parameters, state = state, scope = scope)
     }
 }
@@ -49,33 +49,36 @@ inline fun <reified T : ViewModel> Fragment.stateViewModel(
 @OptIn(KoinInternalApi::class)
 fun <T : ViewModel> Fragment.stateViewModel(
     qualifier: Qualifier? = null,
+    key: String? = null,
     clazz: KClass<T>,
     state: BundleDefinition = emptyState(),
     owner: ViewModelStoreOwnerProducer = { this },
     parameters: ParametersDefinition? = null,
 ): Lazy<T> {
     val scope = getKoinScope()
-    return createViewModelLazy(clazz, { viewModelStore }) {
+    return KoinViewModelLazy(clazz, key, { viewModelStore }) {
         getViewModelFactory(owner(), clazz, qualifier, parameters, state = state, scope = scope)
     }
 }
 
 inline fun <reified T : ViewModel> Fragment.getStateViewModel(
     qualifier: Qualifier? = null,
+    key: String? = null,
     noinline state: BundleDefinition = emptyState(),
     noinline owner: ViewModelStoreOwnerProducer = { this },
     noinline parameters: ParametersDefinition? = null,
 ): T {
-    return stateViewModel<T>(qualifier, state, owner, parameters).value
+    return stateViewModel<T>(qualifier, key, state, owner, parameters).value
 }
 
 @OptIn(KoinInternalApi::class)
 fun <T : ViewModel> Fragment.getStateViewModel(
     qualifier: Qualifier? = null,
+    key: String? = null,
     clazz: KClass<T>,
     state: BundleDefinition = emptyState(),
     owner: ViewModelStoreOwnerProducer = { this },
     parameters: ParametersDefinition? = null,
 ): T {
-    return stateViewModel(qualifier, clazz, state, owner, parameters).value
+    return stateViewModel(qualifier, key, clazz, state, owner, parameters).value
 }

--- a/android/koin-android/src/main/java/org/koin/androidx/viewmodel/ext/android/FragmentVM.kt
+++ b/android/koin-android/src/main/java/org/koin/androidx/viewmodel/ext/android/FragmentVM.kt
@@ -16,9 +16,9 @@
 package org.koin.androidx.viewmodel.ext.android
 
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.viewModels
 import androidx.lifecycle.ViewModel
 import org.koin.android.ext.android.getKoinScope
+import org.koin.androidx.viewmodel.KoinViewModelLazy
 import org.koin.androidx.viewmodel.ViewModelStoreOwnerProducer
 import org.koin.core.annotation.KoinInternalApi
 import org.koin.core.parameter.ParametersDefinition
@@ -35,19 +35,21 @@ import org.koin.core.qualifier.Qualifier
 @OptIn(KoinInternalApi::class)
 inline fun <reified T : ViewModel> Fragment.viewModel(
     qualifier: Qualifier? = null,
+    key: String? = null,
     noinline owner: ViewModelStoreOwnerProducer = { this },
     noinline parameters: ParametersDefinition? = null
 ): Lazy<T> {
     val scope = getKoinScope()
-    return viewModels(ownerProducer = owner) {
+    return KoinViewModelLazy(T::class, key, { owner().viewModelStore }) {
         getViewModelFactory<T>(owner(), qualifier, parameters, scope = scope)
     }
 }
 
 inline fun <reified T : ViewModel> Fragment.getViewModel(
     qualifier: Qualifier? = null,
+    key: String? = null,
     noinline owner: ViewModelStoreOwnerProducer = { this },
     noinline parameters: ParametersDefinition? = null,
 ): T {
-    return viewModel<T>(qualifier, owner, parameters).value
+    return viewModel<T>(qualifier, key, owner, parameters).value
 }

--- a/android/koin-androidx-navigation/src/main/java/org/koin/androidx/navigation/NavGraphExt.kt
+++ b/android/koin-androidx-navigation/src/main/java/org/koin/androidx/navigation/NavGraphExt.kt
@@ -2,11 +2,11 @@ package org.koin.androidx.navigation
 
 import androidx.annotation.IdRes
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.viewModels
 import androidx.lifecycle.ViewModel
 import androidx.navigation.NavBackStackEntry
 import androidx.navigation.fragment.findNavController
 import org.koin.android.ext.android.getKoinScope
+import org.koin.androidx.viewmodel.KoinViewModelLazy
 import org.koin.androidx.viewmodel.ext.android.getViewModelFactory
 import org.koin.core.annotation.KoinInternalApi
 import org.koin.core.parameter.ParametersDefinition
@@ -21,11 +21,12 @@ import org.koin.core.parameter.ParametersDefinition
 @OptIn(KoinInternalApi::class)
 inline fun <reified VM : ViewModel> Fragment.koinNavGraphViewModel(
     @IdRes navGraphId: Int,
+    key: String? = null,
     noinline parameters: ParametersDefinition? = null,
 ): Lazy<VM> {
     val backStackEntry: NavBackStackEntry by lazy { findNavController().getBackStackEntry(navGraphId) }
     val scope = getKoinScope()
-    return viewModels(ownerProducer = { backStackEntry }) {
+    return KoinViewModelLazy(VM::class, key, { backStackEntry.viewModelStore }) {
         getViewModelFactory<VM>(
             owner = backStackEntry,
             qualifier = null,


### PR DESCRIPTION
Hi, because the ViewModel provider has the function (`ViewModelProvider.get(key, clazz)`) that can let you pass the key to ViewModel provide in order to get a different ViewModel with a different key, I want to raise this PR, and according to this : 
https://github.com/InsertKoinIO/koin/issues/213

Originally I was going to change `ViewModelProvider.resolveInstance`, but I found that the new version of koin uses ViewModelLazy instead, but it is an Android lib, so I tried to build a KoinViewModelLazy, please consider this scenario carefully, I believe that I am not the only one who needs to pass in the key