### PR TITLE
Add composable SubComponents injection and Decompose integration

### DIFF
--- a/projects/compose/koin-compose/src/commonMain/kotlin/org/koin/compose/subcoponent/Inject.kt
+++ b/projects/compose/koin-compose/src/commonMain/kotlin/org/koin/compose/subcoponent/Inject.kt
@@ -1,0 +1,29 @@
+package org.koin.compose.subcoponent
+
+import androidx.compose.runtime.Composable
+import org.koin.compose.LocalKoinScope
+import org.koin.compose.koinInject
+import org.koin.core.parameter.ParametersDefinition
+import org.koin.core.qualifier.Qualifier
+
+/**
+ * Obtains and remembers instance of the given type from the current scope
+ *
+ * @param qualifier the qualifier to be used
+ * @param parameters definition of the parameters to be used
+ *
+ * @author Antonio Vicente
+ */
+@Composable
+inline fun <reified T> inject(
+    qualifier: Qualifier? = null,
+    noinline parameters: ParametersDefinition? = null,
+): T = koinInject<T>(
+    qualifier = qualifier,
+    scope = LocalKoinScope.current,
+    parameters = parameters,
+)
+
+
+
+

--- a/projects/compose/koin-compose/src/commonMain/kotlin/org/koin/compose/subcoponent/KoinSubComponent.kt
+++ b/projects/compose/koin-compose/src/commonMain/kotlin/org/koin/compose/subcoponent/KoinSubComponent.kt
@@ -1,0 +1,59 @@
+package org.koin.compose.subcoponent
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.remember
+import org.koin.compose.LocalKoinScope
+import org.koin.core.module.Module
+import org.koin.core.scope.Scope
+import org.koin.dsl.module
+import org.koin.mp.KoinPlatformTools
+
+/**
+ * Defines a dependency injection component that holds a scope that will load all the dependencies
+ * for the given composable content. The scope will be created with the given [ScopeKey] and will be
+ * linked to the parent scope (the scope of the immediate [KoinSubComponent] caller). When the
+ * component is disposed, the [Scope] will be closed.
+ *
+ * @param ScopeKey - the key to define the scope
+ * @param subComponentModule - the module to load to the sub component dependencies
+ * @param content - @Composable function
+ *
+ * @author Antonio Vicente
+ */
+@Composable
+inline fun <reified ScopeKey : Any> KoinSubComponent(
+    subComponentModule : Module = module {  },
+    crossinline content: @Composable () -> Unit
+) {
+    val parentScope : Scope = LocalKoinScope.current
+    val id = remember { KoinPlatformTools.generateId() }
+    val subScope : Scope = parentScope.getKoin()
+        .getOrCreateScope<ScopeKey>(id)
+        .apply {
+            linkTo(parentScope)
+            loadModule(subComponentModule)
+        }
+
+    DisposableEffect(Unit) {
+        onDispose {
+            subScope.unloadModule(subComponentModule)
+            subScope.close()
+        }
+    }
+
+    CompositionLocalProvider(
+        LocalKoinScope provides subScope
+    ) {
+        content()
+    }
+}
+
+fun Scope.loadModule(module: Module) {
+    getKoin().loadModules(listOf(module))
+}
+
+fun Scope.unloadModule(module: Module) {
+    getKoin().unloadModules(listOf(module))
+}

