### PR TITLE
Fix VM key generation - on key only, or qualifier + class name

### DIFF
--- a/projects/android/koin-android/src/main/java/org/koin/androidx/viewmodel/GetViewModel.kt
+++ b/projects/android/koin-android/src/main/java/org/koin/androidx/viewmodel/GetViewModel.kt
@@ -6,7 +6,6 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelStore
 import androidx.lifecycle.viewmodel.CreationExtras
 import org.koin.androidx.viewmodel.factory.KoinViewModelFactory
-import org.koin.core.Koin
 import org.koin.core.annotation.KoinInternalApi
 import org.koin.core.parameter.ParametersDefinition
 import org.koin.core.parameter.ParametersHolder
@@ -39,10 +38,7 @@ fun <T : ViewModel> resolveViewModel(
     //TODO In 3.6 - propose to resolve scope strictly from root or not
     val factory = KoinViewModelFactory(vmClass, scope, qualifier, parameters)
     val provider = ViewModelProvider(viewModelStore, factory, extras)
-    val vmKey = getViewModelKey(qualifier, key)
-
-    //To help track Keys
-//    koin.logger.debug("[vm_key] - provider:$provider - class:$modelClass = $vmKey (q:'${qualifier?.value}', k:'$key')")
+    val vmKey = getViewModelKey(qualifier, key, modelClass.canonicalName)
     return when {
         vmKey != null -> provider[vmKey, modelClass]
         else -> provider[modelClass]
@@ -50,10 +46,10 @@ fun <T : ViewModel> resolveViewModel(
 }
 
 @KoinInternalApi
-internal fun getViewModelKey(qualifier: Qualifier?, key: String?): String? {
+internal fun getViewModelKey(qualifier: Qualifier? = null, key: String? = null, className: String? = null): String? {
     return when {
-        qualifier != null -> qualifier.value + (key?.let { "_$it" } ?: "")
         key != null -> key
+        qualifier != null -> qualifier.value + (className?.let { "_$className" } ?: "")
         else -> null
     }
 }

--- a/projects/android/koin-android/src/test/java/org/koin/test/android/viewmodel/ViewModelKeyTest.kt
+++ b/projects/android/koin-android/src/test/java/org/koin/test/android/viewmodel/ViewModelKeyTest.kt
@@ -4,8 +4,6 @@ import org.junit.Test
 import org.koin.androidx.viewmodel.getViewModelKey
 import org.koin.core.annotation.KoinInternalApi
 import org.koin.core.qualifier.StringQualifier
-import org.koin.core.scope.Scope
-import org.koin.dsl.koinApplication
 import kotlin.test.assertEquals
 
 class ViewModelKeyTest {
@@ -15,18 +13,30 @@ class ViewModelKeyTest {
     fun generate_right_key() {
         val q = StringQualifier("_qualifier_")
         val key = "_KEY_"
+        val className = "this.is.just.a.class"
 
         assertEquals(
-            null, getViewModelKey(qualifier = null,  key = null)
+            null, getViewModelKey(qualifier = null, key = null, className = null)
         )
         assertEquals(
-            q.value, getViewModelKey(qualifier = q, key = null)
+            q.value, getViewModelKey(qualifier = q, key = null, className = null)
         )
         assertEquals(
-            q.value + "_$key", getViewModelKey(qualifier = q, key = key)
+            q.value+"_"+className, getViewModelKey(qualifier = q, key = null, className = className)
         )
         assertEquals(
-            key, getViewModelKey(qualifier = null, key = key)
+            key, getViewModelKey(
+                qualifier = q,
+                key = key,
+                className = null
+            )
+        )
+        assertEquals(
+            key, getViewModelKey(qualifier = null, key = key, className = null)
+        )
+
+        assertEquals(
+            key, getViewModelKey(qualifier = q, key = key, className = className)
         )
     }
 }

--- a/projects/android/koin-android/src/test/java/org/koin/test/androidx/viewmodel/GetViewModelTest.kt
+++ b/projects/android/koin-android/src/test/java/org/koin/test/androidx/viewmodel/GetViewModelTest.kt
@@ -8,6 +8,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import org.junit.Assert.assertNotNull
 import org.junit.Test
+import org.koin.androidx.viewmodel.getViewModelKey
 import org.koin.androidx.viewmodel.resolveViewModel
 import org.koin.core.annotation.KoinInternalApi
 import org.koin.core.qualifier.Qualifier
@@ -64,7 +65,7 @@ class GetViewModelTest {
         val koinVmKey = "${qualifierName}_$key"
 
         assertNotNull(viewModel)
-        verify { viewModelStore[koinVmKey] }
+        verify { viewModelStore[key] }
     }
 
     @Test
@@ -104,7 +105,7 @@ class GetViewModelTest {
         )
 
         assertNotNull(viewModel)
-        verify { viewModelStore[qualifierValue] }
+        verify { viewModelStore[qualifierValue+"_"+classToTest.java.canonicalName] }
     }
 
     companion object {

--- a/projects/core/koin-core/src/commonTest/kotlin/org/koin/dsl/NamingTest.kt
+++ b/projects/core/koin-core/src/commonTest/kotlin/org/koin/dsl/NamingTest.kt
@@ -83,6 +83,28 @@ class NamingTest {
         assertEquals(24, scope.get<Simple.MySingle>(named("24")).id)
         assertEquals(42, scope.get<Simple.MySingle>().id)
     }
+
+    @Test
+    fun same_qualifier_but_different_type() {
+        val qualifier = named("qualifier")
+        val targetString = "_another_string_"
+        val targetInt = 42
+
+        val koin = koinApplication {
+            printLogger(Level.DEBUG)
+            modules(
+                module {
+                    single { Simple.MyIntFactory(24) }
+                    single(qualifier) { Simple.MyIntFactory(targetInt) }
+                    single { Simple.MyStringFactory("_a_string_") }
+                    single(qualifier) { Simple.MyStringFactory(targetString) }
+                },
+            )
+        }.koin
+
+        assertEquals(targetInt,koin.get<Simple.MyIntFactory>(qualifier).id)
+        assertEquals(targetString,koin.get<Simple.MyStringFactory>(qualifier).s)
+    }
 }
 
 enum class MyNames {


### PR DESCRIPTION
Review ViewModel key generation to use either key, either qualifier + class name (qualifier can be used for several types)