### PR TITLE
Fix typo in start markdown file

### DIFF
--- a/docs/reference/koin-android/start.md
+++ b/docs/reference/koin-android/start.md
@@ -22,13 +22,13 @@ class MainApplication : Application() {
             // Load modules
             modules(myAppModules)
         }
-        
+
     }
 }
 ```
 
 :::info
-You can also start Koin from anywhere if you don't ant to start it from your Application class.
+You can also start Koin from anywhere if you don't want to start it from your Application class.
 :::
 
 If you need to start Koin from another Android class, you can use the `startKoin` function and provide your Android `Context`
@@ -70,7 +70,7 @@ startKoin {
     // ...
     // use properties from assets/koin.properties
     androidFileProperties()
-    
+
 }
 ```
 

--- a/docs/reference/koin-android/start.md
+++ b/docs/reference/koin-android/start.md
@@ -2,7 +2,7 @@
 title: Start Koin on Android
 ---
 
-The `koin-android` project is dedicated to provide Koin powers to Android world. See the [Android setup](../../setup/v3.2#android) section for more details.
+The `koin-android` project is dedicated to provide Koin powers to Android world. See the [Android setup](../../setup/koin#android) section for more details.
 
 ## From your Application class
 


### PR DESCRIPTION
- Fixes `ant` to `want` in the start docs.
- Fixes link to Android dependency in setup doc.