--- a/projects/compose/koin-decompose/README.md
+++ b/projects/compose/koin-decompose/README.md
@@ -1,0 +1,181 @@
+## Koin SubComponents
+
+Provide the mechanism to create subcomponents in Koin, similar to `dagger-android` approach. 
+
+- Similar approach to `dagger-android` based on subcomponent
+- Load/Unload modules automatically when composable component is created/disposed
+- Link `Scopes` from leaf children to root navigation stack
+
+`KoinSubComponent` is the composable that will take care of linking Scopes to parent components. Every time each of them is instantiated a new scope is created, and their related modules are loaded. Exactly the same concept as `dagger-android` did with `@ContributesAndroidInjector`, `Activities` and `Fragments` declared a subcomponent where all the  installed dependencies' modules would be provided from. Here, the modules will be installed when calling `KoinSubComponent<ScopeName>(subComponentModules)`
+
+## Koin Decompose
+
+The goal is to provide an easy integration with Decompose for complex navigation hierarchies and large amount of dependencies.
+For that, `NavigationStackComponentContext` will declare at runtime a `StackNavigation` instance with the given qualifier, which is the `StackConfig` type.  
+
+### Components hierarchy
+This is an example of the hierarchy. In the left part, there is a tree that represents the composables components that holds the scopes containers of the dependencies. In the right part there is the relationship between each scope.
+
+Everytime a Stack is instantiated, a new Scope is created within that stack. It also takes the parent scope, and links this new Scope to the parent Scope, so if a dependency is needed, it's module definition will be searched from this Scope to root scope.
+
+#### Example
+``` kotlin
+                                           ┌─────────────┐
+        AppStackComponent -----------------│  AppScope   │ <- modules { AppViewModel, AppRouter } 
+      __________|__________                └──────^──────┘
+      |         |         |                ┌──────┴──────┐
+SplashComponent |---------|----------------│ SplashScope │ <- modules { SplashViewModel, AppRouter }
+        HomeComponent ----|----------------│ HomeScope   │ <- modules { HomeViewModel, AppRouter }
+                AuthStackComponent --------│ AuthScope   │ <- modules { AuthRouter, AppRouter }
+                    ______|________        └──────^──────┘
+                    |     |       |        ┌──────┴──────┐
+        SignInComponent --|----------------│ SignInScope │ <- modules { SignInViewModel, AuthRouter }
+                SignUpComponent --|--------│ SignUpScope │ <- modules { SignUpViewModel, AuthRouter }
+                        SuccessComponent --│ SuccessScope│ <- modules { SuccessViewModel, AppRouter }
+                                           └─────────────┘
+```
+
+### Usage with an example
+The following example is just a small part of the diagram above.
+
+#### Main Activity on Android
+``` kotlin
+class MainActivity : ComponentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        
+        setContentComponentContext {
+            App()
+        }
+    }
+}
+```
+
+#### App Components
+``` kotlin
+@Composable
+fun App(
+    modifier: Modifier = Modifier,
+) = KoinApplicationComponent(
+    application = { modules(appModule) },
+) {
+    AppStackComponent(
+        initialState = AppStackConfig.Splash,
+    )
+}
+
+```
+
+##### Navigation Stack
+
+``` kotlin
+@Composable
+fun AppStackComponent(
+    initialState: AppStackConfig
+    // Declares at runtime a [StackNavigation] intance with
+    // 'AppStackConfig' qualifier, in 'AppScope' scope
+) = NavigationStackComponentContext<AppStackConfig, AppScope>(
+    initialConfiguration = initialState,
+    childProvider = { _ -> this.toChild(send) }
+)
+
+private fun AppStackConfig.toChild() : Child = when (this) {
+    Splash -> DefaultChild { SplashComponent() }
+    Home -> DefaultChild { Home() }
+}
+```
+##### Navigation Configuration
+``` kotlin
+@Serializable
+sealed class AppStackConfig {
+    @Serializable
+    data object Splash : AppStackConfig()
+    @Serializable
+    data object Home : AppStackConfig()
+}
+```
+##### Koin 
+``` kotlin
+val appModule = module {
+    includes(
+        ...
+    )
+}
+```
+
+##### Koin Scope
+``` kotlin
+class AppScope
+```
+---------------
+
+#### Splash Component
+``` kotlin
+@Composable
+fun SplashComponent() = KoinSubComponent<SplashScope>(
+    // Load dependencieds when needed in current scope
+    subComponentModule = splashModule
+) {
+    val splashRT : SplashRT = inject()
+
+    SplashScreen(
+        splashVM = inject(),
+        onAnimationCompleted = { splashRT.goToHome() }
+    )
+}
+```
+
+##### Splash Module 
+``` kotlin
+val splashModule = module {
+    includes(
+        splashViewModelModule,
+        splashRouterModule
+    )
+}
+```
+
+##### Splash View Model
+``` kotlin
+class SplashVM
+```
+
+##### Splash View Model Module
+``` kotlin
+val splashViewModelModule = module {
+    scope<AppScope> {
+        // Viewmodel is scoped intentionally
+        scoped { SplashViewModel() }
+    }
+}
+```
+
+##### Splash Router
+``` kotlin
+class SplashRouter(
+    private val appStackNavigator: StackNavigation<AppStackConfig>
+) {
+
+    fun goToHome() {
+        appStackNavigator.replaceCurrent(AppStackConfig.Home)
+    }
+}
+```
+
+
+##### Splash Router Module
+``` kotlin
+val splashRouterModule = module {
+    scope<AppScope> { 
+        factory {
+            SplashRouter(
+                // [appStackNavigator : StackNavigator] is available in this 'AppScope'
+                // (thanks to NavigationStackComponentContext)
+                // If a navigator from a different parent stack is needed, just use 'named<ParentStackConfig>'
+                appStackNavigator = get(named<AppStackConfig>())
+            )
+        }
+    }
+}
+```

