### PR TITLE
Minimizing code duplication during logging. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Koin is a pragmatic lightweight dependency injection framework for Kotlin develo
 ## Setup & Current Version
 
 Here are the current available Koin project versions:
-- stable: `3.5.5`
-- unstable: `3.6.0-Beta2`
+- stable: `3.5.6` - compose `1.1.5`
+- unstable: `3.6.0-Beta2` - compose `1.2.0-Beta2`
 
 ## Koin Packages
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Koin is a pragmatic lightweight dependency injection framework for Kotlin develo
 ## Setup & Current Version
 
 Here are the current available Koin project versions:
-- stable: `3.5.4`
+- stable: `3.5.5`
 - unstable: `3.6.0-Beta2`
 
 ## Koin Packages

--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/scope/Scope.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/scope/Scope.kt
@@ -245,14 +245,15 @@ class Scope(
         instanceContext: InstanceContext,
         parameterDef: ParametersDefinition?
     ) = (
+        val targetRef = "|- ? t:'${clazz.getFullName()}' - q:'$qualifier'"
             _koin.instanceRegistry.resolveInstance(qualifier, clazz, this.scopeQualifier, instanceContext)
         ?: run {
-            _koin.logger.debug("|- ? t:'${clazz.getFullName()}' - q:'$qualifier' look in injected parameters")
+            _koin.logger.debug("$targetRef look in injected parameters")
             _parameterStackLocal.get()?.firstOrNull()?.getOrNull<T>(clazz)
         }
         ?: run {
             if (!isRoot){
-                _koin.logger.debug("|- ? t:'${clazz.getFullName()}' - q:'$qualifier' look at scope source" )
+                _koin.logger.debug("$targetRef look at scope source" )
                 _source?.let { source ->
                     if (clazz.isInstance(source) && qualifier == null) {
                         _source as? T
@@ -261,7 +262,7 @@ class Scope(
             } else null
         }
         ?: run {
-            _koin.logger.debug("|- ? t:'${clazz.getFullName()}' - q:'$qualifier' look in other scopes" )
+            _koin.logger.debug("$targetRef look in other scopes" )
             findInOtherScope<T>(clazz, qualifier, parameterDef)
         }
         ?: run {


### PR DESCRIPTION
No big deal. Just reducing string duplication. 
If additional sources are added in the future and need to be logged, this code can easily accommodate them.