### PR TITLE
feat: getAll by type and qualifier predicate

### DIFF
--- a/projects/core/koin-core/api/koin-core.api
+++ b/projects/core/koin-core/api/koin-core.api
@@ -519,6 +519,7 @@ public final class org/koin/core/scope/Scope {
 	public final fun get (Lkotlin/reflect/KClass;Lorg/koin/core/qualifier/Qualifier;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
 	public static synthetic fun get$default (Lorg/koin/core/scope/Scope;Lkotlin/reflect/KClass;Lorg/koin/core/qualifier/Qualifier;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun getAll (Lkotlin/reflect/KClass;)Ljava/util/List;
+	public final fun getAll (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function1;)Ljava/util/List;
 	public final fun getClosed ()Z
 	public final fun getId ()Ljava/lang/String;
 	public final fun getKoin ()Lorg/koin/core/Koin;

--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/Koin.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/Koin.kt
@@ -169,11 +169,20 @@ class Koin {
     }
 
     /**
-     * Get a all instance for given inferred class (in primary or secondary type)
+     * Get all instances for given inferred class (in primary or secondary type)
      *
      * @return list of instances of type T
      */
     inline fun <reified T> getAll(): List<T> = scopeRegistry.rootScope.getAll()
+
+    /**
+     * Get all instances for given inferred class (in primary or secondary type) matching the qualifier predicate
+     *
+     * @param qualifierPredicate qualifier predicate
+     * @return list of instances of type T
+     */
+    inline fun <reified T> getAll(noinline qualifierPredicate: (Qualifier?) -> Boolean): List<T> =
+        scopeRegistry.rootScope.getAll(qualifierPredicate)
 
     /**
      * Create a Scope instance

--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/registry/InstanceRegistry.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/registry/InstanceRegistry.kt
@@ -162,8 +162,13 @@ class InstanceRegistry(val _koin: Koin) {
         _instances.clear()
     }
 
-    internal fun <T> getAll(clazz: KClass<*>, instanceContext: InstanceContext): List<T> {
+    internal fun <T> getAll(
+        clazz: KClass<*>,
+        instanceContext: InstanceContext,
+        qualifierPredicate: (Qualifier?) -> Boolean = { true },
+    ): List<T> {
         return _instances.values
+            .asSequence()
             .filter { factory ->
                 factory.beanDefinition.scopeQualifier == instanceContext.scope.scopeQualifier
             }
@@ -172,8 +177,12 @@ class InstanceRegistry(val _koin: Koin) {
                     clazz,
                 )
             }
+            .filter { factory ->
+                qualifierPredicate(factory.beanDefinition.qualifier)
+            }
             .distinct()
             .map { it.get(instanceContext) as T }
+            .toList()
     }
 
     internal fun unloadModules(modules: Set<Module>) {

--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/scope/Scope.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/scope/Scope.kt
@@ -348,21 +348,38 @@ class Scope(
     }
 
     /**
-     * Get a all instance for given inferred class (in primary or secondary type)
+     * Get all instances for given inferred class (in primary or secondary type)
      *
      * @return list of instances of type T
      */
-    inline fun <reified T : Any> getAll(): List<T> = getAll(T::class)
+    inline fun <reified T : Any> getAll(): List<T> = getAll<T> { true }
 
     /**
-     * Get a all instance for given class (in primary or secondary type)
+     * Get all instances for given inferred class (in primary or secondary type) matching the qualifier predicate
+     *
+     * @return list of instances of type T
+     */
+    inline fun <reified T : Any> getAll(noinline qualifierPredicate: (Qualifier?) -> Boolean): List<T> =
+        getAll(T::class, qualifierPredicate)
+
+    /**
+     * Get all instances for given class (in primary or secondary type)
      * @param clazz T
      *
      * @return list of instances of type T
      */
-    fun <T> getAll(clazz: KClass<*>): List<T> {
+    fun <T> getAll(clazz: KClass<*>): List<T> = getAll(clazz) { true }
+
+    /**
+     * Get all instances for given class (in primary or secondary type) matching the qualifier predicate
+     * @param clazz T
+     * @param qualifierPredicate qualifier predicate
+     *
+     * @return list of instances of type T
+     */
+    fun <T> getAll(clazz: KClass<*>, qualifierPredicate: (Qualifier?) -> Boolean): List<T> {
         val context = InstanceContext(_koin.logger, this)
-        return _koin.instanceRegistry.getAll<T>(clazz, context) + linkedScopes.flatMap { scope -> scope.getAll(clazz) }
+        return _koin.instanceRegistry.getAll<T>(clazz, context, qualifierPredicate) + linkedScopes.flatMap { scope -> scope.getAll(clazz, qualifierPredicate) }
     }
 
     /**

--- a/projects/core/koin-core/src/commonTest/kotlin/org/koin/Components.kt
+++ b/projects/core/koin-core/src/commonTest/kotlin/org/koin/Components.kt
@@ -1,5 +1,8 @@
 package org.koin
 
+import org.koin.core.qualifier.Qualifier
+import org.koin.core.qualifier.QualifierValue
+
 class Simple {
     class ComponentA
     class ComponentB(val a: ComponentA)
@@ -20,6 +23,10 @@ class Simple {
     class MyStringFactory(val s: String)
     class AllFactory(val ints: MyIntFactory, val strings: MyStringFactory)
     class AllFactory2(val strings: MyStringFactory, val ints: MyIntFactory)
+}
+
+class ComplexQualifier(val value1: Int, val value2: String) : Qualifier {
+    override val value: QualifierValue = "$value1$value2"
 }
 
 @Suppress("unused")

--- a/projects/core/koin-core/src/commonTest/kotlin/org/koin/core/InstanceResolutionTest.kt
+++ b/projects/core/koin-core/src/commonTest/kotlin/org/koin/core/InstanceResolutionTest.kt
@@ -1,13 +1,16 @@
 package org.koin.core
 
+import org.koin.ComplexQualifier
 import org.koin.Simple
 import org.koin.core.logger.Level
 import org.koin.core.qualifier.named
 import org.koin.dsl.bind
 import org.koin.dsl.koinApplication
 import org.koin.dsl.module
-import kotlin.test.*
 import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
 
 class InstanceResolutionTest {
 
@@ -46,6 +49,33 @@ class InstanceResolutionTest {
 
         assertEquals(2, instances.size)
         assertTrue(instances.contains(a1) && instances.contains(a2))
+    }
+
+    @Test
+    fun `can resolve all ComponentInterface1 with qualifier predicate`() {
+        val q1 = ComplexQualifier(1, "asd")
+        val q2 = ComplexQualifier(2, "qwe")
+        val q3 = ComplexQualifier(2, "zxc")
+        val koin = koinApplication {
+            modules(
+                module {
+                    single(q1) { Simple.Component1() } bind Simple.ComponentInterface1::class
+                    single(q2) { Simple.Component2() } bind Simple.ComponentInterface1::class
+                    single(q3) { Simple.Component2() } bind Simple.ComponentInterface1::class
+                },
+            )
+        }.koin
+
+        val a1: Simple.Component1 = koin.get(q1)
+        val a2: Simple.Component2 = koin.get(q2)
+        val a3: Simple.Component2 = koin.get(q3)
+
+        val instances = koin.getAll<Simple.ComponentInterface1> {
+            (it as? ComplexQualifier)?.value1 == 2
+        }
+
+        assertEquals(2, instances.size)
+        assertTrue(instances.contains(a2) && instances.contains(a3))
     }
 
     @Test


### PR DESCRIPTION
This PR introduces `<reified T : Any> getAll(qualifierPredicate: (Qualifier?) -> Boolean)` method to get all instances of the specified type matching the given qualifier predicate.

This is convenient when you have multiple instances of the same type and only want to get a subset of those instances based on the qualifier.