### PR TITLE
Fixing race condition in Scope

### DIFF
--- a/core/koin-core/build.gradle
+++ b/core/koin-core/build.gradle
@@ -71,6 +71,7 @@ kotlin {
             dependsOn commonMain
             dependencies {
                 implementation 'org.jetbrains.kotlin:kotlin-stdlib-js'
+                implementation "co.touchlab:stately-concurrency:1.2.2"
             }
         }
 

--- a/core/koin-core/src/commonMain/kotlin/org/koin/mp/KoinPlatformTools.kt
+++ b/core/koin-core/src/commonMain/kotlin/org/koin/mp/KoinPlatformTools.kt
@@ -32,3 +32,9 @@ expect object KoinPlatformTools {
 }
 
 expect open class Lockable()
+
+expect open class ThreadLocal<T>() {
+    fun get(): T?
+    fun set(value: T?)
+    fun remove()
+}

--- a/core/koin-core/src/commonTest/kotlin/org/koin/core/ParameterStackTest.kt
+++ b/core/koin-core/src/commonTest/kotlin/org/koin/core/ParameterStackTest.kt
@@ -28,6 +28,6 @@ class ParameterStackTest {
             koin.get<Simple.MyStringFactory> { parametersOf(KoinPlatformTools.generateId()) }
         }
 
-        assertTrue(koin.scopeRegistry.rootScope._parameterStack.isEmpty())
+        assertTrue(koin.scopeRegistry.rootScope._parameterStackLocal.get()!!.isEmpty())
     }
 }

--- a/core/koin-core/src/jsMain/kotlin/org/koin/mp/PlatformTools.kt
+++ b/core/koin-core/src/jsMain/kotlin/org/koin/mp/PlatformTools.kt
@@ -1,5 +1,6 @@
 package org.koin.mp
 
+import co.touchlab.stately.concurrency.ThreadLocalRef
 import org.koin.core.context.GlobalContext
 import org.koin.core.context.KoinContext
 import org.koin.core.logger.*
@@ -37,3 +38,5 @@ actual object KoinPlatformTools {
 }
 
 actual typealias Lockable = Any
+
+actual typealias ThreadLocal<T> = ThreadLocalRef<T>

--- a/core/koin-core/src/jvmMain/kotlin/org/koin/mp/KoinPlatformTools.kt
+++ b/core/koin-core/src/jvmMain/kotlin/org/koin/mp/KoinPlatformTools.kt
@@ -22,3 +22,5 @@ actual object KoinPlatformTools {
 }
 
 actual typealias Lockable = Any
+
+actual typealias ThreadLocal<T> = java.lang.ThreadLocal<T>

--- a/core/koin-core/src/nativeMain/kotlin/org/koin/mp/KoinPlatformTools.kt
+++ b/core/koin-core/src/nativeMain/kotlin/org/koin/mp/KoinPlatformTools.kt
@@ -2,6 +2,7 @@ package org.koin.mp
 
 import co.touchlab.stately.concurrency.Lock
 import co.touchlab.stately.concurrency.withLock
+import co.touchlab.stately.concurrency.ThreadLocalRef
 import org.koin.core.context.KoinContext
 import org.koin.core.context.globalContextByMemoryModel
 import org.koin.core.logger.Level
@@ -39,3 +40,5 @@ actual object KoinPlatformTools {
 actual open class Lockable {
     internal val lock = Lock()
 }
+
+actual typealias ThreadLocal<T> = ThreadLocalRef<T>


### PR DESCRIPTION
A race condition may occur when using the same Scope from different threads.
Now only add and remove calls are synchronized. And operations between these calls can be in a race.

Imagine that 2 threads are simultaneously resolving instances from some scope. These instances need parameters to be created. This means that some of their dependencies will be found in `_parameterStack`.

We call the `resolveInstance` method simultaneously from both threads.
The first thread puts the parameters on the `_parameterStack`. The second thread does the same. Next, the first thread calls `_parameterStack.firstOrNull()` and gets parameters from the second thread.
It turns out that the threads swapped their parameters.

This could be solved by additional synchronization, but in fact the threads don't need to be synchronized here. Resolution of particular dependencies takes place on a single thread, the main thing is to make sure that the stack is not changed from the outside during the resolution.
ThreadLocal is suitable for this purpose.

And since we made `_parameterStack` thread local, we don't need to additionally synchronize access to it and can remove `KoinPlatformTools.synchronized(this)`.