### PR TITLE
Use explicit Gradle DependencyHandlerEnvorderPlatform

### DIFF
--- a/docs/setup/koin.md
+++ b/docs/setup/koin.md
@@ -35,7 +35,7 @@ Starting from 3.5.0 you can use BOM-version to manage all Koin library versions.
 
 Add `koin-bom` BOM and `koin-core` dependency to your application: 
 ```kotlin
-implementation(platform("io.insert-koin:koin-bom:$koin_version"))
+implementation(project.dependencies.platform("io.insert-koin:koin-bom:$koin_version"))
 implementation("io.insert-koin:koin-core")
 ```
 If you are using version catalogs:
@@ -51,7 +51,7 @@ koin-core = { module = "io.insert-koin:koin-core" }
 ```
 ```kotlin
 dependencies {
-    implementation(platform(libs.koin.bom))
+    implementation(project.dependencies.platform(libs.koin.bom))
     implementation(libs.koin.core)
 }
 ```


### PR DESCRIPTION
According to Jetbrains, using 'platform()' is deprecated and one should use the explicit 'project.dependencies.platform()' instead. See https://youtrack.jetbrains.com/issue/KT-58759/Deprecate-platform-enforcedPlatform-and-other-related-to-Gradle-DependencyHandler-methods-in-KotlinDependencyHandler

I do not really know much about the dependency handling logic. I only stumbled over this as I added Koin to my Compose project.