### PR TITLE
Fix race condition in scope resolveInstance

### DIFF
--- a/core/koin-core/build.gradle
+++ b/core/koin-core/build.gradle
@@ -49,6 +49,7 @@ kotlin {
             dependencies {
                 implementation kotlin("test-common")
                 implementation kotlin("test-annotations-common")
+                implementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.4"
             }
         }
 

--- a/core/koin-core/src/commonMain/kotlin/org/koin/core/scope/Scope.kt
+++ b/core/koin-core/src/commonMain/kotlin/org/koin/core/scope/Scope.kt
@@ -218,13 +218,17 @@ data class Scope(
         val parameters = parameterDef?.invoke()
         if (parameters != null) {
             _koin.logger.log(Level.DEBUG) { "| put parameters on stack $parameters " }
-            _parameterStack.addFirst(parameters)
+            KoinPlatformTools.synchronized(this@Scope) {
+                _parameterStack.addFirst(parameters)
+            }
         }
         val instanceContext = InstanceContext(_koin, this, parameters)
         val value = resolveValue<T>(qualifier, clazz, instanceContext, parameterDef)
         if (parameters != null) {
             _koin.logger.log(Level.DEBUG) { "| remove parameters from stack" }
-            _parameterStack.removeFirstOrNull()
+            KoinPlatformTools.synchronized(this@Scope) {
+                _parameterStack.removeFirstOrNull()
+            }
         }
         return value
     }
@@ -252,7 +256,9 @@ data class Scope(
             findInOtherScope<T>(clazz, qualifier, parameterDef)
         }
         ?: run {
-            _parameterStack.clear()
+            KoinPlatformTools.synchronized(this@Scope) {
+                _parameterStack.clear()
+            }
             _koin.logger.log(Level.DEBUG) { "| clear parameter stack" }
             throwDefinitionNotFound(qualifier, clazz)
         })

--- a/core/koin-core/src/commonTest/kotlin/org/koin/core/ParametersInjectionTest.kt
+++ b/core/koin-core/src/commonTest/kotlin/org/koin/core/ParametersInjectionTest.kt
@@ -245,7 +245,7 @@ class ParametersInjectionTest {
 
         val koin = app.koin
 
-        for (i in 0..1000) {
+        repeat(1000) {
             val range = (0 until 1000)
             val deferreds = range.map {
                 async(Dispatchers.Default) {


### PR DESCRIPTION
Fix an issue where concurrent calls to koin.get would create a race condition resulting in this stack trace:

```
Fatal Exception: java.util.NoSuchElementException
ArrayDeque is empty.
kotlin.collections.ArrayDeque.removeFirst (ArrayDeque.kt:145) 
kotlin.collections.ArrayDeque.removeFirstOrNull (ArrayDeque.java:157) 
org.koin.core.scope.Scope.resolveInstance (Scope.kt:244) 
org.koin.core.scope.Scope.get (Scope.kt:204)
org.koin.core.scope.Scope.getOrNull (Scope.kt:172)
```

ArrayDeque is not a thread-safe collection, by wrapping calls to parameterStack in a synchronized block it makes sure the race condition cannot happen.

Also added a test that reproduced quite easily the problem.

Closes #1149