### PR TITLE
[maintenance] jcenter removal

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,7 +6,6 @@ buildscript {
         mavenLocal()
         mavenCentral()
         google()
-        jcenter()
         //TODO replace io.mockk
     }
     dependencies {
@@ -32,7 +31,6 @@ allprojects {
         mavenLocal()
         mavenCentral()
         google()
-        jcenter()
     }
 
     group = 'io.insert-koin'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -5,7 +5,6 @@ buildscript {
         mavenLocal()
         mavenCentral()
         google()
-        jcenter()
     }
     dependencies {
         // Kotlin
@@ -28,7 +27,6 @@ allprojects {
         mavenLocal()
         mavenCentral()
         google()
-        jcenter()
     }
 
     group = 'io.insert-koin'

--- a/examples/androidx-samples/build.gradle
+++ b/examples/androidx-samples/build.gradle
@@ -2,7 +2,6 @@ buildscript {
     repositories {
         mavenLocal()
         mavenCentral()
-        jcenter()
     }
     dependencies {
 //        classpath "io.insert-koin:koin-gradle-plugin:$koin_version"

--- a/examples/coffee-maker/build.gradle
+++ b/examples/coffee-maker/build.gradle
@@ -2,7 +2,6 @@ buildscript {
     repositories {
         mavenLocal()
         mavenCentral()
-        jcenter()
     }
     dependencies {
 //        classpath "io.insert-koin:koin-gradle-plugin:$koin_version"

--- a/ktor/examples/build.gradle
+++ b/ktor/examples/build.gradle
@@ -4,7 +4,6 @@ buildscript {
     repositories {
         google()
         mavenCentral()
-        jcenter()
     }
     dependencies {
         // Kotlin
@@ -22,6 +21,5 @@ allprojects {
         mavenLocal()
         mavenCentral()
         google()
-        jcenter()
     }
 }

--- a/ktor/examples/multimodule-ktor/build.gradle
+++ b/ktor/examples/multimodule-ktor/build.gradle
@@ -9,7 +9,6 @@ subprojects {
 
     repositories {
         mavenLocal()
-        jcenter()
         mavenCentral()
         maven { url "https://dl.bintray.com/kotlin/kotlinx" }
         maven { url "https://dl.bintray.com/kotlin/ktor" }

--- a/plugins/build.gradle
+++ b/plugins/build.gradle
@@ -4,7 +4,7 @@ buildscript {
 
     repositories {
         google()
-        jcenter()
+        gradlePluginPortal()
     }
     dependencies {
         // Kotlin
@@ -24,7 +24,6 @@ allprojects {
     repositories {
         mavenLocal()
         google()
-        jcenter()
     }
 
     group = 'io.insert-koin'


### PR DESCRIPTION
From [official info](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/) and [site itself](https://jcenter.bintray.com/), jcenter is dead. Removing leftovers from project.