### PR TITLE
Dont ignore getviewmodel key

### DIFF
--- a/android/koin-android/src/main/java/org/koin/androidx/viewmodel/GetViewModel.kt
+++ b/android/koin-android/src/main/java/org/koin/androidx/viewmodel/GetViewModel.kt
@@ -39,7 +39,7 @@ fun <T : ViewModel> resolveViewModel(
     val factory = KoinViewModelFactory(vmClass, scope, qualifier, parameters)
     val provider = ViewModelProvider(viewModelStore, factory, extras)
     return when {
-        qualifier != null -> provider[qualifier.value + key?.let { "_$it" }, modelClass]
+        qualifier != null -> provider[qualifier.value + (key?.let { "_$it" } ?: ""), modelClass]
         key != null -> provider[key, modelClass]
         else -> provider[modelClass]
     }

--- a/android/koin-android/src/main/java/org/koin/androidx/viewmodel/GetViewModel.kt
+++ b/android/koin-android/src/main/java/org/koin/androidx/viewmodel/GetViewModel.kt
@@ -39,7 +39,7 @@ fun <T : ViewModel> resolveViewModel(
     val factory = KoinViewModelFactory(vmClass, scope, qualifier, parameters)
     val provider = ViewModelProvider(viewModelStore, factory, extras)
     return when {
-        qualifier != null -> provider[qualifier.value, modelClass]
+        qualifier != null -> provider[qualifier.value + key?.let { "_$it" }, modelClass]
         key != null -> provider[key, modelClass]
         else -> provider[modelClass]
     }


### PR DESCRIPTION
Follow up on https://github.com/InsertKoinIO/koin/pull/1592 from @lammertw 

> Right now, the key is ignored in case a qualifier is used. I don't think that's the correct behavior as it makes it now impossible to force the creation of a new view model in case parameters have changed that require a new view model.

Relates to https://github.com/InsertKoinIO/koin/issues/1578 and https://github.com/InsertKoinIO/koin/issues/1477