--- a/projects/compose/koin-decompose/build.gradle.kts
+++ b/projects/compose/koin-decompose/build.gradle.kts
@@ -1,0 +1,61 @@
+@file:Suppress("UnstableApiUsage")
+
+plugins {
+    alias(libs.plugins.kotlinMultiplatform)
+    alias(libs.plugins.androidLibrary)
+    alias(libs.plugins.compose)
+}
+
+kotlin {
+    androidTarget()
+    jvm()
+
+    js(IR) {
+        browser()
+    }
+
+    iosX64()
+    iosArm64()
+    iosSimulatorArm64()
+    macosX64()
+    macosArm64()
+
+    sourceSets {
+        androidMain.dependencies {
+            api(project(":android:koin-android"))
+            api(libs.androidx.activity.compose)
+        }
+        commonMain.dependencies {
+            api(project(":core:koin-core"))
+            api(project(":compose:koin-compose"))
+            implementation(libs.compose.jb)
+
+            api(libs.decompose)
+            api(libs.decompose.extensions)
+            implementation(compose.foundation)
+        }
+    }
+}
+
+val androidCompileSDK : String by project
+val androidMinSDK : String by project
+val jetpackComposeCompiler : String by project
+
+android {
+    namespace = "org.koin.decompose"
+    compileSdk = androidCompileSDK.toInt()
+    defaultConfig {
+        minSdk = androidMinSDK.toInt()
+    }
+    buildFeatures {
+        buildConfig = false
+        compose = true
+    }
+    composeOptions {
+        kotlinCompilerExtensionVersion = jetpackComposeCompiler
+    }
+}
+
+apply(from = file("../../gradle/publish.gradle.kts"))
+
+

--- a/projects/compose/koin-decompose/src/androidMain/AndroidManifest.xml
+++ b/projects/compose/koin-decompose/src/androidMain/AndroidManifest.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+</manifest>

--- a/projects/compose/koin-decompose/src/androidMain/kotlin/org/koin/decompose/AppContextBinder.android.kt
+++ b/projects/compose/koin-decompose/src/androidMain/kotlin/org/koin/decompose/AppContextBinder.android.kt
@@ -1,0 +1,32 @@
+package org.koin.decompose
+
+import android.app.Application
+import android.content.Context
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
+import org.koin.compose.LocalKoinApplication
+import org.koin.core.Koin
+import org.koin.dsl.bind
+import org.koin.dsl.module
+
+/**
+ * Binds the [Context] to the dependency graph
+ *
+ * @author Antonio Vicente
+ */
+@Composable
+actual fun AppContextBinder() {
+    LocalKoinApplication.current.androidContext(LocalContext.current.applicationContext)
+}
+
+fun Koin.androidContext(androidContext: Context) {
+    if (androidContext is Application) {
+        loadModules(listOf(module {
+            single { androidContext } bind Context::class
+        }))
+    } else {
+        loadModules(listOf(module {
+            single { androidContext }
+        }))
+    }
+}

--- a/projects/compose/koin-decompose/src/androidMain/kotlin/org/koin/decompose/androidx/activity/ComponentActivityExt.kt
+++ b/projects/compose/koin-decompose/src/androidMain/kotlin/org/koin/decompose/androidx/activity/ComponentActivityExt.kt
@@ -1,0 +1,39 @@
+package org.koin.decompose.androidx.activity
+
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionContext
+import androidx.compose.runtime.CompositionLocalProvider
+import com.arkivanov.decompose.defaultComponentContext
+import org.koin.decompose.context.LocalComponentContext
+
+/**
+ * Set the content of the [ComponentActivity] with the [CompositionContext] provided by the [ComponentActivity]
+ *
+ * @param parent the parent [CompositionContext] to be used
+ * @param content the content of the [ComponentActivity]
+ *
+ * @see ComponentActivity
+ * @see CompositionContext
+ * @see setContent
+ * @see LocalComponentContext
+ *
+ * @author Antonio Vicente
+ */
+fun ComponentActivity.setContentComponentContext(
+    parent: CompositionContext? = null,
+    content: @Composable () -> Unit
+) {
+    val activityComponentContext = defaultComponentContext()
+    setContent(
+        parent = parent,
+        content = {
+            CompositionLocalProvider(
+                LocalComponentContext provides activityComponentContext
+            ) {
+                content()
+            }
+        }
+    )
+}

