### PR TITLE
Allow includes to take Collection

### DIFF
--- a/core/koin-core/src/commonMain/kotlin/org/koin/core/module/Module.kt
+++ b/core/koin-core/src/commonMain/kotlin/org/koin/core/module/Module.kt
@@ -70,7 +70,7 @@ class Module(
      * A collection of [Module] from which the current [Module] is compose.
      * Duplicated modules are ignored.
      */
-    fun includes(module: List<Module>) {
+    fun includes(module: Collection<Module>) {
         includedModules += module
     }
 


### PR DESCRIPTION
Allow for `includes` to take a `Collection` as its parameter.
Functionality the same as a List however, it allows for Sets and Lists to be used in conjunction. 