### PR TITLE
[documentation] Fix link to junit5 extensions in testing.md

### DIFF
--- a/docs/reference/koin-test/testing.md
+++ b/docs/reference/koin-test/testing.md
@@ -161,7 +161,7 @@ Koin offers a way to test if you Koin modules are good: `checkModules` - walk th
 Take attention to stop your koin instance (if you use `startKoin` in your tests) between every test. Else be sure to use `koinApplication`, for local koin instances or `stopKoin()` to stop the current global instance.
 
 ## Testing with JUnit5
-JUnit 5 support provides [Extensions]([url](https://junit.org/junit5/docs/current/user-guide/#extensions)) that will handle the starting and stopping of Koin context. This means that if you are using the extension you don't need to use the `AutoCloseKoinTest`.
+JUnit 5 support provides [Extensions](https://junit.org/junit5/docs/current/user-guide/#extensions) that will handle the starting and stopping of Koin context. This means that if you are using the extension you don't need to use the `AutoCloseKoinTest`.
 
 ### Dependency
 For testing with JUnit5 you need to use `koin-test-junit5` dependency.


### PR DESCRIPTION
Currently the link `Extensions` on https://insert-koin.io/docs/reference/koin-test/testing/#testing-with-junit5 redirects to the not existing url https://insert-koin.io/docs/reference/koin-test/testing/[url](https://junit.org/junit5/docs/current/user-guide/#extensions)