--- a/projects/compose/koin-decompose/src/commonMain/kotlin/org/koin/decompose/AppContextBinder.kt
+++ b/projects/compose/koin-decompose/src/commonMain/kotlin/org/koin/decompose/AppContextBinder.kt
@@ -1,0 +1,7 @@
+package org.koin.decompose
+
+import androidx.compose.runtime.Composable
+
+
+@Composable
+expect fun AppContextBinder()

--- a/projects/compose/koin-decompose/src/commonMain/kotlin/org/koin/decompose/KoinContextApplication.kt
+++ b/projects/compose/koin-decompose/src/commonMain/kotlin/org/koin/decompose/KoinContextApplication.kt
@@ -1,0 +1,26 @@
+package org.koin.decompose
+
+import androidx.compose.runtime.Composable
+import org.koin.compose.KoinApplication
+import org.koin.dsl.KoinAppDeclaration
+
+/**
+ * Defines a KoinApplicationComponent that binds AppContext to the graph
+ *
+ * @param application the [KoinAppDeclaration] to be used
+ * @param content the content of the application
+ *
+ * @author Antonio Vicente
+ */
+@Composable
+fun KoinApplicationComponent(
+    application: KoinAppDeclaration,
+    content: @Composable () -> Unit
+) {
+    KoinApplication(
+        application = application,
+    ) {
+        AppContextBinder()
+        content()
+    }
+}

--- a/projects/compose/koin-decompose/src/commonMain/kotlin/org/koin/decompose/component/NavigationStackComponentContext.kt
+++ b/projects/compose/koin-decompose/src/commonMain/kotlin/org/koin/decompose/component/NavigationStackComponentContext.kt
@@ -1,0 +1,57 @@
+package org.koin.decompose.component
+
+import androidx.compose.runtime.Composable
+import com.arkivanov.decompose.extensions.compose.stack.animation.StackAnimation
+import com.arkivanov.decompose.extensions.compose.stack.animation.stackAnimation
+import com.arkivanov.decompose.router.stack.StackNavigation
+import org.koin.compose.LocalKoinScope
+import org.koin.core.module.Module
+import org.koin.core.qualifier.TypeQualifier
+import org.koin.compose.subcoponent.KoinSubComponent
+import org.koin.decompose.context.LocalComponentContext
+import org.koin.decompose.navigation.Child
+import org.koin.decompose.navigation.defaultAnimation
+import org.koin.decompose.navigation.navigationStack
+import org.koin.dsl.module
+
+/**
+ * Instantiates, renders and declares a navigation stack. The stack is declared in the current Koin
+ * scope. We assume that each stack is a singleton within this its scope (Scoped) so it can be
+ * injected by declaring a module like this:
+ *
+ * val DependencyInScopeModule = module {
+ * 	    scope<ScopeKey> {
+ * 		    factory() { DependencyInScope(stackNavigator = get()) }
+ * 	    }
+ * }
+ *
+ * @param Config the configuration type of the stack
+ * @param ScopeKey the key of the scope where the stack will be declared
+ *
+ * @param subComponentModule the module to load to the sub component dependencies
+ * @param initialConfiguration the initial configuration of the stack
+ * @param animation the animator to be used for the stack
+ * @param childProvider a lambda that converts a configuration to a [Child]
+ *
+ * @author Antonio Vicente
+ */
+@Composable
+inline fun <reified Config : Any, reified ScopeKey : Any> NavigationStackComponentContext(
+    subComponentModule : Module = module {  },
+    initialConfiguration: Config,
+    animation: StackAnimation<Config, Child>? = stackAnimation(defaultAnimation),
+    noinline childProvider : Config.(StackNavigation<Config>) -> Child
+) = KoinSubComponent<ScopeKey>(
+    subComponentModule = subComponentModule
+) {
+    val navigationStack = LocalComponentContext.current.navigationStack(
+        initialConfiguration = initialConfiguration,
+        toChildRenderable = childProvider,
+        animation = animation
+    )
+    LocalKoinScope.current.declare(
+        instance = navigationStack.navigation,
+        qualifier = TypeQualifier(Config::class)
+    )
+    navigationStack.render()
+}

