### PR TITLE
[bugfix] Wrong gradle version in CONTRIBUTING.adoc

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -48,7 +48,7 @@ https://developer.android.com/studio/[AndroidStudio]
 
 === Building from source
 To build the source you will need to install
-https://gradle.org/[Gradle] v4.7 or more.
+https://gradle.org/[Gradle] v7.4.2 or more.
 
 We use Gradlew in the build scripts
 


### PR DESCRIPTION
Wrong gradle version. According to `gradle-wrapper.properties` files it should be at least v7.4.2.