### PR TITLE
Fix #1631, Disable BuildConfig for android modules

### DIFF
--- a/android/koin-android-compat/build.gradle
+++ b/android/koin-android-compat/build.gradle
@@ -14,6 +14,10 @@ android {
         minSdkVersion android_min_version
 //        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
+
+    buildFeatures {
+        buildConfig false
+    }
 }
 
 dependencies {

--- a/android/koin-android-test/build.gradle
+++ b/android/koin-android-test/build.gradle
@@ -14,6 +14,10 @@ android {
         minSdkVersion android_min_version
     }
 
+    buildFeatures {
+        buildConfig false
+    }
+
     compileOptions {
         sourceCompatibility 1.8
         targetCompatibility 1.8

--- a/android/koin-android/build.gradle
+++ b/android/koin-android/build.gradle
@@ -14,6 +14,10 @@ android {
         minSdkVersion android_min_version
     }
 
+    buildFeatures {
+        buildConfig false
+    }
+
     compileOptions {
         sourceCompatibility 1.8
         targetCompatibility 1.8

--- a/android/koin-androidx-navigation/build.gradle
+++ b/android/koin-androidx-navigation/build.gradle
@@ -17,6 +17,10 @@ android {
 
     }
 
+    buildFeatures {
+        buildConfig false
+    }
+
     kotlinOptions {
         jvmTarget = JavaVersion.VERSION_1_8.toString()
     }

--- a/android/koin-androidx-workmanager/build.gradle
+++ b/android/koin-androidx-workmanager/build.gradle
@@ -17,6 +17,10 @@ android {
 
     }
 
+    buildFeatures {
+        buildConfig false
+    }
+
     kotlinOptions {
         jvmTarget = JavaVersion.VERSION_1_8.toString()
     }

--- a/compose/koin-androidx-compose-navigation/build.gradle
+++ b/compose/koin-androidx-compose-navigation/build.gradle
@@ -28,6 +28,7 @@ android {
 
     buildFeatures {
         compose true
+        buildConfig false
     }
 
     composeOptions {

--- a/compose/koin-androidx-compose/build.gradle
+++ b/compose/koin-androidx-compose/build.gradle
@@ -29,6 +29,7 @@ android {
 
     buildFeatures {
         compose true
+        buildConfig false
     }
 
     composeOptions {


### PR DESCRIPTION
BuildConfig is not required so it can be turned off.