### PR TITLE
Updating readme with the correct class names

### DIFF
--- a/docs/reference/koin-android/workmanager.md
+++ b/docs/reference/koin-android/workmanager.md
@@ -87,8 +87,8 @@ That's something that checkModules could help: if any class in the project imple
 ```kotlin
 
 val workerFactoryModule = module {
-   factory<WorkFactory> { WorkFactory1() }
-   factory<WorkFactory> { WorkFactory2() }
+   factory<WorkerFactory> { WorkerFactory1() }
+   factory<WorkerFactory> { WorkerFactory2() }
 }
 ```
 


### PR DESCRIPTION
There is no WorkFactory class. It should be WorkerFactory. I also renamed example class names accordingly.