### PR TITLE
Fix few typos and reword few sentences in Android documentation

### DIFF
--- a/docs/reference/koin-android/get-instances.md
+++ b/docs/reference/koin-android/get-instances.md
@@ -48,12 +48,12 @@ override fun onCreate(savedInstanceState: Bundle?) {
 ```
 
 :::info
-if you class doesn't have extensions, just add KoinComponent interface If you need to `inject()` or `get()` an instance from another class.
+if your class doesn't have extensions, just implement the `KoinComponent` interface in it to `inject()` or `get()` an instance from another class.
 :::
 
 ## Using the Android Context in a Definition
 
-Once your `Application` class you can use `androidContext` function:
+Once your `Application` class configures Koin you can use the `androidContext` function to inject Android Context so that it can be resolved later when you need it in modules:
 
 ```kotlin
 class MainApplication : Application() {
@@ -62,7 +62,7 @@ class MainApplication : Application() {
         super.onCreate()
 
         startKoin {
-            //inject Android context
+            // inject Android context
             androidContext(this@MainApplication)
             // ...
         }

--- a/docs/reference/koin-android/start.md
+++ b/docs/reference/koin-android/start.md
@@ -28,7 +28,7 @@ class MainApplication : Application() {
 ```
 
 :::info
-You can also start Koin from anywhere if you don't ant to start it from your Application class.
+You can also start Koin from anywhere if you don't want to start it from your Application class.
 :::
 
 If you need to start Koin from another Android class, you can use the `startKoin` function and provide your Android `Context`
@@ -48,7 +48,7 @@ From your Koin configuration (in `startKoin { }` block code), you can also confi
 
 ### Koin Logging for Android
 
-Within your `KoinApplication` instance, we have an extension `androidLogger` which use the `AndroidLogger()`#
+Within your `KoinApplication` instance, we have an extension `androidLogger` which uses the `AndroidLogger` class.
 This logger is an Android implementation of the Koin logger.
 
 Up to you to change this logger if it doesn't suits to your needs.
@@ -73,4 +73,3 @@ startKoin {
     
 }
 ```
-


### PR DESCRIPTION
## Description:
I was playing around with Koin on Android while following the documentation.
I found few typos and wanted to reword a couple of sentences to make the documentation clearer.