### PR TITLE
Fix typo in setup documentation

### DIFF
--- a/docs/setup/koin.md
+++ b/docs/setup/koin.md
@@ -44,7 +44,7 @@ koin-bom = "x.x.x"
 ...
 
 [libraries]
-koin-bom = { module = "io.insert-koin:koin-bom", version.ref = "di-koin" }
+koin-bom = { module = "io.insert-koin:koin-bom", version.ref = "koin-bom" }
 koin-core = { module = "io.insert-koin:koin-core" }
 ...
 ```


### PR DESCRIPTION
Just update a typo in the verion catalog setup documentation.