### PR TITLE
Use more gradle-build-action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,14 +110,9 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: 11
-    
-      - name: Cache build tooling
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.konan
-          key: ${{ runner.os }}-v1-${{ hashFiles('*.gradle.kts') }}
+
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
 
       - name: Run Core
         run: cd core && ../gradlew macosX64Test --no-daemon --stacktrace

--- a/.github/workflows/release-android.yml
+++ b/.github/workflows/release-android.yml
@@ -30,6 +30,9 @@ jobs:
           distribution: 'zulu'
           java-version: 11
 
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+
       - name: Install Core
         run: cd core && ./install.sh
       

--- a/.github/workflows/release-compose.yml
+++ b/.github/workflows/release-compose.yml
@@ -30,6 +30,9 @@ jobs:
           distribution: 'zulu'
           java-version: 11
 
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+
       - name: Install Core
         run: cd core && ./install.sh
       

--- a/.github/workflows/release-core.yml
+++ b/.github/workflows/release-core.yml
@@ -30,6 +30,9 @@ jobs:
           distribution: 'zulu'
           java-version: 11
 
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+
       - name: Install Core
         run: cd core && ./install.sh
       

--- a/.github/workflows/release-ktor.yml
+++ b/.github/workflows/release-ktor.yml
@@ -30,6 +30,9 @@ jobs:
           distribution: 'zulu'
           java-version: 11
 
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+
       - name: Install Core
         run: cd core && ./install.sh
       

--- a/.github/workflows/release-plugins.yml
+++ b/.github/workflows/release-plugins.yml
@@ -30,6 +30,9 @@ jobs:
           distribution: 'zulu'
           java-version: 11
 
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+
       - name: Install Core
         run: cd core && ./install.sh
       


### PR DESCRIPTION
Use more [gradle/gradle-build-action@v2](https://github.com/gradle/gradle-build-action) to cache Gradle.