### PR TITLE
#1569 Provide more helpful error message for CheckModules with secondary types

### DIFF
--- a/core/koin-test-junit4/src/test/kotlin/org/koin/test/CheckModulesTest.kt
+++ b/core/koin-test-junit4/src/test/kotlin/org/koin/test/CheckModulesTest.kt
@@ -6,7 +6,6 @@ import org.junit.Test
 import org.koin.core.logger.Level
 import org.koin.core.parameter.parametersOf
 import org.koin.core.qualifier.named
-import org.koin.core.scope.Scope
 import org.koin.dsl.bind
 import org.koin.dsl.binds
 import org.koin.dsl.koinApplication
@@ -16,6 +15,8 @@ import org.koin.test.check.checkModules
 import org.koin.test.mock.MockProviderRule
 import org.mockito.Mockito
 import java.util.*
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 
 class CheckModulesTest {
 
@@ -573,7 +574,7 @@ class CheckModulesTest {
 
     @Test
     fun `check a module with wrong secondary types array - error`() {
-        try {
+        val exception = assertFailsWith<IllegalArgumentException> {
             koinApplication {
                 printLogger(Level.DEBUG)
                 modules(
@@ -585,9 +586,11 @@ class CheckModulesTest {
                     }
                 )
             }.checkModules()
-            fail("should not pass with broken definitions")
-        } catch (e: Exception) {
-            e.printStackTrace()
         }
+
+        assertEquals(
+            expected = "instance of class kotlin.String is not inheritable from class kotlin.Int",
+            actual = exception.message,
+        )
     }
 }

--- a/core/koin-test/src/commonMain/kotlin/org/koin/test/check/CheckModules.kt
+++ b/core/koin-test/src/commonMain/kotlin/org/koin/test/check/CheckModules.kt
@@ -21,7 +21,6 @@ import org.koin.core.annotation.KoinInternalApi
 import org.koin.core.context.startKoin
 import org.koin.core.context.stopKoin
 import org.koin.core.definition.BeanDefinition
-import org.koin.core.instance.InstanceFactory
 import org.koin.core.logger.Level
 import org.koin.core.module.Module
 import org.koin.core.parameter.ParametersHolder
@@ -29,7 +28,6 @@ import org.koin.core.qualifier.Qualifier
 import org.koin.core.qualifier.TypeQualifier
 import org.koin.core.scope.Scope
 import org.koin.dsl.KoinAppDeclaration
-import org.koin.dsl.koinApplication
 import org.koin.mp.KoinPlatformTools
 import org.koin.test.mock.MockProvider
 import org.koin.test.parameter.MockParameter
@@ -141,7 +139,7 @@ private fun Koin.checkDefinition(
     definition: BeanDefinition<*>,
     scope: Scope
 ) {
-    val parameters : ParametersHolder = allParameters.parametersCreators[CheckedComponent(
+    val parameters: ParametersHolder = allParameters.parametersCreators[CheckedComponent(
         definition.qualifier,
         definition.primaryType
     )]?.invoke(
@@ -152,6 +150,8 @@ private fun Koin.checkDefinition(
 
     for (secondaryType in definition.secondaryTypes) {
         val valueAsSecondary = scope.get<Any>(secondaryType, definition.qualifier) { parameters }
-        require(secondaryType.isInstance(valueAsSecondary))
+        require(secondaryType.isInstance(valueAsSecondary)) {
+            "instance of ${valueAsSecondary::class} is not inheritable from $secondaryType"
+        }
     }
 }


### PR DESCRIPTION
Issue: #1569

With wrong secondary type definitions, the error message was just "Failed requirement."

Now: "instance of <type A> is not inheritable from <type B>"