### PR TITLE
Add lazyViewModelForClass to get ViewModel lazily in custom classes

### DIFF
--- a/examples/androidx-samples/src/main/java/org/koin/sample/sandbox/components/main/SimpleServiceImpl.kt
+++ b/examples/androidx-samples/src/main/java/org/koin/sample/sandbox/components/main/SimpleServiceImpl.kt
@@ -1,6 +1,6 @@
 package org.koin.sample.sandbox.components.main
 
-class SimpleServiceImpl() : SimpleService {
+class SimpleServiceImpl : SimpleService {
     override val id: String = SERVICE_IMPL
 }
 const val SERVICE_IMPL = "DefaultService"

--- a/examples/androidx-samples/src/main/java/org/koin/sample/sandbox/main/MainCustomView.kt
+++ b/examples/androidx-samples/src/main/java/org/koin/sample/sandbox/main/MainCustomView.kt
@@ -1,0 +1,22 @@
+package org.koin.sample.sandbox.main
+
+import android.content.Context
+import android.util.AttributeSet
+import androidx.appcompat.widget.AppCompatTextView
+import androidx.lifecycle.findViewTreeViewModelStoreOwner
+import org.koin.androidx.viewmodel.ext.android.lazyViewModelForClass
+import org.koin.sample.sandbox.components.mvvm.SimpleViewModel
+
+class MainCustomView(
+    context: Context,
+    attrs: AttributeSet? = null,
+) : AppCompatTextView(context, attrs) {
+
+    private val viewModel: SimpleViewModel by lazyViewModelForClass(viewModelStoreOwnerLazy = { findViewTreeViewModelStoreOwner()!! })
+
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+
+        text = viewModel.id
+    }
+}

--- a/examples/androidx-samples/src/main/res/layout/main_activity.xml
+++ b/examples/androidx-samples/src/main/res/layout/main_activity.xml
@@ -18,4 +18,8 @@
         android:layout_height="wrap_content"
         android:text="Next"/>
 
+    <org.koin.sample.sandbox.main.MainCustomView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content" />
+
 </LinearLayout>

--- a/projects/android/koin-android/src/main/java/org/koin/androidx/viewmodel/ext/android/ViewModelLazy.kt
+++ b/projects/android/koin-android/src/main/java/org/koin/androidx/viewmodel/ext/android/ViewModelLazy.kt
@@ -91,3 +91,25 @@ fun <T : ViewModel> getLazyViewModelForClass(
         )
     }
 }
+
+@OptIn(KoinInternalApi::class)
+@MainThread
+inline fun <reified T : ViewModel> lazyViewModelForClass(
+    crossinline viewModelStoreOwnerLazy: () -> ViewModelStoreOwner,
+    scope: Scope = GlobalContext.get().scopeRegistry.rootScope,
+    qualifier: Qualifier? = null,
+    noinline state: BundleDefinition? = null,
+    key: String? = null,
+    noinline parameters: ParametersDefinition? = null,
+): Lazy<T> = lazy(LazyThreadSafetyMode.NONE) {
+    val viewModelStoreOwner = viewModelStoreOwnerLazy()
+    resolveViewModel(
+        vmClass = T::class,
+        viewModelStore = viewModelStoreOwner.viewModelStore,
+        extras = state?.invoke()?.toExtras(viewModelStoreOwner) ?: CreationExtras.Empty,
+        qualifier = qualifier,
+        parameters = parameters,
+        key = key,
+        scope = scope
+    )
+}

--- a/projects/android/koin-android/src/test/java/org/koin/test/android/viewmodel/ext/android/ViewModelLazyTest.kt
+++ b/projects/android/koin-android/src/test/java/org/koin/test/android/viewmodel/ext/android/ViewModelLazyTest.kt
@@ -1,0 +1,42 @@
+package org.koin.test.android.viewmodel.ext.android
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelStoreOwner
+import io.mockk.mockk
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.koin.androidx.viewmodel.dsl.viewModelOf
+import org.koin.androidx.viewmodel.ext.android.lazyViewModelForClass
+import org.koin.core.context.startKoin
+import org.koin.dsl.module
+
+class ViewModelLazyTest {
+    @Test
+    fun `lazyViewModelForClass shouldn't resolve ViewModelStoreOwner immediately`() {
+        // Given
+        startKoin {
+            modules(
+                module {
+                    viewModelOf(::FooViewModel)
+                }
+            )
+        }
+
+        var resolved = false
+        val viewModelStoreOwnerResolver: () -> ViewModelStoreOwner = {
+            resolved = true
+            mockk(relaxed = true)
+        }
+
+        // When
+        val lazy: Lazy<FooViewModel> = lazyViewModelForClass(viewModelStoreOwnerLazy = viewModelStoreOwnerResolver)
+
+        // Then
+        assertFalse(resolved)
+        lazy.value
+        assertTrue(resolved)
+    }
+
+    private class FooViewModel : ViewModel()
+}


### PR DESCRIPTION
PR for https://github.com/InsertKoinIO/koin/issues/1774.

I would also change the function `getLazyViewModelForClass` (to resolve the viewModelStore lazily) but this would make a breaking change, which is not the scope of this PR. 