### PR TITLE
Add new KoinApplication Composable

### DIFF
--- a/compose/koin-compose/src/commonMain/kotlin/org/koin/compose/KoinApplication.kt
+++ b/compose/koin-compose/src/commonMain/kotlin/org/koin/compose/KoinApplication.kt
@@ -117,6 +117,28 @@ fun KoinApplication(
 }
 
 /**
+ * Create a new Koin Application context for Compose.
+ *
+ * @param moduleList  list of modules to run within Koin application
+ * @param content     provided Composable element
+ *
+ * @author Bloemcol
+ */
+@Composable
+fun KoinApplication(
+    moduleList: List<Module>,
+    content: @Composable () -> Unit
+) {
+    val koinApplication = remember(moduleList) { koinApplication { modules(moduleList) } }
+    CompositionLocalProvider(
+        LocalKoinApplication provides koinApplication.koin,
+        LocalKoinScope provides koinApplication.koin.scopeRegistry.rootScope
+    ) {
+        content()
+    }
+}
+
+/**
  * Create a new Koin Application context for Compose
  *
  * @param moduleList - list of Modules to run within Koin Application


### PR DESCRIPTION
## Context
After using the `KoinApplication` Composable in a different project, it felt weird to me that [you need a lambda to provide the modules to your Koin application](https://github.com/Bloemcol/koin/blob/add-another-koinapplication-composable/compose/koin-compose/src/commonMain/kotlin/org/koin/compose/KoinApplication.kt#L151).

This new Composable only requires a list of modules to work, making it just a bit easier to use.

### Note
**⚠️ Warning: light mode screenshots ahead!**

I did not use hyphens in the JavaDoc comment, as the docs are easier on the eye without them. Compare the JavaDoc hover preview in Android Studio of the KoinApplication Composable mentioned above
<img width="383" alt="Screenshot 2023-11-11 at 09 03 20" src="https://github.com/InsertKoinIO/koin/assets/50614594/e5da955a-afcc-4ccc-b652-b1da4b91506c">
with the new one.
<img width="383" alt="Screenshot 2023-11-11 at 09 03 34" src="https://github.com/InsertKoinIO/koin/assets/50614594/28de5e59-558c-4b18-80b8-dce0258473cf">