### PR TITLE
Fix conditions for resolving a value by the scope's source

### DIFF
--- a/core/koin-core/src/commonMain/kotlin/org/koin/core/scope/Scope.kt
+++ b/core/koin-core/src/commonMain/kotlin/org/koin/core/scope/Scope.kt
@@ -251,7 +251,7 @@ data class Scope(
         ?: run {
             _koin.logger.debug("|- ? t:'${clazz.getFullName()}' - q:'$qualifier' look at scope source" )
             _source?.let {
-                if (clazz.isInstance(it)) {
+                if (it::class == clazz && qualifier == null) {
                     _source as? T
                 } else null
             }


### PR DESCRIPTION
Currently a value is resolved by the scope's source even if the class of the definition is not equal to the class of the source value and even if a qualifier is actually defined. 

This leads to undesired behavior in some cases, e.g. when the source of a scope is an Android Activity and the Application Context should be injected from that scope:

```
// in Android Application onCreate
startKoin {
  androidContext(context) // context is Application
  modules(
    module {
      scope<MyActivity> {
        scoped { MyPresenter(androidContext()) }
      }
    }
  )
}
```

```
class MyActivity : ScopeActivity() {
    val presenter : MyPresenter by inject() // WRONG: MyPresenter gets this activity injected as Context instead of the ApplicationContext as it is the scope's source and is an instance of Context
}
```

This PR fixes that behavior.