### PR TITLE
Add createEagerInstances on context-isolation

### DIFF
--- a/docs/reference/koin-core/context-isolation.md
+++ b/docs/reference/koin-core/context-isolation.md
@@ -24,6 +24,9 @@ But if we want to use an isolated Koin instance, you can just declare it like fo
 val myApp = koinApplication {
     // declare used modules
     modules(coffeeAppModule)
+    
+    // call this to start singletons with `createdAtStart = true`
+    createEagerInstances()
 }
 ```
 


### PR DESCRIPTION
It's necessary to call `createEagerInstances()` when working with context-isolation (library / SDK development) or else singletons declared with `single(createdAtStart = true)` will be lazily initiated.