--- a/projects/compose/koin-decompose/src/commonMain/kotlin/org/koin/decompose/context/LocalComponentContext.kt
+++ b/projects/compose/koin-decompose/src/commonMain/kotlin/org/koin/decompose/context/LocalComponentContext.kt
@@ -1,0 +1,13 @@
+package org.koin.decompose.context
+
+import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.staticCompositionLocalOf
+import com.arkivanov.decompose.ComponentContext
+
+/**
+ * Local component context to propagate context to children
+ *
+ * @author Antonio Vicente
+ */
+val LocalComponentContext: ProvidableCompositionLocal<ComponentContext> =
+    staticCompositionLocalOf { error("Root component context was not provided") }

--- a/projects/compose/koin-decompose/src/commonMain/kotlin/org/koin/decompose/navigation/Child.kt
+++ b/projects/compose/koin-decompose/src/commonMain/kotlin/org/koin/decompose/navigation/Child.kt
@@ -1,0 +1,30 @@
+package org.koin.decompose.navigation
+
+import androidx.compose.runtime.Composable
+
+/**
+ * Encapsulates a composable to be able to propagate through the navigation stack
+ *
+ * @author Juan Luis Berenquel
+ */
+interface Child {
+    @Composable
+    fun render()
+}
+
+/**
+ * Default implementation of [Child] that renders a composable
+ *
+ * @param composable the composable to render
+ *
+ * @author Juan Luis Berenguel
+ */
+open class DefaultChild(
+    private val composable: @Composable () -> Unit
+) : Child {
+
+    @Composable
+    override fun render() {
+        composable()
+    }
+}

--- a/projects/compose/koin-decompose/src/commonMain/kotlin/org/koin/decompose/navigation/ChildStackComponentContext.kt
+++ b/projects/compose/koin-decompose/src/commonMain/kotlin/org/koin/decompose/navigation/ChildStackComponentContext.kt
@@ -1,0 +1,93 @@
+package org.koin.decompose.navigation
+
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import com.arkivanov.decompose.ComponentContext
+import com.arkivanov.decompose.extensions.compose.stack.Children
+import com.arkivanov.decompose.extensions.compose.stack.animation.StackAnimation
+import com.arkivanov.decompose.extensions.compose.stack.animation.fade
+import com.arkivanov.decompose.router.stack.ChildStack
+import com.arkivanov.decompose.router.stack.StackNavigation
+import com.arkivanov.decompose.router.stack.childStack
+import com.arkivanov.decompose.value.Value
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.serializer
+import org.koin.decompose.context.LocalComponentContext
+import kotlin.random.Random
+
+val defaultAnimation = fade(
+    animationSpec = tween(
+        durationMillis = 500,
+        easing = FastOutSlowInEasing
+    )
+)
+
+/**
+ * Creates a navigation stack from a [ComponentContext]
+ *
+ * @param initialConfiguration the initial configuration of the stack
+ * @param toChildRenderable a lambda that converts a configuration to a [Child]
+ * @param animation the animator to be used for the stack
+ *
+ * @author Antonio Vicente
+ */
+inline fun <reified T : Any> ComponentContext.navigationStack(
+    initialConfiguration: T,
+    noinline toChildRenderable: T.(StackNavigation<T>) -> Child,
+    animation: StackAnimation<T, Child>?
+) : ChildStackComponentContext<T> = ChildStackComponentContext(
+    parent = this,
+    initialConfiguration = initialConfiguration,
+    serializer = serializer(),
+    toChildRenderable = { navigation -> toChildRenderable(navigation) },
+    animation = animation
+)
+
+/**
+ * A [Child] implementation that represents a stack of children
+ *
+ * @param parent the parent [ComponentContext]
+ * @param initialConfiguration the initial configuration of the stack
+ * @param serializer the serializer to be used for the configuration
+ * @param toChildRenderable a lambda that converts a configuration to a [Child]
+ * @param animation the animator to be used for the stack
+ *
+ * @author Antonio Vicente
+ */
+open class ChildStackComponentContext<T : Any>(
+    parent: ComponentContext,
+    initialConfiguration : T,
+    serializer: KSerializer<T>,
+    toChildRenderable : T.(StackNavigation<T>) -> Child,
+    private val animation: StackAnimation<T, Child>?
+) : Child, ComponentContext by parent {
+
+    val navigation : StackNavigation<T> = StackNavigation()
+
+    private val stack: Value<ChildStack<T, Child>> by lazy {
+        childStack(
+            source = navigation,
+            key = Random.nextInt().toString(),
+            serializer = serializer,
+            handleBackButton = true,
+            initialConfiguration = initialConfiguration,
+            childFactory = { config, cc -> config.toChildRenderable(navigation) }
+        )
+    }
+
+    @Composable
+    override fun render() = Children(
+        stack = stack,
+        animation = animation,
+        content = {
+            CompositionLocalProvider(
+                LocalComponentContext provides this,
+            ) {
+                it.instance.render()
+            }
+        }
+    )
+
+}

