### PR TITLE
Updated NavGraph and related doc

### DIFF
--- a/android/koin-androidx-navigation/src/main/java/org/koin/androidx/navigation/NavGraphExt.kt
+++ b/android/koin-androidx-navigation/src/main/java/org/koin/androidx/navigation/NavGraphExt.kt
@@ -26,3 +26,20 @@ inline fun <reified VM : ViewModel> Fragment.koinNavGraphViewModel(
 ): Lazy<VM> {
     return viewModel(qualifier, ownerProducer, extrasProducer, parameters)
 }
+
+/**
+ * Request a ViewModel instance, scoped to Navigation graph route
+ *
+ * @param route
+ *
+ * @author Marco Cattaneo
+ */
+inline fun <reified VM : ViewModel> Fragment.koinNavGraphViewModel(
+    route: String,
+    qualifier: Qualifier? = null,
+    noinline ownerProducer: () -> ViewModelStoreOwner = { findNavController().getBackStackEntry(route) },
+    noinline extrasProducer: (() -> CreationExtras)? = null,
+    noinline parameters: (() -> ParametersHolder)? = null,
+): Lazy<VM> {
+    return viewModel(qualifier, ownerProducer, extrasProducer, parameters)
+}

--- a/docs/reference/koin-android/viewmodel.md
+++ b/docs/reference/koin-android/viewmodel.md
@@ -165,12 +165,22 @@ All `stateViewModel` functions are deprecated. You can just use the regular `vie
 
 ## Navigation Graph ViewModel
 
-You can scope a ViewModel instance to your Navigation graph. Just retrieve with `by koinNavGraphViewModel()`. You just need your graph Id.
+You can scope a ViewModel instance to your Navigation graph. Just retrieve with `by koinNavGraphViewModel()`. You just need your graph Id or the route of a destination that exists on the back stack.
 
 ```kotlin
 class NavFragment : Fragment() {
 
     val mainViewModel: NavViewModel by koinNavGraphViewModel(R.id.my_graph)
+
+}
+```
+
+with the route:
+
+```kotlin
+class NavFragment : Fragment() {
+
+    val mainViewModel: NavViewModel by koinNavGraphViewModel("valid_route")
 
 }
 ```


### PR DESCRIPTION
I have added a new `koinNavGraphViewModel()` method with a route parameter in order to add the capability to get the ViewModel based on a Navigation route.

This is useful if we create a NavGraph programmatically instead of the `R.navigation.*` XML as documented here:

> https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:navigation/navigation-common/src/main/java/androidx/navigation/NavGraphBuilder.kt;l=53-58?q=NavGraphBuilder&ss=androidx%2Fplatform%2Fframeworks%2Fsupport

