### PR TITLE
Fix type parameter count for scopedOf methods

### DIFF
--- a/core/koin-core/src/commonMain/kotlin/org/koin/core/module/dsl/ScopedOf.kt
+++ b/core/koin-core/src/commonMain/kotlin/org/koin/core/module/dsl/ScopedOf.kt
@@ -128,7 +128,7 @@ inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T
 /**
  * @see scopedOf
  */
-inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16, reified T17, reified T18, reified T19, reified T20, reified T21, reified T22> ScopeDSL.scopedOf(
+inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11> ScopeDSL.scopedOf(
     crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11) -> R,
     noinline options: DefinitionOptions<R>? = null,
 ): KoinDefinition<R> = scoped { new(constructor) }.onOptions(options)
@@ -136,7 +136,7 @@ inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T
 /**
  * @see scopedOf
  */
-inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16, reified T17, reified T18, reified T19, reified T20, reified T21, reified T22> ScopeDSL.scopedOf(
+inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12> ScopeDSL.scopedOf(
     crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12) -> R,
     noinline options: DefinitionOptions<R>? = null,
 ): KoinDefinition<R> = scoped { new(constructor) }.onOptions(options)
@@ -144,7 +144,7 @@ inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T
 /**
  * @see scopedOf
  */
-inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16, reified T17, reified T18, reified T19, reified T20, reified T21, reified T22> ScopeDSL.scopedOf(
+inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13> ScopeDSL.scopedOf(
     crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13) -> R,
     noinline options: DefinitionOptions<R>? = null,
 ): KoinDefinition<R> = scoped { new(constructor) }.onOptions(options)
@@ -152,7 +152,7 @@ inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T
 /**
  * @see scopedOf
  */
-inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16, reified T17, reified T18, reified T19, reified T20, reified T21, reified T22> ScopeDSL.scopedOf(
+inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14> ScopeDSL.scopedOf(
     crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14) -> R,
     noinline options: DefinitionOptions<R>? = null,
 ): KoinDefinition<R> = scoped { new(constructor) }.onOptions(options)
@@ -160,7 +160,7 @@ inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T
 /**
  * @see scopedOf
  */
-inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16, reified T17, reified T18, reified T19, reified T20, reified T21, reified T22> ScopeDSL.scopedOf(
+inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15> ScopeDSL.scopedOf(
     crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15) -> R,
     noinline options: DefinitionOptions<R>? = null,
 ): KoinDefinition<R> = scoped { new(constructor) }.onOptions(options)
@@ -168,7 +168,7 @@ inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T
 /**
  * @see scopedOf
  */
-inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16, reified T17, reified T18, reified T19, reified T20, reified T21, reified T22> ScopeDSL.scopedOf(
+inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16> ScopeDSL.scopedOf(
     crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16) -> R,
     noinline options: DefinitionOptions<R>? = null,
 ): KoinDefinition<R> = scoped { new(constructor) }.onOptions(options)
@@ -176,7 +176,7 @@ inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T
 /**
  * @see scopedOf
  */
-inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16, reified T17, reified T18, reified T19, reified T20, reified T21, reified T22> ScopeDSL.scopedOf(
+inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16, reified T17> ScopeDSL.scopedOf(
     crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17) -> R,
     noinline options: DefinitionOptions<R>? = null,
 ): KoinDefinition<R> = scoped { new(constructor) }.onOptions(options)
@@ -184,7 +184,7 @@ inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T
 /**
  * @see scopedOf
  */
-inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16, reified T17, reified T18, reified T19, reified T20, reified T21, reified T22> ScopeDSL.scopedOf(
+inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16, reified T17, reified T18> ScopeDSL.scopedOf(
     crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18) -> R,
     noinline options: DefinitionOptions<R>? = null,
 ): KoinDefinition<R> = scoped { new(constructor) }.onOptions(options)
@@ -192,7 +192,7 @@ inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T
 /**
  * @see scopedOf
  */
-inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16, reified T17, reified T18, reified T19, reified T20, reified T21, reified T22> ScopeDSL.scopedOf(
+inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16, reified T17, reified T18, reified T19> ScopeDSL.scopedOf(
     crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19) -> R,
     noinline options: DefinitionOptions<R>? = null,
 ): KoinDefinition<R> = scoped { new(constructor) }.onOptions(options)
@@ -200,7 +200,7 @@ inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T
 /**
  * @see scopedOf
  */
-inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16, reified T17, reified T18, reified T19, reified T20, reified T21, reified T22> ScopeDSL.scopedOf(
+inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16, reified T17, reified T18, reified T19, reified T20> ScopeDSL.scopedOf(
     crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20) -> R,
     noinline options: DefinitionOptions<R>? = null,
 ): KoinDefinition<R> = scoped { new(constructor) }.onOptions(options)
@@ -208,7 +208,7 @@ inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T
 /**
  * @see scopedOf
  */
-inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16, reified T17, reified T18, reified T19, reified T20, reified T21, reified T22> ScopeDSL.scopedOf(
+inline fun <reified R, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16, reified T17, reified T18, reified T19, reified T20, reified T21> ScopeDSL.scopedOf(
     crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21) -> R,
     noinline options: DefinitionOptions<R>? = null,
 ): KoinDefinition<R> = scoped { new(constructor) }.onOptions(options)


### PR DESCRIPTION
The `scopedOf` extension functions with more than 10 constructor parameters have an incorrect number of type parameters.
This causes compile time errors when using them: `Not enough information to infer type variable T12`

Fixes https://github.com/InsertKoinIO/koin/issues/1505