### PR TITLE
Docs: Use `platform` for BOM in Version Catalog setup

### DIFF
--- a/docs/setup/koin.md
+++ b/docs/setup/koin.md
@@ -35,7 +35,7 @@ Starting from 3.5.0 you can use BOM-version to manage all Koin library versions.
 
 Add `koin-bom` BOM and `koin-core` dependency to your application: 
 ```kotlin
-implementation(platform("io.insert-koin:koin-bom:$koin_version"))
+implementation(project.dependencies.platform("io.insert-koin:koin-bom:$koin_version"))
 implementation("io.insert-koin:koin-core")
 ```
 If you are using version catalogs:
@@ -51,7 +51,7 @@ koin-core = { module = "io.insert-koin:koin-core" }
 ```
 ```kotlin
 dependencies {
-    implementation(libs.koin.bom)
+    implementation(project.dependencies.platform(libs.koin.bom))
     implementation(libs.koin.core)
 }
 ```


### PR DESCRIPTION
Relates to #1721 

Failure to use `platform` for the BOM in a Kotlin Multiplatform project will cause iOS project failures during sync. This updates the setup docs so that the "Version Catalogs" setup is the same as the regular setup.

Additionally, replace `platform` with `project.dependencies.platform` due to the Kotlin deprecation: `'platform(Any): Dependency' is deprecated. Scheduled for removal in Kotlin 2.0`.