### PR TITLE
Fix Gradle dependencies to be in 3.5.3 style

### DIFF
--- a/projects/android/koin-android-compat/build.gradle.kts
+++ b/projects/android/koin-android-compat/build.gradle.kts
@@ -23,7 +23,7 @@ android {
 }
 
 dependencies {
-    implementation(project(":android:koin-android"))
+    api(project(":android:koin-android"))
 }
 
 // android sources

--- a/projects/android/koin-android-test/build.gradle.kts
+++ b/projects/android/koin-android-test/build.gradle.kts
@@ -23,10 +23,9 @@ android {
 }
 
 dependencies {
-    implementation(kotlin("reflect"))
-    implementation(project(":android:koin-android"))
-    implementation(project(":android:koin-androidx-workmanager"))
-    implementation(project(":core:koin-test"))
+    api(project(":android:koin-android"))
+    api(project(":android:koin-androidx-workmanager"))
+    api(project(":core:koin-test"))
     // Test
     testImplementation(libs.test.junit)
     testImplementation(libs.test.mockito)

--- a/projects/android/koin-androidx-navigation/build.gradle.kts
+++ b/projects/android/koin-androidx-navigation/build.gradle.kts
@@ -20,7 +20,7 @@ android {
 }
 
 dependencies {
-    implementation(project(":android:koin-android"))
+    api(project(":android:koin-android"))
     api(libs.androidx.navigation)
 }
 

--- a/projects/android/koin-androidx-workmanager/build.gradle.kts
+++ b/projects/android/koin-androidx-workmanager/build.gradle.kts
@@ -20,7 +20,7 @@ android {
 }
 
 dependencies {
-    implementation(project(":android:koin-android"))
+    api(project(":android:koin-android"))
     api(libs.androidx.workmanager)
 
     // Test

--- a/projects/compose/koin-androidx-compose-navigation/build.gradle.kts
+++ b/projects/compose/koin-androidx-compose-navigation/build.gradle.kts
@@ -24,8 +24,8 @@ android {
 }
 
 dependencies {
-    implementation(project(":compose:koin-androidx-compose"))
-    implementation(libs.androidx.composeNavigation)
+    api(project(":compose:koin-androidx-compose"))
+    api(libs.androidx.composeNavigation)
 }
 
 // android sources

--- a/projects/compose/koin-androidx-compose/build.gradle.kts
+++ b/projects/compose/koin-androidx-compose/build.gradle.kts
@@ -26,8 +26,8 @@ android {
 dependencies {
     api(project(":android:koin-android"))
     api(project(":compose:koin-compose"))
-    implementation(libs.androidx.composeRuntime)
-    implementation(libs.androidx.composeViewModel)
+    api(libs.androidx.composeRuntime)
+    api(libs.androidx.composeViewModel)
 }
 
 // android sources

--- a/projects/compose/koin-compose/build.gradle.kts
+++ b/projects/compose/koin-compose/build.gradle.kts
@@ -26,7 +26,7 @@ kotlin {
     sourceSets {
         commonMain.dependencies {
             api(project(":core:koin-core"))
-            implementation(libs.compose.jb)
+            api(libs.compose.jb)
         }
     }
 }

--- a/projects/core/koin-core-coroutines/build.gradle.kts
+++ b/projects/core/koin-core-coroutines/build.gradle.kts
@@ -34,7 +34,7 @@ kotlin {
     sourceSets {
         commonMain.dependencies {
             api(project(":core:koin-core"))
-            implementation(libs.kotlin.coroutines)
+            api(libs.kotlin.coroutines)
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)

--- a/projects/core/koin-core/build.gradle.kts
+++ b/projects/core/koin-core/build.gradle.kts
@@ -33,8 +33,8 @@ kotlin {
 
     sourceSets {
         commonMain.dependencies {
-            implementation(libs.extras.stately)
-            implementation(libs.extras.stately.collections)
+            api(libs.extras.stately)
+            api(libs.extras.stately.collections)
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)

--- a/projects/core/koin-test-junit4/build.gradle.kts
+++ b/projects/core/koin-test-junit4/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 dependencies {
     api(project(":core:koin-test"))
-    implementation(libs.test.junit)
+    api(libs.test.junit)
     testImplementation(libs.kotlin.test)
     testImplementation(libs.test.mockito)
 }

--- a/projects/core/koin-test-junit5/build.gradle.kts
+++ b/projects/core/koin-test-junit5/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 dependencies {
     api(project(":core:koin-test"))
-    implementation(libs.test.jupiter)
+    api(libs.test.jupiter)
     testImplementation(libs.test.mockito)
 }
 

--- a/projects/core/koin-test/build.gradle.kts
+++ b/projects/core/koin-test/build.gradle.kts
@@ -35,10 +35,10 @@ kotlin {
         commonMain.dependencies {
             api(project(":core:koin-core"))
             //TODO remove in 3.6
-            implementation(libs.kotlin.test)
+            api(libs.kotlin.test)
         }
         jvmMain.dependencies {
-            implementation(kotlin("reflect"))
+            api(kotlin("reflect"))
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)

--- a/projects/gradle.properties
+++ b/projects/gradle.properties
@@ -8,8 +8,8 @@ org.gradle.parallel=true
 kotlin.code.style=official
 
 #Koin
-koinVersion=3.5.5
-koinComposeVersion=1.1.4
+koinVersion=3.5.6
+koinComposeVersion=1.1.5
 
 #Compose
 composeCompiler=1.5.10

--- a/projects/ktor/koin-logger-slf4j/build.gradle.kts
+++ b/projects/ktor/koin-logger-slf4j/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 dependencies {
     api(project(":core:koin-core"))
-    implementation(libs.ktor.slf4j)
+    api(libs.ktor.slf4j)
 }
 
 tasks.withType<KotlinCompile>().all {


### PR DESCRIPTION
Fix gradle dependencies from implementation to api, as it was before