### PR TITLE
Don't ignore key to get a viewmodel when a qualifier is present

### DIFF
--- a/android/gradle/versions.gradle
+++ b/android/gradle/versions.gradle
@@ -1,6 +1,6 @@
 ext {
     // Koin Versions
-    koin_android_version = '3.4.0'
+    koin_android_version = '3.4.1-SNAPSHOT'
 
     // build Tools
     android_min_version = 14

--- a/android/koin-android/src/main/java/org/koin/androidx/viewmodel/GetViewModel.kt
+++ b/android/koin-android/src/main/java/org/koin/androidx/viewmodel/GetViewModel.kt
@@ -39,7 +39,7 @@ fun <T : ViewModel> resolveViewModel(
     val factory = KoinViewModelFactory(vmClass, scope, qualifier, parameters)
     val provider = ViewModelProvider(viewModelStore, factory, extras)
     return when {
-        qualifier != null -> provider[qualifier.value, modelClass]
+        qualifier != null -> provider[qualifier.value + key?.let { "_$it" }, modelClass]
         key != null -> provider[key, modelClass]
         else -> provider[modelClass]
     }

--- a/core/gradle/versions.gradle
+++ b/core/gradle/versions.gradle
@@ -1,6 +1,6 @@
 ext {
     // Koin Versions
-    koin_version = '3.4.0'
+    koin_version = '3.4.1-SNAPSHOT'
     
     // Kotlin
     kotlin_version = '1.8.10'

--- a/ktor/gradle/versions.gradle
+++ b/ktor/gradle/versions.gradle
@@ -1,6 +1,6 @@
 ext {
     // Koin
-    koin_ktor_version = '3.4.0'
+    koin_ktor_version = '3.4.1-SNAPSHOT'
     // Ktor
     ktor_version = '2.2.4'
 }


### PR DESCRIPTION
Right now, the key is ignored in case a qualifier is used. I don't think that's the correct behavior as it makes it now impossible to force the creation of a new view model in case parameters have changed that require a new view model.

Relates to https://github.com/InsertKoinIO/koin/issues/1578 and https://github.com/InsertKoinIO/koin/issues/1477