### PR TITLE
feat: Instances interface

### DIFF
--- a/projects/core/koin-core/api/koin-core.api
+++ b/projects/core/koin-core/api/koin-core.api
@@ -4,7 +4,25 @@ public final class org/koin/KoinApplicationExtKt {
 	public static synthetic fun fileProperties$default (Lorg/koin/core/KoinApplication;Ljava/lang/String;ILjava/lang/Object;)Lorg/koin/core/KoinApplication;
 }
 
-public final class org/koin/core/Koin {
+public abstract interface class org/koin/core/Instances {
+	public abstract fun get (Lkotlin/reflect/KClass;Lorg/koin/core/qualifier/Qualifier;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public abstract fun getAll (Lkotlin/reflect/KClass;)Ljava/util/List;
+	public abstract fun getOrNull (Lkotlin/reflect/KClass;Lorg/koin/core/qualifier/Qualifier;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public abstract fun getProperty (Ljava/lang/String;)Ljava/lang/Object;
+	public abstract fun getProperty (Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/Object;
+	public abstract fun getPropertyOrNull (Ljava/lang/String;)Ljava/lang/Object;
+	public abstract fun inject (Lkotlin/reflect/KClass;Lorg/koin/core/qualifier/Qualifier;Lkotlin/LazyThreadSafetyMode;Lkotlin/jvm/functions/Function0;)Lkotlin/Lazy;
+	public abstract fun injectOrNull (Lkotlin/reflect/KClass;Lorg/koin/core/qualifier/Qualifier;Lkotlin/LazyThreadSafetyMode;Lkotlin/jvm/functions/Function0;)Lkotlin/Lazy;
+}
+
+public final class org/koin/core/Instances$DefaultImpls {
+	public static synthetic fun get$default (Lorg/koin/core/Instances;Lkotlin/reflect/KClass;Lorg/koin/core/qualifier/Qualifier;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun getOrNull$default (Lorg/koin/core/Instances;Lkotlin/reflect/KClass;Lorg/koin/core/qualifier/Qualifier;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun inject$default (Lorg/koin/core/Instances;Lkotlin/reflect/KClass;Lorg/koin/core/qualifier/Qualifier;Lkotlin/LazyThreadSafetyMode;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)Lkotlin/Lazy;
+	public static synthetic fun injectOrNull$default (Lorg/koin/core/Instances;Lkotlin/reflect/KClass;Lorg/koin/core/qualifier/Qualifier;Lkotlin/LazyThreadSafetyMode;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)Lkotlin/Lazy;
+}
+
+public final class org/koin/core/Koin : org/koin/core/Instances {
 	public fun <init> ()V
 	public final fun close ()V
 	public final fun createEagerInstances ()V
@@ -13,21 +31,23 @@ public final class org/koin/core/Koin {
 	public static synthetic fun createScope$default (Lorg/koin/core/Koin;Ljava/lang/String;Lorg/koin/core/qualifier/Qualifier;Ljava/lang/Object;ILjava/lang/Object;)Lorg/koin/core/scope/Scope;
 	public final fun deleteProperty (Ljava/lang/String;)V
 	public final fun deleteScope (Ljava/lang/String;)V
-	public final fun get (Lkotlin/reflect/KClass;Lorg/koin/core/qualifier/Qualifier;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
-	public static synthetic fun get$default (Lorg/koin/core/Koin;Lkotlin/reflect/KClass;Lorg/koin/core/qualifier/Qualifier;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)Ljava/lang/Object;
+	public fun get (Lkotlin/reflect/KClass;Lorg/koin/core/qualifier/Qualifier;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public fun getAll (Lkotlin/reflect/KClass;)Ljava/util/List;
 	public final fun getExtensionManager ()Lorg/koin/core/extension/ExtensionManager;
 	public final fun getInstanceRegistry ()Lorg/koin/core/registry/InstanceRegistry;
 	public final fun getLogger ()Lorg/koin/core/logger/Logger;
 	public final fun getOrCreateScope (Ljava/lang/String;Lorg/koin/core/qualifier/Qualifier;Ljava/lang/Object;)Lorg/koin/core/scope/Scope;
 	public static synthetic fun getOrCreateScope$default (Lorg/koin/core/Koin;Ljava/lang/String;Lorg/koin/core/qualifier/Qualifier;Ljava/lang/Object;ILjava/lang/Object;)Lorg/koin/core/scope/Scope;
-	public final fun getOrNull (Lkotlin/reflect/KClass;Lorg/koin/core/qualifier/Qualifier;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
-	public static synthetic fun getOrNull$default (Lorg/koin/core/Koin;Lkotlin/reflect/KClass;Lorg/koin/core/qualifier/Qualifier;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun getProperty (Ljava/lang/String;)Ljava/lang/Object;
-	public final fun getProperty (Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun getOrNull (Lkotlin/reflect/KClass;Lorg/koin/core/qualifier/Qualifier;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public fun getProperty (Ljava/lang/String;)Ljava/lang/Object;
+	public fun getProperty (Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun getPropertyOrNull (Ljava/lang/String;)Ljava/lang/Object;
 	public final fun getPropertyRegistry ()Lorg/koin/core/registry/PropertyRegistry;
 	public final fun getScope (Ljava/lang/String;)Lorg/koin/core/scope/Scope;
 	public final fun getScopeOrNull (Ljava/lang/String;)Lorg/koin/core/scope/Scope;
 	public final fun getScopeRegistry ()Lorg/koin/core/registry/ScopeRegistry;
+	public fun inject (Lkotlin/reflect/KClass;Lorg/koin/core/qualifier/Qualifier;Lkotlin/LazyThreadSafetyMode;Lkotlin/jvm/functions/Function0;)Lkotlin/Lazy;
+	public fun injectOrNull (Lkotlin/reflect/KClass;Lorg/koin/core/qualifier/Qualifier;Lkotlin/LazyThreadSafetyMode;Lkotlin/jvm/functions/Function0;)Lkotlin/Lazy;
 	public final fun loadModules (Ljava/util/List;ZZ)V
 	public static synthetic fun loadModules$default (Lorg/koin/core/Koin;Ljava/util/List;ZZILjava/lang/Object;)V
 	public final fun setProperty (Ljava/lang/String;Ljava/lang/Object;)V
@@ -512,27 +532,27 @@ public final class org/koin/core/registry/ScopeRegistry$Companion {
 	public final fun getRootScopeQualifier ()Lorg/koin/core/qualifier/StringQualifier;
 }
 
-public final class org/koin/core/scope/Scope {
+public final class org/koin/core/scope/Scope : org/koin/core/Instances {
 	public fun <init> (Lorg/koin/core/qualifier/Qualifier;Ljava/lang/String;ZLorg/koin/core/Koin;)V
 	public synthetic fun <init> (Lorg/koin/core/qualifier/Qualifier;Ljava/lang/String;ZLorg/koin/core/Koin;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun close ()V
-	public final fun get (Lkotlin/reflect/KClass;Lorg/koin/core/qualifier/Qualifier;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
-	public static synthetic fun get$default (Lorg/koin/core/scope/Scope;Lkotlin/reflect/KClass;Lorg/koin/core/qualifier/Qualifier;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun getAll (Lkotlin/reflect/KClass;)Ljava/util/List;
+	public fun get (Lkotlin/reflect/KClass;Lorg/koin/core/qualifier/Qualifier;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public fun getAll (Lkotlin/reflect/KClass;)Ljava/util/List;
 	public final fun getClosed ()Z
 	public final fun getId ()Ljava/lang/String;
 	public final fun getKoin ()Lorg/koin/core/Koin;
 	public final fun getLogger ()Lorg/koin/core/logger/Logger;
-	public final fun getOrNull (Lkotlin/reflect/KClass;Lorg/koin/core/qualifier/Qualifier;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
-	public static synthetic fun getOrNull$default (Lorg/koin/core/scope/Scope;Lkotlin/reflect/KClass;Lorg/koin/core/qualifier/Qualifier;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun getProperty (Ljava/lang/String;)Ljava/lang/Object;
-	public final fun getProperty (Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/Object;
-	public final fun getPropertyOrNull (Ljava/lang/String;)Ljava/lang/Object;
+	public fun getOrNull (Lkotlin/reflect/KClass;Lorg/koin/core/qualifier/Qualifier;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public fun getProperty (Ljava/lang/String;)Ljava/lang/Object;
+	public fun getProperty (Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun getPropertyOrNull (Ljava/lang/String;)Ljava/lang/Object;
 	public final fun getScope (Ljava/lang/String;)Lorg/koin/core/scope/Scope;
 	public final fun getScopeQualifier ()Lorg/koin/core/qualifier/Qualifier;
 	public final fun get_koin ()Lorg/koin/core/Koin;
 	public final fun get_parameterStackLocal ()Ljava/lang/ThreadLocal;
 	public final fun get_source ()Ljava/lang/Object;
+	public fun inject (Lkotlin/reflect/KClass;Lorg/koin/core/qualifier/Qualifier;Lkotlin/LazyThreadSafetyMode;Lkotlin/jvm/functions/Function0;)Lkotlin/Lazy;
+	public fun injectOrNull (Lkotlin/reflect/KClass;Lorg/koin/core/qualifier/Qualifier;Lkotlin/LazyThreadSafetyMode;Lkotlin/jvm/functions/Function0;)Lkotlin/Lazy;
 	public final fun isNotClosed ()Z
 	public final fun isRoot ()Z
 	public final fun linkTo ([Lorg/koin/core/scope/Scope;)V

--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/Instances.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/Instances.kt
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2024-Present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.koin.core
+
+import org.koin.core.parameter.ParametersDefinition
+import org.koin.core.qualifier.Qualifier
+import kotlin.reflect.KClass
+
+/**
+ * Provides access to Koin instances
+ *
+ * @author Andrei Nevedomskii
+ */
+interface Instances {
+
+    /**
+     * Get a all instance for given class (in primary or secondary type)
+     * @param clazz T
+     *
+     * @return list of instances of type T
+     */
+    fun <T> getAll(clazz: KClass<*>): List<T>
+
+    /**
+     * Get a Koin instance if available
+     * @param clazz type of the instance to get
+     * @param qualifier
+     * @param parameters
+     *
+     * @return instance of type T or null
+     */
+    fun <T> getOrNull(
+        clazz: KClass<*>,
+        qualifier: Qualifier? = null,
+        parameters: ParametersDefinition? = null,
+    ): T?
+
+    /**
+     * Get a Koin instance
+     * @param clazz type of the instance to get
+     * @param qualifier
+     * @param parameters
+     */
+    fun <T> get(
+        clazz: KClass<*>,
+        qualifier: Qualifier? = null,
+        parameters: ParametersDefinition? = null,
+    ): T
+
+    /**
+     * Lazy inject a Koin instance if available
+     * @param clazz type of the instance to get
+     * @param qualifier
+     * @param mode - LazyThreadSafetyMode
+     * @param parameters
+     *
+     * @return Lazy instance of type T or null
+     */
+    fun <T> injectOrNull(
+        clazz: KClass<*>,
+        qualifier: Qualifier? = null,
+        mode: LazyThreadSafetyMode = LazyThreadSafetyMode.SYNCHRONIZED,
+        parameters: ParametersDefinition? = null,
+    ): Lazy<T?>
+
+    /**
+     * Lazy inject a Koin instance
+     * @param clazz type of the instance to inject
+     * @param qualifier
+     * @param mode - LazyThreadSafetyMode
+     * @param parameters
+     *
+     * @return Lazy instance of type T
+     */
+    fun <T> inject(
+        clazz: KClass<*>,
+        qualifier: Qualifier? = null,
+        mode: LazyThreadSafetyMode = LazyThreadSafetyMode.SYNCHRONIZED,
+        parameters: ParametersDefinition? = null,
+    ): Lazy<T>
+
+    /**
+     * Retrieve a property
+     * @param key
+     * @param defaultValue
+     */
+    fun <T : Any> getProperty(key: String, defaultValue: T): T
+
+    /**
+     * Retrieve a property
+     * @param key
+     */
+    fun <T : Any> getProperty(key: String): T
+
+    /**
+     * Retrieve a property
+     * @param key
+     */
+    fun <T : Any> getPropertyOrNull(key: String): T?
+}
+
+/**
+ * Get a all instance for given inferred class (in primary or secondary type)
+ *
+ * @return list of instances of type T
+ */
+inline fun <reified T> Instances.getAll() = getAll<T>(T::class)
+
+/**
+ * Get a Koin instance if available
+ * @param qualifier
+ * @param parameters
+ *
+ * @return instance of type T or null
+ */
+inline fun <reified T> Instances.getOrNull(
+    qualifier: Qualifier? = null,
+    noinline parameters: ParametersDefinition? = null,
+) = getOrNull<T>(T::class, qualifier, parameters)
+
+/**
+ * Get a Koin instance
+ * @param qualifier
+ * @param parameters
+ */
+inline fun <reified T> Instances.get(
+    qualifier: Qualifier? = null,
+    noinline parameters: ParametersDefinition? = null,
+) = get<T>(T::class, qualifier, parameters)
+
+/**
+ * Lazy inject a Koin instance if available
+ * @param qualifier
+ * @param mode - LazyThreadSafetyMode
+ * @param parameters
+ *
+ * @return Lazy instance of type T or null
+ */
+inline fun <reified T> Instances.injectOrNull(
+    qualifier: Qualifier? = null,
+    mode: LazyThreadSafetyMode = LazyThreadSafetyMode.SYNCHRONIZED,
+    noinline parameters: ParametersDefinition? = null,
+) = injectOrNull<T>(T::class, qualifier, mode, parameters)
+
+/**
+ * Lazy inject a Koin instance
+ * @param qualifier
+ * @param mode - LazyThreadSafetyMode
+ * @param parameters
+ *
+ * @return Lazy instance of type T
+ */
+inline fun <reified T> Instances.inject(
+    qualifier: Qualifier? = null,
+    mode: LazyThreadSafetyMode = LazyThreadSafetyMode.SYNCHRONIZED,
+    noinline parameters: ParametersDefinition? = null,
+) = inject<T>(T::class, qualifier, mode, parameters)

--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/Koin.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/Koin.kt
@@ -37,6 +37,11 @@ import org.koin.core.scope.ScopeID
 import org.koin.core.time.measureDuration
 import org.koin.mp.KoinPlatformTools
 import kotlin.reflect.KClass
+import org.koin.core.get as extensionGet
+import org.koin.core.getAll as extensionGetAll
+import org.koin.core.getOrNull as extensionGetOrNull
+import org.koin.core.inject as extensionInject
+import org.koin.core.injectOrNull as extensionInjectOrNull
 
 /**
  * Koin
@@ -81,7 +86,7 @@ class Koin : Instances {
         qualifier: Qualifier? = null,
         mode: LazyThreadSafetyMode = KoinPlatformTools.defaultLazyMode(),
         noinline parameters: ParametersDefinition? = null,
-    ): Lazy<T> = scopeRegistry.rootScope.inject(qualifier, mode, parameters)
+    ): Lazy<T> = extensionInject<T>(qualifier, mode, parameters)
 
     /**
      * Lazy inject a Koin instance if available
@@ -95,7 +100,7 @@ class Koin : Instances {
         qualifier: Qualifier? = null,
         mode: LazyThreadSafetyMode = KoinPlatformTools.defaultLazyMode(),
         noinline parameters: ParametersDefinition? = null,
-    ): Lazy<T?> = scopeRegistry.rootScope.injectOrNull(qualifier, mode, parameters)
+    ): Lazy<T?> = extensionInjectOrNull<T>(qualifier, mode, parameters)
 
     /**
      * Get a Koin instance
@@ -106,7 +111,7 @@ class Koin : Instances {
     inline fun <reified T : Any> get(
         qualifier: Qualifier? = null,
         noinline parameters: ParametersDefinition? = null,
-    ): T = scopeRegistry.rootScope.get(qualifier, parameters)
+    ): T = extensionGet<T>(qualifier, parameters)
 
     /**
      * Get a Koin instance if available
@@ -119,7 +124,7 @@ class Koin : Instances {
     inline fun <reified T : Any> getOrNull(
         qualifier: Qualifier? = null,
         noinline parameters: ParametersDefinition? = null,
-    ): T? = scopeRegistry.rootScope.getOrNull(qualifier, parameters)
+    ): T? = extensionGetOrNull<T>(qualifier, parameters)
 
     override fun <T> get(
         clazz: KClass<*>,
@@ -175,7 +180,7 @@ class Koin : Instances {
      *
      * @return list of instances of type T
      */
-    inline fun <reified T> getAll(): List<T> = scopeRegistry.rootScope.getAll()
+    inline fun <reified T> getAll(): List<T> = extensionGetAll<T>()
 
     /**
      * Create a Scope instance

--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/scope/Scope.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/scope/Scope.kt
@@ -36,6 +36,11 @@ import org.koin.mp.KoinPlatformTools
 import org.koin.mp.Lockable
 import org.koin.mp.ThreadLocal
 import kotlin.reflect.KClass
+import org.koin.core.get as extensionGet
+import org.koin.core.getAll as extensionGetAll
+import org.koin.core.getOrNull as extensionGetOrNull
+import org.koin.core.inject as extensionInject
+import org.koin.core.injectOrNull as extensionInjectOrNull
 
 @Suppress("UNCHECKED_CAST")
 @OptIn(KoinInternalApi::class)
@@ -106,8 +111,7 @@ class Scope(
         qualifier: Qualifier? = null,
         mode: LazyThreadSafetyMode = LazyThreadSafetyMode.SYNCHRONIZED,
         noinline parameters: ParametersDefinition? = null,
-    ): Lazy<T> =
-        inject(T::class, qualifier, mode, parameters)
+    ): Lazy<T> = extensionInject<T>(qualifier, mode, parameters)
 
     /**
      * Lazy inject a Koin instance if available
@@ -121,8 +125,7 @@ class Scope(
         qualifier: Qualifier? = null,
         mode: LazyThreadSafetyMode = LazyThreadSafetyMode.SYNCHRONIZED,
         noinline parameters: ParametersDefinition? = null,
-    ): Lazy<T?> =
-        injectOrNull(T::class, qualifier, mode, parameters)
+    ): Lazy<T?> = extensionInjectOrNull<T>(qualifier, mode, parameters)
 
     /**
      * Get a Koin instance
@@ -133,9 +136,7 @@ class Scope(
     inline fun <reified T : Any> get(
         qualifier: Qualifier? = null,
         noinline parameters: ParametersDefinition? = null,
-    ): T {
-        return get(T::class, qualifier, parameters)
-    }
+    ): T = extensionGet(qualifier, parameters)
 
     /**
      * Get Koin Scope "source" instance. Retrive the object instance, that initiated the creation of the scope.
@@ -157,9 +158,7 @@ class Scope(
     inline fun <reified T : Any> getOrNull(
         qualifier: Qualifier? = null,
         noinline parameters: ParametersDefinition? = null,
-    ): T? {
-        return getOrNull(T::class, qualifier, parameters)
-    }
+    ): T? = extensionGetOrNull<T>(qualifier, parameters)
 
     override fun <T> getOrNull(
         clazz: KClass<*>,
@@ -353,7 +352,7 @@ class Scope(
      *
      * @return list of instances of type T
      */
-    inline fun <reified T : Any> getAll(): List<T> = getAll(T::class)
+    inline fun <reified T : Any> getAll(): List<T> = extensionGetAll<T>()
 
     override fun <T> getAll(clazz: KClass<*>): List<T> {
         val context = InstanceContext(_koin.logger, this)


### PR DESCRIPTION
The goal of this PR is to provide an abstraction that can be used to interact with both `org.koin.core.scope.Scope` and `org.koin.core.Koin`.

It is especially convenient when you'd like to have extension functions usable with both entities.

Tbh, not having this abstraction has been annoying me for a while, so figured I'll give it a shot :smile: 