### PR TITLE
Android 3.2.3

### DIFF
--- a/.github/workflows/github-actions-ci-cd-mac.yml
+++ b/.github/workflows/github-actions-ci-cd-mac.yml
@@ -13,6 +13,7 @@ jobs:
         with:
           distribution: "adopt"
           java-version: "11"
+      
       - name: Validate Gradle Wrapper
         uses: gradle/wrapper-validation-action@v1
       - name: Cache build tooling

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,21 @@ Badges: `[UPDATED]`, `[FIXED]`, `[NEW]`, `[DEPRECATED]`, `[REMOVED]`,  `[BREAKIN
 
 # [3.2]()
 
-## [3.2.2](https://github.com/InsertKoinIO/koin/milestone/36?closed=1) - (2022-09-23)
+## [android-3.2.3](https://github.com/InsertKoinIO/koin/milestone/38) - 2022-10-18
+
+* `[FIXED]` - Fix Broken Scope API and revert back `AndroidScopeComponent` with related API in `Activity` & `Fragment`. Reworked `activityScope()`, `activityRetainedScope()` and `fragmentScope()`. Removed Deprecations. #1443 #1448
+* `[FIXED]` - Fix NavGraph scope resolution #1446
+
+
+## [3.2.2](https://github.com/InsertKoinIO/koin/milestone/36?closed=1) - 2022-09-23
 
 * `[FIXED]` `[core]` - Java 8 Compat fix
 * `[MERGE]` `[test]` - Java 8 Compat fix #1437
 
 
-## [3.2.1](https://github.com/InsertKoinIO/koin/milestone/36?closed=1) - (2022-09-12)
+## [3.2.1](https://github.com/InsertKoinIO/koin/milestone/36?closed=1) - 2022-09-12
 
-* `[NEW]` - Version split for Koin core & Android, to allow sperate track on core & android topics
+* `[NEW]` - Version split for Koin core & Android, to allow sperate track on core & android topics (dedicated Github milestones & Git branches/tag)
 * `[UPDATED]` `[core]` - lib update - `co.touchlab:stately-concurrency:1.2.2`
 * `[UPDATED]` `[android]` - lib update - `androidx.appcompat:appcompat:1.4.2`
 * `[MERGE]` - #1409 - Android Test Instrumentation Contribution
@@ -24,6 +30,16 @@ Badges: `[UPDATED]`, `[FIXED]`, `[NEW]`, `[DEPRECATED]`, `[REMOVED]`,  `[BREAKIN
 * `[FIXED]` `[android]` - Open ViewModel with KClass access for generic uses - #1402, #1384
 * `[UPDATED]` `[android]` - New Android Scope API - https://insert-koin.io/docs/reference/koin-android/scope - #1399, #1356, #1328, #1385, #1414
 * `[BREAKING]` `[android]` - Deprecate Android Scope API to avoid use lazy delegate API 
+
+
+## [3.2.0]() 
+
+The repository has been splitted for the following sub projects. 
+
+- `koin-ktor` - https://github.com/InsertKoinIO/koin-ktor
+- `koin-androidx-compose` - https://github.com/InsertKoinIO/koin-compose
+
+This allow independant version tracking and updates.
 
 
 ## [3.2.0-beta-2]()

--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@ A pragmatic lightweight dependency injection framework for Kotlin developers. `K
 
 ## Latest Version
 
-- current stable version: `koin_version = 3.2.2`
-
 You can find the following page to help setup your project: [Koin Gradle Setup](https://insert-koin.io/docs/setup/v3.2)
 
 ## Latest News

--- a/android/koin-android/src/main/java/org/koin/android/ext/android/AndroidKoinScopeExt.kt
+++ b/android/koin-android/src/main/java/org/koin/android/ext/android/AndroidKoinScopeExt.kt
@@ -5,8 +5,6 @@ import org.koin.android.scope.AndroidScopeComponent
 import org.koin.core.annotation.KoinInternalApi
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.KoinScopeComponent
-import org.koin.core.component.getScopeId
-import org.koin.core.component.getScopeName
 import org.koin.core.context.GlobalContext
 import org.koin.core.scope.Scope
 
@@ -14,7 +12,7 @@ import org.koin.core.scope.Scope
 @KoinInternalApi
 fun ComponentCallbacks.getKoinScope(): Scope {
     return when (this) {
-        is AndroidScopeComponent -> requireScope()
+        is AndroidScopeComponent -> scope
         is KoinScopeComponent -> scope
         is KoinComponent -> getKoin().scopeRegistry.rootScope
         else -> GlobalContext.get().scopeRegistry.rootScope

--- a/android/koin-android/src/main/java/org/koin/android/scope/AndroidScopeComponent.kt
+++ b/android/koin-android/src/main/java/org/koin/android/scope/AndroidScopeComponent.kt
@@ -5,7 +5,9 @@ import org.koin.core.scope.Scope
 /**
  * Android Component that can handle a Koin Scope
  */
+//TODO Breaking Changes to make it 'var scope: Scope?'
 interface AndroidScopeComponent {
-    var scope: Scope?
-    fun requireScope() : Scope = scope ?: error("Trying to access Android Scope on '$this' but scope is not created")
+    // TODO Change val to other type of value
+    // TODO Make it nullable
+    val scope: Scope
 }

--- a/android/koin-android/src/main/java/org/koin/android/scope/ComponentCallbacksExt.kt
+++ b/android/koin-android/src/main/java/org/koin/android/scope/ComponentCallbacksExt.kt
@@ -15,8 +15,5 @@ fun <T : ComponentCallbacks> T.getScopeOrNull(): Scope? {
     return getKoin().getScopeOrNull(getScopeId())
 }
 
-@Deprecated("Internal function not used anymore")
 fun <T : ComponentCallbacks> T.newScope() = lazy { createScope() }
-
-@Deprecated("Internal function not used anymore")
 fun <T : ComponentCallbacks> T.getOrCreateScope() = lazy { getScopeOrNull() ?: createScope() }

--- a/android/koin-android/src/main/java/org/koin/android/scope/ScopeService.kt
+++ b/android/koin-android/src/main/java/org/koin/android/scope/ScopeService.kt
@@ -28,17 +28,18 @@ import org.koin.core.scope.Scope
  */
 abstract class ScopeService : Service(), AndroidScopeComponent {
 
-    override var scope: Scope? = null
+    override val scope: Scope by serviceScope()
 
     override fun onCreate() {
         super.onCreate()
-
-        createServiceScope()
+        checkNotNull(scope)
+        //TODO replace with createServiceScope
     }
 
     override fun onDestroy() {
         super.onDestroy()
 
         destroyServiceScope()
+        //TODO be sure to close scope
     }
 }

--- a/android/koin-android/src/main/java/org/koin/android/scope/ServiceExt.kt
+++ b/android/koin-android/src/main/java/org/koin/android/scope/ServiceExt.kt
@@ -2,23 +2,34 @@ package org.koin.android.scope
 
 import android.app.Service
 import org.koin.android.ext.android.getKoin
+import org.koin.core.annotation.KoinInternalApi
 import org.koin.core.component.getScopeId
 import org.koin.core.component.getScopeName
+import org.koin.core.scope.Scope
 
-fun Service.createServiceScope() {
+fun Service.createServiceScope(): Scope {
     if (this !is AndroidScopeComponent) {
         error("Service should implement AndroidScopeComponent")
     }
     val koin = getKoin()
     val scope =
         koin.getScopeOrNull(getScopeId()) ?: koin.createScope(getScopeId(), getScopeName(), this)
-    this.scope = scope
+    return scope
 }
 
 fun Service.destroyServiceScope() {
     if (this !is AndroidScopeComponent) {
         error("Service should implement AndroidScopeComponent")
     }
-    this.scope?.close()
-    this.scope = null
+    scope.close()
 }
+
+fun Service.serviceScope() = lazy { createServiceScope() }
+
+/**
+ * Create new scope
+ */
+@KoinInternalApi
+fun Service.createScope(source: Any? = null): Scope = getKoin().createScope(getScopeId(), getScopeName(), source)
+@KoinInternalApi
+fun Service.getScopeOrNull(): Scope? = getKoin().getScopeOrNull(getScopeId())

--- a/android/koin-android/src/main/java/org/koin/androidx/scope/ComponentActivityExt.kt
+++ b/android/koin-android/src/main/java/org/koin/androidx/scope/ComponentActivityExt.kt
@@ -15,15 +15,14 @@
  */
 package org.koin.androidx.scope
 
-import android.app.Activity
 import android.content.ComponentCallbacks
 import androidx.activity.ComponentActivity
 import androidx.activity.viewModels
-import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import org.koin.android.ext.android.getKoin
 import org.koin.android.scope.AndroidScopeComponent
+import org.koin.core.annotation.KoinInternalApi
 import org.koin.core.component.getScopeId
 import org.koin.core.component.getScopeName
 import org.koin.core.scope.Scope
@@ -31,27 +30,27 @@ import org.koin.core.scope.Scope
 /**
  * Provide Koin Scope tied to ComponentActivity
  */
-@Deprecated("Delegate Lazy API is deprecatede. Please use AppCompatActivity.createActivityScope()")
-fun ComponentActivity.activityScope() = LifecycleScopeDelegate<Activity>(this, this.getKoin())
-@Deprecated("Delegate Lazy API is deprecatede. Please use AppCompatActivity.createActivityRetainedScope()")
-fun ComponentActivity.activityRetainedScope() = LifecycleViewModelScopeDelegate(this, this.getKoin())
-@Deprecated("Internal API not used anymore")
-internal fun ComponentActivity.createScope(source: Any? = null): Scope = getKoin().createScope(getScopeId(), getScopeName(), source)
+
+fun ComponentActivity.activityScope() = lazy { createActivityScope() }
+fun ComponentActivity.activityRetainedScope() = lazy { createActivityRetainedScope() }
+
+@KoinInternalApi
+fun ComponentActivity.createScope(source: Any? = null): Scope = getKoin().createScope(getScopeId(), getScopeName(), source)
+
 fun ComponentActivity.getScopeOrNull(): Scope? = getKoin().getScopeOrNull(getScopeId())
 
 /**
  * Create Scope for AppCompatActivity, given it's extending AndroidScopeComponent.
  * Also register it in AndroidScopeComponent.scope
  */
-fun AppCompatActivity.createActivityScope() {
+fun ComponentActivity.createActivityScope(): Scope {
     if (this !is AndroidScopeComponent) {
         error("Activity should implement AndroidScopeComponent")
     }
-    if (this.scope != null) {
-        error("Activity Scope is already created")
-    }
-    val scope = getKoin().getScopeOrNull(getScopeId()) ?: createScopeForCurrentLifecycle(this)
-    this.scope = scope
+//    if (this.scope != null) {
+//        error("Activity Scope is already created")
+//    }
+    return getKoin().getScopeOrNull(getScopeId()) ?: createScopeForCurrentLifecycle(this)
 }
 
 internal fun ComponentCallbacks.createScopeForCurrentLifecycle(owner: LifecycleOwner): Scope {
@@ -77,17 +76,17 @@ internal fun LifecycleOwner.registerScopeForLifecycle(
  * Create Retained Scope for AppCompatActivity, given it's extending AndroidScopeComponent.
  * Also register it in AndroidScopeComponent.scope
  */
-fun ComponentActivity.createActivityRetainedScope() {
+fun ComponentActivity.createActivityRetainedScope(): Scope {
     if (this !is AndroidScopeComponent) {
         error("Activity should implement AndroidScopeComponent")
     }
-    if (this.scope != null) {
-        error("Activity Scope is already created")
-    }
+//    if (this.scope != null) {
+//        error("Activity Scope is already created")
+//    }
     val scopeViewModel = viewModels<ScopeHandlerViewModel>().value
     if (scopeViewModel.scope == null) {
         val scope = getKoin().createScope(getScopeId(), getScopeName())
         scopeViewModel.scope = scope
     }
-    this.scope = scopeViewModel.scope
+    return scopeViewModel.scope!!
 }

--- a/android/koin-android/src/main/java/org/koin/androidx/scope/FragmentExt.kt
+++ b/android/koin-android/src/main/java/org/koin/androidx/scope/FragmentExt.kt
@@ -18,7 +18,6 @@ package org.koin.androidx.scope
 import androidx.fragment.app.Fragment
 import org.koin.android.ext.android.getKoin
 import org.koin.android.scope.AndroidScopeComponent
-import org.koin.core.Koin
 import org.koin.core.component.getScopeId
 import org.koin.core.component.getScopeName
 import org.koin.core.scope.Scope
@@ -28,33 +27,27 @@ import org.koin.core.scope.Scope
  * Link parent Activity's Scope
  * Also register it in AndroidScopeComponent.scope
  */
-fun Fragment.createFragmentScope() {
-    if (this !is AndroidScopeComponent){
+fun Fragment.createFragmentScope(): Scope {
+    if (this !is AndroidScopeComponent) {
         error("Fragment should implement AndroidScopeComponent")
     }
-    if (this.scope != null) {
-        error("Fragment Scope is already created")
-    }
+//    if (this.scope != null) {
+//        error("Fragment Scope is already created")
+//    }
     val scope = getKoin().getScopeOrNull(getScopeId()) ?: createScopeForCurrentLifecycle(this)
     val activityScope = requireActivity().getScopeOrNull()
-    if (activityScope != null){
+    if (activityScope != null) {
         scope.linkTo(activityScope)
     } else {
         scope.logger.debug("Fragment '$this' can't be linked to parent activity scope")
     }
-    this.scope = scope
+    return scope
 }
 
 /**
  * Provide scope tied to Fragment
  */
-@Deprecated("Delegate Lazy API is deprecatede. Please use Fragment.createFragmentScope()")
-fun Fragment.fragmentScope() = LifecycleScopeDelegate<Fragment>(this,this.getKoin()){ koin: Koin ->
-    val scope = koin.createScope(getScopeId(), getScopeName())
-    val activityScope = activity?.getScopeOrNull()
-    activityScope?.let { scope.linkTo(it) }
-    scope
-}
+fun Fragment.fragmentScope() = lazy { createFragmentScope() }
 
 @Deprecated("Unused Internal API")
 internal fun Fragment.createScope(source: Any? = null): Scope = getKoin().createScope(getScopeId(), getScopeName(), source)

--- a/android/koin-android/src/main/java/org/koin/androidx/scope/LifecycleScopeDelegate.kt
+++ b/android/koin-android/src/main/java/org/koin/androidx/scope/LifecycleScopeDelegate.kt
@@ -8,7 +8,7 @@ import org.koin.core.scope.Scope
 import kotlin.properties.ReadOnlyProperty
 import kotlin.reflect.KProperty
 
-@Deprecated("Use ComponentActivity.createActivityScope() or Fragment.createFragmentScope() with AndroidScopeComponent. Check Also ScopeActivity or ScopeFragment")
+//TODO Deprecate
 class LifecycleScopeDelegate<T>(
     private val lifecycleOwner: LifecycleOwner,
     private val koin: Koin,

--- a/android/koin-android/src/main/java/org/koin/androidx/scope/LifecycleViewModelScopeDelegate.kt
+++ b/android/koin-android/src/main/java/org/koin/androidx/scope/LifecycleViewModelScopeDelegate.kt
@@ -11,7 +11,7 @@ import org.koin.core.scope.Scope
 import kotlin.properties.ReadOnlyProperty
 import kotlin.reflect.KProperty
 
-@Deprecated("Use ComponentActivity.createActivityRetainedScope() with ScopeActivity or AndroidScopeComponent")
+//TODO Deprecate
 class LifecycleViewModelScopeDelegate(
         private val lifecycleOwner: ComponentActivity,
         private val koin : Koin,

--- a/android/koin-android/src/main/java/org/koin/androidx/scope/RetainedScopeActivity.kt
+++ b/android/koin-android/src/main/java/org/koin/androidx/scope/RetainedScopeActivity.kt
@@ -32,11 +32,11 @@ abstract class RetainedScopeActivity(
     @LayoutRes contentLayoutId: Int = 0,
 ) : AppCompatActivity(contentLayoutId), AndroidScopeComponent {
 
-    override var scope: Scope? = null
+    override val scope: Scope by activityRetainedScope()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        createActivityRetainedScope()
+        checkNotNull(scope)
     }
 }

--- a/android/koin-android/src/main/java/org/koin/androidx/scope/ScopeActivity.kt
+++ b/android/koin-android/src/main/java/org/koin/androidx/scope/ScopeActivity.kt
@@ -32,12 +32,11 @@ abstract class ScopeActivity(
     @LayoutRes contentLayoutId: Int = 0,
 ) : AppCompatActivity(contentLayoutId), AndroidScopeComponent {
 
-
-    override var scope: Scope? = null
+    override val scope: Scope by activityScope()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        createActivityScope()
+        checkNotNull(scope)
     }
 }

--- a/android/koin-android/src/main/java/org/koin/androidx/scope/ScopeFragment.kt
+++ b/android/koin-android/src/main/java/org/koin/androidx/scope/ScopeFragment.kt
@@ -20,11 +20,7 @@ import android.os.Bundle
 import android.view.View
 import androidx.annotation.LayoutRes
 import androidx.fragment.app.Fragment
-import org.koin.android.ext.android.getKoin
 import org.koin.android.scope.AndroidScopeComponent
-import org.koin.core.component.KoinScopeComponent
-import org.koin.core.component.getScopeId
-import org.koin.core.component.getScopeName
 import org.koin.core.scope.Scope
 
 /**
@@ -36,13 +32,13 @@ import org.koin.core.scope.Scope
  */
 abstract class ScopeFragment(
     @LayoutRes contentLayoutId: Int = 0,
-) : Fragment(contentLayoutId) , AndroidScopeComponent {
+) : Fragment(contentLayoutId), AndroidScopeComponent {
 
-    override var scope: Scope? = null
+    override val scope: Scope by fragmentScope()
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        createFragmentScope()
+        checkNotNull(scope)
     }
 }

--- a/android/koin-android/src/main/java/org/koin/androidx/viewmodel/ViewModelResolver.kt
+++ b/android/koin-android/src/main/java/org/koin/androidx/viewmodel/ViewModelResolver.kt
@@ -7,7 +7,7 @@ import org.koin.androidx.viewmodel.factory.DefaultViewModelFactory
 import org.koin.core.annotation.KoinInternalApi
 import org.koin.core.scope.Scope
 
-//TODO Use instance resolution & key
+//TODO Deprecate for ViewModel API 2.5 + initializers
 internal fun <T : ViewModel> ViewModelProvider.resolveInstance(viewModelParameters: ViewModelParameter<T>): T {
     val javaClass = viewModelParameters.clazz.java
     return if (viewModelParameters.qualifier != null) {

--- a/android/koin-android/src/main/java/org/koin/androidx/viewmodel/ext/android/ActivityVM.kt
+++ b/android/koin-android/src/main/java/org/koin/androidx/viewmodel/ext/android/ActivityVM.kt
@@ -18,15 +18,11 @@ package org.koin.androidx.viewmodel.ext.android
 import androidx.activity.ComponentActivity
 import androidx.activity.viewModels
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.ViewModelLazy
 import androidx.lifecycle.ViewModelStoreOwner
 import org.koin.android.ext.android.getKoinScope
-import org.koin.androidx.viewmodel.scope.BundleDefinition
-import org.koin.androidx.viewmodel.scope.emptyState
 import org.koin.core.annotation.KoinInternalApi
 import org.koin.core.parameter.ParametersDefinition
 import org.koin.core.qualifier.Qualifier
-import kotlin.reflect.KClass
 
 //TODO Clean up ViewModelOwnerDefinition in 3.2
 
@@ -38,20 +34,20 @@ import kotlin.reflect.KClass
 
 @OptIn(KoinInternalApi::class)
 inline fun <reified T : ViewModel> ComponentActivity.viewModel(
-        qualifier: Qualifier? = null,
-        owner : ViewModelStoreOwner = this,
-        noinline parameters: ParametersDefinition? = null
+    qualifier: Qualifier? = null,
+    owner: ViewModelStoreOwner = this,
+    noinline parameters: ParametersDefinition? = null
 ): Lazy<T> {
-        return viewModels {
-                getViewModelFactory<T>(owner, qualifier, parameters, scope = getKoinScope())
-        }
+    return viewModels {
+        getViewModelFactory<T>(owner, qualifier, parameters, scope = getKoinScope())
+    }
 }
 
 inline fun <reified T : ViewModel> ComponentActivity.getViewModel(
-        qualifier: Qualifier? = null,
-        owner : ViewModelStoreOwner = this,
-        noinline parameters: ParametersDefinition? = null,
+    qualifier: Qualifier? = null,
+    owner: ViewModelStoreOwner = this,
+    noinline parameters: ParametersDefinition? = null,
 ): T {
-        return viewModel<T>(qualifier, owner, parameters).value
+    return viewModel<T>(qualifier, owner, parameters).value
 }
 

--- a/android/koin-android/src/main/java/org/koin/androidx/viewmodel/ext/android/FragmentSharedStateVM.kt
+++ b/android/koin-android/src/main/java/org/koin/androidx/viewmodel/ext/android/FragmentSharedStateVM.kt
@@ -68,7 +68,6 @@ inline fun <reified T : ViewModel> Fragment.getSharedStateViewModel(
     return sharedStateViewModel<T>(qualifier, state, owner, parameters).value
 }
 
-@OptIn(KoinInternalApi::class)
 fun <T : ViewModel> Fragment.getSharedStateViewModel(
     qualifier: Qualifier? = null,
     state: BundleDefinition = emptyState(),

--- a/android/koin-android/src/main/java/org/koin/androidx/viewmodel/ext/android/FragmentStateVM.kt
+++ b/android/koin-android/src/main/java/org/koin/androidx/viewmodel/ext/android/FragmentStateVM.kt
@@ -16,7 +16,6 @@
 package org.koin.androidx.viewmodel.ext.android
 
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.createViewModelLazy
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.ViewModel
 import org.koin.android.ext.android.getKoinScope
@@ -26,7 +25,6 @@ import org.koin.androidx.viewmodel.scope.emptyState
 import org.koin.core.annotation.KoinInternalApi
 import org.koin.core.parameter.ParametersDefinition
 import org.koin.core.qualifier.Qualifier
-import kotlin.reflect.KClass
 
 /**
  * ComponentActivity extensions to help for ViewModel

--- a/android/koin-android/src/main/java/org/koin/androidx/viewmodel/ext/android/FragmentVM.kt
+++ b/android/koin-android/src/main/java/org/koin/androidx/viewmodel/ext/android/FragmentVM.kt
@@ -15,20 +15,14 @@
  */
 package org.koin.androidx.viewmodel.ext.android
 
-import androidx.activity.ComponentActivity
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.ViewModelLazy
-import androidx.lifecycle.ViewModelStoreOwner
 import org.koin.android.ext.android.getKoinScope
 import org.koin.androidx.viewmodel.ViewModelStoreOwnerProducer
-import org.koin.androidx.viewmodel.scope.BundleDefinition
-import org.koin.androidx.viewmodel.scope.emptyState
 import org.koin.core.annotation.KoinInternalApi
 import org.koin.core.parameter.ParametersDefinition
 import org.koin.core.qualifier.Qualifier
-import kotlin.reflect.KClass
 
 //TODO Clean up ViewModelOwnerDefinition
 

--- a/android/koin-androidx-navigation/src/main/java/org/koin/androidx/navigation/NavGraphExt.kt
+++ b/android/koin-androidx-navigation/src/main/java/org/koin/androidx/navigation/NavGraphExt.kt
@@ -26,13 +26,12 @@ inline fun <reified VM : ViewModel> Fragment.koinNavGraphViewModel(
     noinline parameters: ParametersDefinition? = null,
 ): Lazy<VM> {
     val backStackEntry: NavBackStackEntry by lazy { findNavController().getBackStackEntry(navGraphId) }
-    val scope = getKoinScope()
     return viewModels(ownerProducer = { backStackEntry }) {
         getViewModelFactory<VM>(
             owner = backStackEntry,
             qualifier = qualifier,
             parameters = parameters,
-            scope = scope
+            scope = getKoinScope()
         )
     }
 }

--- a/docs/reference/koin-android/scope.md
+++ b/docs/reference/koin-android/scope.md
@@ -99,12 +99,12 @@ abstract class ScopeActivity(
     @LayoutRes contentLayoutId: Int = 0,
 ) : AppCompatActivity(contentLayoutId), AndroidScopeComponent {
 
-    override var scope: Scope? = null
+    override val scope: Scope by activityScope()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        createActivityScope()
+        checkNotNull(scope)
     }
 }
 ```
@@ -118,16 +118,17 @@ To create a Koin scope bound to an Android component, just use the following fun
 - `createActivityRetainedScope()` - Create a retained Scope (backed by ViewModel lifecycle) for current Activity (scope section must be declared)
 - `createFragmentScope()` - Create Scope for current Fragment and link to parent Activity scope
 
+Those functions are available as delegate, to implement different kind of scope:
+
+- `activityScope()` - Create Scope for current Activity (scope section must be declared)
+- `activityRetainedScope()` - Create a retained Scope (backed by ViewModel lifecycle) for current Activity (scope section must be declared)
+- `fragmentScope()` - Create Scope for current Fragment and link to parent Activity scope
+
 ```kotlin
 class MyActivity() : AppCompatActivity(contentLayoutId), AndroidScopeComponent {
 
-    override var scope: Scope? = null
-
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-
-        createActivityScope()
-    }
+    override val scope: Scope by activityScope()
+    
 }
 ```
 
@@ -136,23 +137,12 @@ We can also setup a retained scope (backed by a ViewModel lifecycle) with the fo
 ```kotlin
 class MyActivity() : AppCompatActivity(contentLayoutId), AndroidScopeComponent {
 
-    override var scope: Scope? = null
-
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-
-        createActivityRetainedScope()
-    }
+    override val scope: Scope by activityRetainedScope()
 }
 ```
 
 :::note
 If you don't want to use Android Scope classes, you can work with your own and use `AndroidScopeComponent` with the Scope creation API
-::: 
-
-:::warning
-The previous lazy delegate API is deprecated since 3.2.1: `activityScope()`, `activityRetainedScope()`, `fragmentScope()`,`serviceScope()`
-This has been replaced with more explicit API 
 :::
 
 ## Scope Links

--- a/docs/setup/v3.2.md
+++ b/docs/setup/v3.2.md
@@ -8,8 +8,8 @@ title: Koin 3.2
 
 ```groovy
 koin_version= "3.2.2"
-koin_android_version= "3.2.2"
-koin_android_compose_version= "3.2.1"
+koin_android_version= "3.2.3"
+koin_android_compose_version= "3.2.2"
 koin_ktor= "3.2.2"
 ```
 

--- a/examples/androidx-samples/src/main/java/org/koin/sample/androidx/MainApplication.kt
+++ b/examples/androidx-samples/src/main/java/org/koin/sample/androidx/MainApplication.kt
@@ -27,6 +27,8 @@ class MainApplication : Application() {
             modules(allModules)
         }
 
+        //TODO Load/Unload Koin modules scenario cases
+
         cancelPendingWorkManager(this)
     }
 }

