### PR TITLE
Clean jvmTarget in build.gradle file in androidx-samples

### DIFF
--- a/examples/androidx-samples/build.gradle
+++ b/examples/androidx-samples/build.gradle
@@ -48,10 +48,6 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
-
-    kotlinOptions {
-        jvmTarget = "1.8"
-    }
 }
 
 dependencies {


### PR DESCRIPTION
This is a cosmetic change to the build.gradle file, the ``jvmTarget`` got defined two times in the file which is not needed.