### PR TITLE
Avoid retaining outdated LocalKoinApplication/LocalKoinScope

### DIFF
--- a/compose/koin-androidx-compose-navigation/src/main/java/org/koin/androidx/compose/navigation/NavViewModel.kt
+++ b/compose/koin-androidx-compose-navigation/src/main/java/org/koin/androidx/compose/navigation/NavViewModel.kt
@@ -18,11 +18,12 @@
 package org.koin.androidx.compose.navigation
 
 import androidx.compose.runtime.Composable
-import androidx.lifecycle.*
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelStoreOwner
 import androidx.lifecycle.viewmodel.CreationExtras
 import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
 import org.koin.androidx.viewmodel.resolveViewModel
-import org.koin.compose.LocalKoinScope
+import org.koin.compose.getKoinScope
 import org.koin.core.annotation.KoinInternalApi
 import org.koin.core.parameter.ParametersDefinition
 import org.koin.core.qualifier.Qualifier
@@ -45,7 +46,7 @@ inline fun <reified T : ViewModel> koinNavViewModel(
     },
     key: String? = null,
     extras: CreationExtras = defaultNavExtras(viewModelStoreOwner),
-    scope: Scope = LocalKoinScope.current,
+    scope: Scope = getKoinScope(),
     noinline parameters: ParametersDefinition? = null,
 ): T {
     return resolveViewModel(

--- a/compose/koin-androidx-compose/src/main/java/org/koin/androidx/compose/KoinApplication.kt
+++ b/compose/koin-androidx-compose/src/main/java/org/koin/androidx/compose/KoinApplication.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:OptIn(KoinInternalApi::class)
+
+package org.koin.androidx.compose
+
+import android.app.Application
+import android.content.ComponentCallbacks
+import android.content.Context
+import android.content.ContextWrapper
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
+import org.koin.android.ext.android.getKoin
+import org.koin.compose.LocalKoinApplication
+import org.koin.compose.LocalKoinScope
+import org.koin.core.annotation.KoinInternalApi
+import org.koin.core.component.KoinComponent
+
+/**
+ * Provide active Koin application from Android [Context] to Compose
+ *
+ * @param content - following compose function
+ *
+ * @author Jan-Jelle Kester
+ */
+@Composable
+fun KoinApplication(content: @Composable () -> Unit) {
+    val context = LocalContext.current
+    val koinApplication = remember(context) {
+        context.findContextForKoin().getKoin()
+    }
+    CompositionLocalProvider(
+        LocalKoinApplication provides koinApplication,
+        LocalKoinScope provides koinApplication.scopeRegistry.rootScope,
+        content = content
+    )
+}
+
+/**
+ * Find the [KoinComponent] in the Context tree
+ */
+private fun Context.findContextForKoin(): ComponentCallbacks {
+    var context = this
+    while (context is ContextWrapper) {
+        if (context is KoinComponent && context is ComponentCallbacks) return context
+        context = context.baseContext
+    }
+    return applicationContext as Application
+}

--- a/compose/koin-androidx-compose/src/main/java/org/koin/androidx/compose/ViewModel.kt
+++ b/compose/koin-androidx-compose/src/main/java/org/koin/androidx/compose/ViewModel.kt
@@ -18,11 +18,12 @@
 package org.koin.androidx.compose
 
 import androidx.compose.runtime.Composable
-import androidx.lifecycle.*
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelStoreOwner
 import androidx.lifecycle.viewmodel.CreationExtras
 import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
 import org.koin.androidx.viewmodel.resolveViewModel
-import org.koin.compose.LocalKoinScope
+import org.koin.compose.getKoinScope
 import org.koin.core.annotation.KoinInternalApi
 import org.koin.core.parameter.ParametersDefinition
 import org.koin.core.qualifier.Qualifier
@@ -45,7 +46,7 @@ inline fun <reified T : ViewModel> getViewModel(
     },
     key: String? = null,
     extras: CreationExtras = defaultExtras(viewModelStoreOwner),
-    scope: Scope = LocalKoinScope.current,
+    scope: Scope = getKoinScope(),
     noinline parameters: ParametersDefinition? = null,
 ): T {
     return koinViewModel(qualifier, viewModelStoreOwner, key, extras, scope, parameters)
@@ -60,7 +61,7 @@ inline fun <reified T : ViewModel> koinViewModel(
     },
     key: String? = null,
     extras: CreationExtras = defaultExtras(viewModelStoreOwner),
-    scope: Scope = LocalKoinScope.current,
+    scope: Scope = getKoinScope(),
     noinline parameters: ParametersDefinition? = null,
 ): T {
     return resolveViewModel(

--- a/compose/koin-compose/src/commonMain/kotlin/org/koin/compose/Inject.kt
+++ b/compose/koin-compose/src/commonMain/kotlin/org/koin/compose/Inject.kt
@@ -33,7 +33,7 @@ import org.koin.core.scope.Scope
 @Composable
 inline fun <reified T> koinInject(
     qualifier: Qualifier? = null,
-    scope: Scope = LocalKoinScope.current,
+    scope: Scope = getKoinScope(),
     noinline parameters: ParametersDefinition? = null,
 ): T = rememberKoinInject(qualifier, scope, parameters)
 
@@ -47,10 +47,8 @@ inline fun <reified T> koinInject(
 @Composable
 inline fun <reified T> rememberKoinInject(
     qualifier: Qualifier? = null,
-    scope: Scope = LocalKoinScope.current,
+    scope: Scope = getKoinScope(),
     noinline parameters: ParametersDefinition? = null,
 ): T = remember(qualifier, scope, parameters) {
     scope.get(qualifier, parameters)
 }
-
-


### PR DESCRIPTION
The `CompositionLocal`s that Koin uses only work when the (`GlobalContext`) Koin application is not changed at runtime, see #1557 

#### Option 1: The `KoinApplication` composable

The Koin application is looked up in the `Context` tree and the Koin `CompositionLocal`s are provided with/from this value. This (still) requires this function to be called around the first time Koin is used from Compose. A practical place for this is the `setContent` function. This means that (boilerplate) code needs to be added to every Activity or Fragment using Compose, and every test case where a Composable is tested in isolation.

Benefits:
- Works in Kotlin Compose Multiplatform
- Follows principles of already existing APIs

Drawbacks:
- Use is required to keep Compose and Context based APIs in sync, easy to forget to add

#### Option 2: Throwing `UnknownKoinContext` in the default value factory

By throwing an exception as default factory for the `CompositionLocal`s we signal that there is no explicit value set. This will trigger the default lookup behavior that used to be the result of the factory function, as long as the appropriate functions `getKoin()` and `getKoinScope()` are used. By using the internal Compose API we are able to catch the exception to run the lookup code. We remember the result of the try/catch block to ensure we only incur the overhead of the exception once per `getKoin()` call per composition.

The default value of a `CompositionLocal` is singleton for the JVM process; when remembering a value as done in this approach the specific value is tied to the composition where it is used.

Benefits:
- Developers do not have to add the `KoinApplication` composable as compared to option 1

Drawbacks:
- Exceptions means a performance hit
- Uses an internal Compose API that we are not supposed to call

#### Other options

- Always retrieve the Koin application from the Android Context on Android
  - This means a specific Android implementation while the MPP code stays the same
- Reuse the initially referenced objects in Koin
  - This means keeping the same global `Koin` and `Scope` objects, even when a different Koin application is started using the test rule
  - Unsure about viability
- Ask Compose devs nicely to create a `CompositionLocal` variant that evaluates the default value expression every time instead of using `lazy` (and wait a long time for them to implement it)

### Open tasks

- [ ] Investigate alternatives
- [ ] Investigate integrations with test frameworks for testing standalone composables
- [ ] Analyze performance of exception strategy
- [ ] Add test cases
  - [ ] Looking up the right Koin application from the Android context
  - [ ] Resolving #1557 for Robolectric and Android instrumented tests

### Open questions to maintainer(s)

- Where to place Robolectric and instrumented tests?
- What is the preferred solution?