--- a/examples/androidx-samples/src/main/java/org/koin/sample/androidx/di/AppModule.kt
+++ b/examples/androidx-samples/src/main/java/org/koin/sample/androidx/di/AppModule.kt
@@ -55,7 +55,7 @@ val mvvmModule = module {
 
     scope<MVVMActivity> {
 
-        scoped { Session() }
+        scopedOf(::Session)
         fragmentOf(::MVVMFragment) // { MVVMFragment(get()) }
         viewModelOf(::ExtSimpleViewModel)
         viewModelOf(::ExtSimpleViewModel){ named("ext")}
@@ -63,7 +63,7 @@ val mvvmModule = module {
     }
     scope<MVVMFragment> {
         scoped { (id: String) -> ScopedPresenter(id, get()) }
-        scopedOf(::Session)
+//        scopedOf(::Session)
         viewModelOf(::ExtSimpleViewModel)
         viewModelOf(::ExtSimpleViewModel){ named("ext")}
     }
@@ -102,6 +102,6 @@ val navModule = module {
 }
 
 // workerScopedModule can't be runned in unit test
-val allModules = appModule + mvpModule + mvvmModule + scopeModule + workerServiceModule + workerScopedModule + navModule
+val allModules = appModule + mvpModule + mvvmModule + scopeModule + workerServiceModule + workerScopedModule + navModule + scopeModuleActivityA
 
 val allTestModules = appModule + mvpModule + mvvmModule + scopeModule + workerServiceModule + navModule + scopeModuleActivityA

--- a/examples/androidx-samples/src/main/java/org/koin/sample/androidx/mvp/MVPActivity.kt
+++ b/examples/androidx-samples/src/main/java/org/koin/sample/androidx/mvp/MVPActivity.kt
@@ -7,6 +7,9 @@ import org.koin.android.ext.android.get
 import org.koin.android.ext.android.getKoin
 import org.koin.android.ext.android.inject
 import org.koin.android.scope.AndroidScopeComponent
+import org.koin.androidx.scope.ScopeActivity
+import org.koin.androidx.scope.activityRetainedScope
+import org.koin.androidx.scope.activityScope
 import org.koin.androidx.scope.createActivityRetainedScope
 import org.koin.core.parameter.parametersOf
 import org.koin.core.scope.Scope
@@ -19,7 +22,7 @@ import org.koin.sample.androidx.utils.navigateTo
 
 class MVPActivity : AppCompatActivity(R.layout.mvp_activity), AndroidScopeComponent {
 
-    override var scope: Scope? = null
+    override val scope: Scope by activityScope()
 
     // Inject presenter as Factory
     val factoryPresenter: FactoryPresenter by inject { parametersOf(ID) }
@@ -30,13 +33,11 @@ class MVPActivity : AppCompatActivity(R.layout.mvp_activity), AndroidScopeCompon
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        createActivityRetainedScope()
-
         assert(factoryPresenter.id == scopedPresenter.id)
         assert(factoryPresenter.service == scopedPresenter.service)
 
         assert(get<FactoryPresenter> { parametersOf(ID) } != factoryPresenter)
-        assert(requireScope().get<ScopedPresenter>() == scopedPresenter)
+        assert(scope.get<ScopedPresenter>() == scopedPresenter)
 
         title = "Android MVP"
 

--- a/examples/androidx-samples/src/main/java/org/koin/sample/androidx/mvvm/MVVMActivity.kt
+++ b/examples/androidx-samples/src/main/java/org/koin/sample/androidx/mvvm/MVVMActivity.kt
@@ -1,31 +1,21 @@
 package org.koin.sample.androidx.mvvm
 
 import android.os.Bundle
-import androidx.activity.ComponentActivity
-import androidx.activity.viewModels
-import androidx.fragment.app.Fragment
-import androidx.fragment.app.viewModels
-import androidx.lifecycle.ViewModel
-import androidx.savedstate.SavedStateRegistryOwner
 import kotlinx.android.synthetic.main.mvvm_activity.*
 import org.koin.android.ext.android.getKoin
-import org.koin.android.ext.android.getKoinScope
-import org.koin.android.ext.android.inject
 import org.koin.androidx.fragment.android.replace
 import org.koin.androidx.fragment.android.setupKoinFragmentFactory
 import org.koin.androidx.scope.ScopeActivity
-import org.koin.androidx.viewmodel.ViewModelParameter
-import org.koin.androidx.viewmodel.ext.android.getViewModel
 import org.koin.androidx.viewmodel.ext.android.stateViewModel
 import org.koin.androidx.viewmodel.ext.android.viewModel
-import org.koin.androidx.viewmodel.pickFactory
-import org.koin.core.annotation.KoinInternalApi
-import org.koin.core.context.loadKoinModules
 import org.koin.core.parameter.parametersOf
 import org.koin.core.qualifier.named
 import org.koin.sample.android.R
 import org.koin.sample.androidx.components.ID
-import org.koin.sample.androidx.components.mvvm.*
+import org.koin.sample.androidx.components.mvvm.ExtSimpleViewModel
+import org.koin.sample.androidx.components.mvvm.SavedStateBundleViewModel
+import org.koin.sample.androidx.components.mvvm.SavedStateViewModel
+import org.koin.sample.androidx.components.mvvm.SimpleViewModel
 import org.koin.sample.androidx.components.scope.Session
 import org.koin.sample.androidx.scope.ScopedActivityA
 import org.koin.sample.androidx.utils.navigateTo
@@ -43,20 +33,16 @@ class MVVMActivity : ScopeActivity(contentLayoutId = R.layout.mvvm_activity) {
     val savedVm: SavedStateViewModel by stateViewModel { parametersOf("vm1") }
 //    val scopedSavedVm: SavedStateViewModel by viewModel(named("vm2")){ parametersOf("vm2") }
 
-    val state = Bundle().apply { putString("id","vm1") }
-    val stateVM: SavedStateBundleViewModel by stateViewModel(state = {state})
+    val state = Bundle().apply { putString("id", "vm1") }
+    val stateVM: SavedStateBundleViewModel by stateViewModel(state = { state })
 
     override fun onCreate(savedInstanceState: Bundle?) {
         // should set `lifecycleScope` here because we're
         // using MVVMActivity with scope in mvvmModule (AppModule)
-        super.onCreate(savedInstanceState)
         setupKoinFragmentFactory(scope)
+        super.onCreate(savedInstanceState)
 
         assert(simpleViewModel != null)
-
-//        scope.get<Session>()
-//
-//        assert(getViewModel<SimpleViewModel> { parametersOf(ID) } == simpleViewModel)
 
         title = "Android MVVM"
 
@@ -64,16 +50,12 @@ class MVVMActivity : ScopeActivity(contentLayoutId = R.layout.mvvm_activity) {
             .replace<MVVMFragment>(R.id.mvvm_frame)
             .commit()
 
-        getKoin().setProperty("session_id", requireScope().get<Session>().id)
+        getKoin().setProperty("session_id", scope.get<Session>().id)
 
         mvvm_button.setOnClickListener {
             navigateTo<ScopedActivityA>(isRoot = true)
         }
 
-//        assert(vm1 == vm2)
-//        assert(savedVm.id != scopedSavedVm.id)
-////        assert("value to stateViewModel" == savedVm.handle.get("vm1"))
-//        assert("value to scope.stateViewModel" == scopedSavedVm.handle.get("vm3"))
         assert(scopeVm.session.id == extScopeVm.session.id)
         assert(stateVM.result == "vm1")
     }

--- a/examples/androidx-samples/src/main/java/org/koin/sample/androidx/mvvm/MVVMFragment.kt
+++ b/examples/androidx-samples/src/main/java/org/koin/sample/androidx/mvvm/MVVMFragment.kt
@@ -2,9 +2,12 @@ package org.koin.sample.androidx.mvvm
 
 import android.os.Bundle
 import android.view.View
+import androidx.fragment.app.Fragment
 import org.koin.android.ext.android.get
 import org.koin.android.ext.android.getKoin
+import org.koin.android.scope.AndroidScopeComponent
 import org.koin.androidx.scope.ScopeFragment
+import org.koin.androidx.scope.fragmentScope
 import org.koin.androidx.scope.requireScopeActivity
 import org.koin.androidx.viewmodel.ext.android.getSharedViewModel
 import org.koin.androidx.viewmodel.ext.android.sharedViewModel
@@ -13,6 +16,7 @@ import org.koin.androidx.viewmodel.ext.android.viewModel
 import org.koin.androidx.viewmodel.scope.emptyState
 import org.koin.core.parameter.parametersOf
 import org.koin.core.qualifier.named
+import org.koin.core.scope.Scope
 import org.koin.sample.android.R
 import org.koin.sample.androidx.components.ID
 import org.koin.sample.androidx.components.mvvm.ExtSimpleViewModel
@@ -20,7 +24,9 @@ import org.koin.sample.androidx.components.mvvm.SavedStateViewModel
 import org.koin.sample.androidx.components.mvvm.SimpleViewModel
 import org.koin.sample.androidx.components.scope.Session
 
-class MVVMFragment(val session: Session) : ScopeFragment(contentLayoutId = R.layout.mvvm_fragment) {
+class MVVMFragment(val session: Session) : Fragment(R.layout.mvvm_fragment), AndroidScopeComponent {
+
+    override val scope: Scope by fragmentScope()
 
     val simpleViewModel: SimpleViewModel by viewModel { parametersOf(ID) }
     val scopeVm: ExtSimpleViewModel by viewModel()
@@ -52,5 +58,6 @@ class MVVMFragment(val session: Session) : ScopeFragment(contentLayoutId = R.lay
         assert(saved == saved2)
 
         assert(requireScopeActivity<MVVMActivity>().get<Session>().id == getKoin().getProperty("session_id"))
+        assert(scope.get<Session>().id == requireScopeActivity<MVVMActivity>().get<Session>().id)
     }
 }

--- a/examples/androidx-samples/src/main/java/org/koin/sample/androidx/scope/ScopedActivityA.kt
+++ b/examples/androidx-samples/src/main/java/org/koin/sample/androidx/scope/ScopedActivityA.kt
@@ -7,6 +7,8 @@ import org.koin.android.ext.android.get
 import org.koin.android.ext.android.getKoin
 import org.koin.android.ext.android.inject
 import org.koin.android.scope.AndroidScopeComponent
+import org.koin.androidx.scope.RetainedScopeActivity
+import org.koin.androidx.scope.ScopeActivity
 import org.koin.androidx.scope.createActivityRetainedScope
 import org.koin.core.context.loadKoinModules
 import org.koin.core.context.unloadKoinModules
@@ -19,29 +21,20 @@ import org.koin.sample.androidx.components.scope.SessionActivity
 import org.koin.sample.androidx.di.scopeModuleActivityA
 import org.koin.sample.androidx.utils.navigateTo
 
-class ScopedActivityA : AppCompatActivity(R.layout.scoped_activity_a), AndroidScopeComponent {
+class ScopedActivityA : RetainedScopeActivity(R.layout.scoped_activity_a) {
 
     // Inject from current scope
     val currentSession by inject<Session>()
-    val currentActivitySession by inject<SessionActivity>()
-
-    // Don't mix Activity Android Scopes
-    val longSession by inject<Session>()
-
-    override var scope: Scope? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        loadKoinModules(scopeModuleActivityA)
-        createActivityRetainedScope()
-
         assert(currentSession == get<Session>())
         if (SESSION_ID_VAR.isEmpty()) {
-            println("Create ID from session: $SESSION_ID_VAR")
-            SESSION_ID_VAR = longSession.id
+            println("Create ID for session: $SESSION_ID_VAR")
+            SESSION_ID_VAR = currentSession.id
         }
-        assert(SESSION_ID_VAR == longSession.id)
+        assert(SESSION_ID_VAR == currentSession.id)
 
         // Conpare different scope instances
         val scopeSession1 = getKoin().createScope(SESSION_1, named(SCOPE_ID))
@@ -68,11 +61,6 @@ class ScopedActivityA : AppCompatActivity(R.layout.scoped_activity_a), AndroidSc
 
         scopeSession1.close()
         scopeSession2.close()
-    }
-
-    override fun onDestroy() {
-        super.onDestroy()
-        unloadKoinModules(scopeModuleActivityA)
     }
 
     companion object {

--- a/examples/androidx-samples/src/main/java/org/koin/sample/androidx/sdk/HostActivity.kt
+++ b/examples/androidx-samples/src/main/java/org/koin/sample/androidx/sdk/HostActivity.kt
@@ -42,7 +42,7 @@ class HostActivity : ScopeActivity(), CustomKoinComponent {
         val defaultKoin = GlobalContext.get()
 
         assert(scope != koinSDKRootScope)
-        val sdkSession2 = requireScope().get<Session>()
+        val sdkSession2 = scope.get<Session>()
         assert(sdkSession == sdkSession2)
 
         val globalService = defaultKoin.get<SimpleService>()//CustomSDK.koinApp.koin.get<SimpleService>()

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -1,7 +1,7 @@
 ext {
     // Koin Versions
     koin_version = '3.2.2'
-    koin_android_version = '3.2.2'
+    koin_android_version = '3.2.3'
 
     // pass it to true to make release
     is_snaptshot = true


### PR DESCRIPTION
* `[FIXED]` - Fix Broken Scope API and revert back `AndroidScopeComponent` with related API in `Activity` & `Fragment`. Reworked `activityScope()`, `activityRetainedScope()` and `fragmentScope()`. Removed Deprecations. #1443 #1448
* `[FIXED]` - Fix NavGraph scope resolution #1446