--- a/projects/compose/koin-decompose/src/iosMain/kotlin/org/koin/decompose/AppContextBinder.ios.kt
+++ b/projects/compose/koin-decompose/src/iosMain/kotlin/org/koin/decompose/AppContextBinder.ios.kt
@@ -1,0 +1,7 @@
+package org.koin.decompose
+
+import androidx.compose.runtime.Composable
+
+@Composable
+actual fun AppContextBinder() {
+}

--- a/projects/gradle.properties
+++ b/projects/gradle.properties
@@ -18,3 +18,6 @@ android.useAndroidX=true
 androidMinSDK=14
 androidCompileSDK=34
 #android.nonTransitiveRClass=true
+
+org.jetbrains.compose.experimental.jscanvas.enabled=true
+org.jetbrains.compose.experimental.macos.enabled=true

--- a/projects/gradle/libs.versions.toml
+++ b/projects/gradle/libs.versions.toml
@@ -22,6 +22,8 @@ androidx-navigation = "2.7.7"
 composeJB = "1.6.1"
 composeJetpackRuntime = "1.6.5"
 composeJetpackViewmodel = "2.7.0"
+# Decompose
+decompose = "3.0.0-beta01"
 # Test
 stately = "2.0.6"
 junit = "4.13.2"
@@ -63,7 +65,10 @@ compose-jb = { module = "org.jetbrains.compose.runtime:runtime", version.ref = "
 androidx-composeRuntime = { module = "androidx.compose.runtime:runtime", version.ref = "composeJetpackRuntime" }
 androidx-composeViewModel = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "composeJetpackViewmodel" }
 androidx-composeNavigation = { module = "androidx.navigation:navigation-compose", version.ref = "androidx-navigation" }
-
+androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "android-activity" }
+# Decompose
+decompose = { group = "com.arkivanov.decompose", name = "decompose", version.ref = "decompose" }
+decompose-extensions = { group = "com.arkivanov.decompose", name = "extensions-compose", version.ref = "decompose" }
 [plugins]
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kotlinAndroid = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }

--- a/projects/settings.gradle.kts
+++ b/projects/settings.gradle.kts
@@ -34,6 +34,7 @@ include(
     ":compose:koin-compose",
     ":compose:koin-androidx-compose",
     ":compose:koin-androidx-compose-navigation",
+    ":compose:koin-decompose",
     // Plugin
     ":plugins:koin-gradle-plugin",
     // BOM


### PR DESCRIPTION
Hi there, I've been recently working on a large project that requires a large dependencies injection management, and I've encountered the need of having the possibility of loading those modules dynamically, only where they are being used, particularly using Decompose. Since I have not found this feature in the repo, I have taken the liberty of proposing it here.

So basically I have created a new gradle module called `koin-decompose`, that tries to mymic `dagger-android` concept.

First of all I'd like to thank @arkivanov for his amazing job on Decompose, but also @juanlubf for helping to start the foundations of Koin with Decompose in that project.

And last but not least, of course thanks to @arnaudgiuliani for make Koin happen. So this is my humble contribution to he project, if you believe it makes sense and it could be helpful for the community

1. Include Koin SubComponents using Compose
2. Integrate with Decompose

There is a detailed explanation in the [readme file here](https://github.com/antoniovm/koin/tree/create_koin-decompose/projects/compose/koin-decompose), but as a summary the goal of this contribution is to be able to navigate through the app and easily create/destroy dependencies modules only when needed, so a better memory managment is achieved.

Again thank you very much, and let me know what do you think. All namings, packages, arguments, etc.. are open to be changed if needed, so please do not hesitate on providing feedback about it.

Kind regards,
Antonio