### PR TITLE
Add compose viewmodel

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Koin is a pragmatic lightweight dependency injection framework for Kotlin develo
 ## Setup & Current Version
 
 Here are the current available Koin project versions:
-- stable: `3.5.5`
-- unstable: `3.6.0-Beta2`
+- stable: `3.5.6` - compose `1.1.5`
+- unstable: `3.6.0-Beta2` - compose `1.2.0-Beta2`
 
 ## Koin Packages
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![logo](./docs/img/koin_main_logo.png)
 
-[![Kotlin](https://img.shields.io/badge/Kotlin-1.9.22-blue.svg?style=flat&logo=kotlin)](https://kotlinlang.org)
+[![Kotlin](https://img.shields.io/badge/Kotlin-1.9.24-blue.svg?style=flat&logo=kotlin)](https://kotlinlang.org)
 ![Github Actions](https://github.com/InsertKoinIO/koin/actions/workflows/build.yml/badge.svg)
 [![Apache 2 License](https://img.shields.io/github/license/InsertKoinIO/koin)](https://github.com/InsertKoinIO/koin/blob/main/LICENSE.txt)
 [![Slack channel](https://img.shields.io/badge/Chat-Slack-orange.svg?style=flat&logo=slack)](https://kotlinlang.slack.com/messages/koin/)
@@ -15,29 +15,33 @@ Koin is a pragmatic lightweight dependency injection framework for Kotlin develo
 
 ## Setup & Current Version
 
-Here are the current available Koin project versions:
-- stable: `3.5.6` - compose `1.1.5`
-- unstable: `3.6.0-Beta2` - compose `1.2.0-Beta2`
+Here are the current available Koin project versions: ![](https://img.shields.io/badge/stable-version-blue) ![](https://img.shields.io/badge/unstable-version-orange)
+
+- Koin ![](https://img.shields.io/badge/3.5.6-blue) ![](https://img.shields.io/badge/3.6.0-Beta4-orange)
+- Koin for Compose ![](https://img.shields.io/badge/1.1.5-blue) ![](https://img.shields.io/badge/1.2.0-Beta4-orange)
+- Koin Annotations ![](https://img.shields.io/badge/1.3.1-blue) ![](https://img.shields.io/badge/1.4.0-Alpha1-orange)
 
 ## Koin Packages
 
-| Project   |      Version      |
+| Project   |      Versions     |
 |----------|:-------------:|
-| koin-bom |  [![Maven Central](https://img.shields.io/maven-central/v/io.insert-koin/koin-bom)](https://mvnrepository.com/artifact/io.insert-koin/koin-bom) |
-| koin-core |  [![Maven Central](https://img.shields.io/maven-central/v/io.insert-koin/koin-core)](https://mvnrepository.com/artifact/io.insert-koin/koin-core) |
-| koin-core-coroutines |  [![Maven Central](https://img.shields.io/maven-central/v/io.insert-koin/koin-core-coroutines)](https://mvnrepository.com/artifact/io.insert-koin/koin-core-coroutines) |
-| koin-test |  [![Maven Central](https://img.shields.io/maven-central/v/io.insert-koin/koin-test)](https://mvnrepository.com/artifact/io.insert-koin/koin-test) |
-| koin-android |  [![Maven Central](https://img.shields.io/maven-central/v/io.insert-koin/koin-android)](https://mvnrepository.com/artifact/io.insert-koin/koin-android) |
-| koin-android-test |  [![Maven Central](https://img.shields.io/maven-central/v/io.insert-koin/koin-android-test)](https://mvnrepository.com/artifact/io.insert-koin/koin-android-test) |
-| koin-android-compat |  [![Maven Central](https://img.shields.io/maven-central/v/io.insert-koin/koin-android-compat)](https://mvnrepository.com/artifact/io.insert-koin/koin-android-compat) |
-| koin-androidx-navigation |  [![Maven Central](https://img.shields.io/maven-central/v/io.insert-koin/koin-androidx-navigation)](https://mvnrepository.com/artifact/io.insert-koin/koin-androidx-navigation) |
-| koin-androidx-workmanager |  [![Maven Central](https://img.shields.io/maven-central/v/io.insert-koin/koin-androidx-workmanager)](https://mvnrepository.com/artifact/io.insert-koin/koin-androidx-workmanager) |
-| koin-androidx-compose |  [![Maven Central](https://img.shields.io/maven-central/v/io.insert-koin/koin-androidx-compose)](https://mvnrepository.com/artifact/io.insert-koin/koin-androidx-compose) |
-| koin-androidx-compose-navigation |  [![Maven Central](https://img.shields.io/maven-central/v/io.insert-koin/koin-androidx-compose-navigation)](https://mvnrepository.com/artifact/io.insert-koin/koin-androidx-compose-navigation) |
-| koin-compose |  [![Maven Central](https://img.shields.io/maven-central/v/io.insert-koin/koin-compose)](https://mvnrepository.com/artifact/io.insert-koin/koin-compose) |
-| koin-ktor |  [![Maven Central](https://img.shields.io/maven-central/v/io.insert-koin/koin-ktor)](https://mvnrepository.com/artifact/io.insert-koin/koin-ktor) |
-| koin-logger-slf4j |  [![Maven Central](https://img.shields.io/maven-central/v/io.insert-koin/koin-logger-slf4j)](https://mvnrepository.com/artifact/io.insert-koin/koin-logger-slf4j) |
-| koin-annotations |  [![Maven Central](https://img.shields.io/maven-central/v/io.insert-koin/koin-annotations)](https://mvnrepository.com/artifact/io.insert-koin/koin-annotations) |
+| [koin-bom](https://mvnrepository.com/artifact/io.insert-koin/koin-bom) |  ![](https://img.shields.io/badge/3.5.6-blue) - ![](https://img.shields.io/badge/3.6.0-Beta4-orange) |
+| [koin-core](https://mvnrepository.com/artifact/io.insert-koin/koin-core) |  ![](https://img.shields.io/badge/3.5.6-blue) - ![](https://img.shields.io/badge/3.6.0-Beta4-orange) |
+| [koin-core-coroutines](https://mvnrepository.com/artifact/io.insert-koin/koin-core-coroutines) |  ![](https://img.shields.io/badge/3.5.6-blue) - ![](https://img.shields.io/badge/3.6.0-Beta4-orange) |
+| [koin-test](https://mvnrepository.com/artifact/io.insert-koin/koin-test) |  ![](https://img.shields.io/badge/3.5.6-blue) - ![](https://img.shields.io/badge/3.6.0-Beta4-orange) |
+| [koin-android](https://mvnrepository.com/artifact/io.insert-koin/koin-android) |  ![](https://img.shields.io/badge/3.5.6-blue) - ![](https://img.shields.io/badge/3.6.0-Beta4-orange) |
+| [koin-android-test](https://mvnrepository.com/artifact/io.insert-koin/koin-android-test) |  ![](https://img.shields.io/badge/3.5.6-blue) - ![](https://img.shields.io/badge/3.6.0-Beta4-orange) |
+| [koin-android-compat](https://mvnrepository.com/artifact/io.insert-koin/koin-android-compat) |  ![](https://img.shields.io/badge/3.5.6-blue) - ![](https://img.shields.io/badge/3.6.0-Beta4-orange) |
+| [koin-android-navigation](https://mvnrepository.com/artifact/io.insert-koin/koin-android-navigation) |  ![](https://img.shields.io/badge/3.5.6-blue) - ![](https://img.shields.io/badge/3.6.0-Beta4-orange) |
+| [koin-android-workmanager](https://mvnrepository.com/artifact/io.insert-koin/koin-android-workmanager) |  ![](https://img.shields.io/badge/3.5.6-blue) - ![](https://img.shields.io/badge/3.6.0-Beta4-orange) |
+| [koin-android-compose](https://mvnrepository.com/artifact/io.insert-koin/koin-android-compose) |  ![](https://img.shields.io/badge/3.5.6-blue) - ![](https://img.shields.io/badge/3.6.0-Beta4-orange) |
+| [koin-android-compose-navigation](https://mvnrepository.com/artifact/io.insert-koin/koin-android-compose-navigation) |  ![](https://img.shields.io/badge/3.5.6-blue) - ![](https://img.shields.io/badge/3.6.0-Beta4-orange) |
+| [koin-ktor](https://mvnrepository.com/artifact/io.insert-koin/koin-ktor) |  ![](https://img.shields.io/badge/3.5.6-blue) - ![](https://img.shields.io/badge/3.6.0-Beta4-orange) |
+| [koin-compose](https://mvnrepository.com/artifact/io.insert-koin/koin-android-compose-navigation) |  ![](https://img.shields.io/badge/1.1.5-blue) - ![](https://img.shields.io/badge/1.2.0-Beta4-orange) |
+| [koin-compose-viewmodel](https://mvnrepository.com/artifact/io.insert-koin/koin-android-compose-navigation) |  ![](https://img.shields.io/badge/1.2.0-Beta4-orange) |
+| [koin-ktor](https://mvnrepository.com/artifact/io.insert-koin/koin-ktor) |  ![](https://img.shields.io/badge/3.5.6-blue) - ![](https://img.shields.io/badge/3.6.0-Beta4-orange) |
+| [koin-logger-slf4](https://mvnrepository.com/artifact/io.insert-koin/koin-logger-slf4) |  ![](https://img.shields.io/badge/3.5.6-blue) - ![](https://img.shields.io/badge/3.6.0-Beta4-orange) |
+| [koin-annotations](https://mvnrepository.com/artifact/io.insert-koin/koin-annotations) |  ![](https://img.shields.io/badge/1.3.1-blue) - ![](https://img.shields.io/badge/1.4.0-alpha1-orange) |
 
 🔎 Check the [latest changes](https://github.com/InsertKoinIO/koin/blob/main/CHANGELOG.md) to update your Koin project.
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Koin is a pragmatic lightweight dependency injection framework for Kotlin develo
 ## Setup & Current Version
 
 Here are the current available Koin project versions:
-- stable: `3.5.4`
+- stable: `3.5.5`
 - unstable: `3.6.0-Beta2`
 
 ## Koin Packages

--- a/examples/sample-android-compose/build.gradle
+++ b/examples/sample-android-compose/build.gradle
@@ -45,6 +45,8 @@ dependencies {
 
     // Koin
     implementation "io.insert-koin:koin-androidx-compose:$koin_version"
+//    implementation "io.insert-koin:koin-androidx-compose-viewmodel:$koin_version"
+
     implementation "io.insert-koin:koin-androidx-compose-navigation:$koin_version"
 
     // Compose

--- a/projects/compose/koin-compose-viewmodel/api/koin-compose.api
+++ b/projects/compose/koin-compose-viewmodel/api/koin-compose.api
@@ -1,0 +1,62 @@
+public final class org/koin/compose/KoinApplicationKt {
+	public static final fun KoinApplication (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;I)V
+	public static final fun KoinContext (Lorg/koin/core/Koin;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
+	public static final fun KoinIsolatedContext (Lorg/koin/core/KoinApplication;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;I)V
+	public static final fun currentKoinScope (Landroidx/compose/runtime/Composer;I)Lorg/koin/core/scope/Scope;
+	public static final fun getKoin (Landroidx/compose/runtime/Composer;I)Lorg/koin/core/Koin;
+	public static final fun getLocalKoinApplication ()Landroidx/compose/runtime/ProvidableCompositionLocal;
+	public static final fun getLocalKoinScope ()Landroidx/compose/runtime/ProvidableCompositionLocal;
+	public static final fun rememberCurrentKoinScope (Landroidx/compose/runtime/Composer;I)Lorg/koin/core/scope/Scope;
+}
+
+public final class org/koin/compose/error/UnknownKoinContext : java/lang/RuntimeException {
+	public static final field $stable I
+	public fun <init> ()V
+}
+
+public final class org/koin/compose/module/CompositionKoinModuleLoader : androidx/compose/runtime/RememberObserver {
+	public static final field $stable I
+	public fun <init> (Ljava/util/List;Lorg/koin/core/Koin;ZZ)V
+	public final fun getKoin ()Lorg/koin/core/Koin;
+	public final fun getModules ()Ljava/util/List;
+	public final fun getUnloadOnAbandoned ()Z
+	public final fun getUnloadOnForgotten ()Z
+	public fun onAbandoned ()V
+	public fun onForgotten ()V
+	public fun onRemembered ()V
+}
+
+public final class org/koin/compose/module/RememberModulesKt {
+	public static final fun rememberKoinModules (Ljava/lang/Boolean;Ljava/lang/Boolean;ZLkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;II)V
+}
+
+public final class org/koin/compose/scope/CompositionKoinScopeLoader : androidx/compose/runtime/RememberObserver {
+	public static final field $stable I
+	public fun <init> (Lorg/koin/core/scope/Scope;Lorg/koin/core/Koin;)V
+	public final fun getKoin ()Lorg/koin/core/Koin;
+	public final fun getScope ()Lorg/koin/core/scope/Scope;
+	public fun onAbandoned ()V
+	public fun onForgotten ()V
+	public fun onRemembered ()V
+}
+
+public final class org/koin/compose/scope/KoinScopeKt {
+	public static final fun KoinScope (Ljava/lang/String;Lorg/koin/core/qualifier/Qualifier;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;I)V
+	public static final fun KoinScope (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;I)V
+	public static final fun OnKoinScope (Lorg/koin/core/scope/Scope;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;I)V
+}
+
+public final class org/koin/compose/scope/RememberScopesKt {
+	public static final fun rememberKoinScope (Lorg/koin/core/scope/Scope;Landroidx/compose/runtime/Composer;I)Lorg/koin/core/scope/Scope;
+}
+
+public final class org/koin/compose/stable/StableHoldersKt {
+	public static final fun rememberStableParametersDefinition (Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)Lorg/koin/compose/stable/StableParametersDefinition;
+}
+
+public final class org/koin/compose/stable/StableParametersDefinition {
+	public static final field $stable I
+	public fun <init> (Lkotlin/jvm/functions/Function0;)V
+	public final fun getParametersDefinition ()Lkotlin/jvm/functions/Function0;
+}
+

--- a/projects/compose/koin-compose-viewmodel/build.gradle.kts
+++ b/projects/compose/koin-compose-viewmodel/build.gradle.kts
@@ -1,0 +1,38 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+plugins {
+    alias(libs.plugins.kotlinMultiplatform)
+    alias(libs.plugins.compose)
+}
+
+val koinComposeVersion: String by project
+version = koinComposeVersion
+
+kotlin {
+    jvm {
+        withJava()
+    }
+
+    js(IR) {
+        browser()
+    }
+
+    iosX64()
+    iosArm64()
+    iosSimulatorArm64()
+    macosX64()
+    macosArm64()
+
+    sourceSets {
+        commonMain.dependencies {
+            api(project(":core:koin-core"))
+            api(project(":compose:koin-compose"))
+
+            api(libs.compose.jb)
+            api(libs.kotlin.coroutines)
+
+        }
+    }
+}
+
+apply(from = file("../../gradle/publish.gradle.kts"))

--- a/projects/compose/koin-compose-viewmodel/src/commonMain/kotlin/org/koin/composeviewmodel/ComposableViewModel.kt
+++ b/projects/compose/koin-compose-viewmodel/src/commonMain/kotlin/org/koin/composeviewmodel/ComposableViewModel.kt
@@ -1,0 +1,52 @@
+package org.koin.composeviewmodel
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.remember
+import org.koin.compose.getKoin
+import org.koin.core.qualifier.Qualifier
+
+/**
+ * A composable function that provides a convenient way to instantiate and manage a [ComposeViewModel]
+ * within the composable hierarchy. The [ComposeViewModel] instance created by this function is scoped
+ * to the current composition, and its lifetime is bound to the composable's lifecycle.
+ *
+ * Usage of this function ensures that the [ComposeViewModel] and its associated resources are cleared
+ * and disposed of properly when the composable is removed from the hierarchy.
+ *
+ * @param T The type of the [ComposeViewModel] being managed.
+ * @param qualifier An optional qualifier to associate with the [ComposeViewModel] instance. Providing
+ * a qualifier can be useful to distinguish between multiple instances of the same ViewModel type.
+ * @param key1 An optional key to associate with the [ComposeViewModel] instance. Providing a key can
+ * be useful to control the identity and therefore the lifecycle of the ViewModel, especially across
+ * recompositions.
+ * @param content A [Composable] lambda expression that will be invoked with the created [ComposeViewModel]
+ * instance as its argument. This lambda is the consumer of the ViewModel, and is where the ViewModel
+ * should be used to obtain data and interact with the rest of the composable hierarchy.
+ */
+@Composable
+inline fun <reified T : ComposeViewModel> ComposableViewModel(
+    qualifier: Qualifier? = null,
+    key1: Any? = null,
+    content: @Composable (T) -> Unit,
+) {
+    val koin = getKoin()
+    val viewModel: T = remember(key1) { koin.get<T>(qualifier)}
+
+    /*
+     * Manages the disposal process of the [ComposeViewModel] and its associated resources. When the
+     * composable associated with this ViewModel is removed from the hierarchy, or when there is a
+     * change in the provided key, this effect will trigger the [ComposeViewModel.clearViewModel] method
+     * to clean up resources.
+     *
+     * @see DisposableEffect
+     */
+    DisposableEffect(key1 = true) {
+        onDispose {
+            viewModel.clearViewModel()
+        }
+    }
+
+    // Invokes the consumer [content] lambda with the created [ComposeViewModel] instance.
+    content(viewModel)
+}

--- a/projects/compose/koin-compose-viewmodel/src/commonMain/kotlin/org/koin/composeviewmodel/ComposeViewModel.kt
+++ b/projects/compose/koin-compose-viewmodel/src/commonMain/kotlin/org/koin/composeviewmodel/ComposeViewModel.kt
@@ -1,0 +1,52 @@
+package org.koin.composeviewmodel
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import org.koin.core.component.KoinComponent
+
+/**
+ * A base view model designed to wrap [Composable] functions with associated business logic.
+ *
+ * This class provides core utilities and structures to manage coroutine lifecycles within the
+ * scope of a ViewModel. It ensures that the coroutines are automatically cancelled and cleaned up
+ * when the ViewModel is no longer in use.
+ */
+abstract class ComposeViewModel : KoinComponent {
+
+    /**
+     * Represents a [SupervisorJob] that oversees all coroutine jobs initiated by this ViewModel.
+     * Utilizing a supervisor allows child jobs to fail independently without affecting others.
+     */
+    protected val viewModelSupervisor = SupervisorJob()
+
+    /**
+     * A coroutine scope specifically for this ViewModel, determined by [viewModelSupervisor].
+     * All coroutines launched within this ViewModel should use this scope to ensure they are
+     * tied to the ViewModel's lifecycle.
+     */
+    protected val viewModelScope = CoroutineScope(viewModelSupervisor)
+
+
+    /**
+     * Abstract function that should be overridden by subclasses to clear or release resources
+     * and jobs when the ViewModel is about to be disposed of.
+     *
+     * This function gets called when [clearViewModel] is executed, before the supervisor gets cancelled.
+     */
+    abstract suspend fun onClear()
+
+    /**
+     * Handles the process of cleaning up and releasing all resources tied to the ViewModel.
+     * It first triggers the [onClear] method and, upon completion, cancels the [viewModelSupervisor]
+     * which in turn cancels all active jobs under its jurisdiction.
+     */
+    fun clearViewModel() {
+        viewModelScope.launch {
+            onClear()
+        }.invokeOnCompletion {
+            viewModelSupervisor.cancel("Compose View Model Job Cancelled")
+        }
+    }
+}

--- a/projects/compose/koin-compose-viewmodel/src/commonMain/kotlin/org/koin/composeviewmodel/ComposeViewModelDelegate.kt
+++ b/projects/compose/koin-compose-viewmodel/src/commonMain/kotlin/org/koin/composeviewmodel/ComposeViewModelDelegate.kt
@@ -1,0 +1,198 @@
+package org.koin.composeviewmodel
+
+import org.koin.core.definition.Definition
+import org.koin.core.definition.KoinDefinition
+import org.koin.core.module.Module
+import org.koin.core.module.dsl.DefinitionOptions
+import org.koin.core.module.dsl.new
+import org.koin.core.module.dsl.onOptions
+import org.koin.core.qualifier.Qualifier
+
+inline fun <reified T : ComposeViewModel> Module.composeViewModel(
+    qualifier: Qualifier? = null,
+    noinline definition: Definition<T>
+): KoinDefinition<T> {
+    return factory(qualifier, definition)
+}
+
+
+inline fun <reified R : ComposeViewModel> Module.composeViewModelOf(
+    crossinline constructor: () -> R,
+    noinline options: DefinitionOptions<R>? = null,
+): KoinDefinition<R> = composeViewModel { new(constructor) }.onOptions(options)
+
+/**
+ * @see ComposeViewModelOf
+ */
+inline fun <reified R : ComposeViewModel, reified T1> Module.composeViewModelOf(
+    crossinline constructor: (T1) -> R,
+    noinline options: DefinitionOptions<R>? = null,
+): KoinDefinition<R> = composeViewModel { new(constructor) }.onOptions(options)
+
+/**
+ * @see ComposeViewModelOf
+ */
+inline fun <reified R : ComposeViewModel, reified T1, reified T2> Module.composeViewModelOf(
+    crossinline constructor: (T1, T2) -> R,
+    noinline options: DefinitionOptions<R>? = null,
+): KoinDefinition<R> = composeViewModel { new(constructor) }.onOptions(options)
+
+/**
+ * @see ComposeViewModelOf
+ */
+inline fun <reified R : ComposeViewModel, reified T1, reified T2, reified T3> Module.composeViewModelOf(
+    crossinline constructor: (T1, T2, T3) -> R,
+    noinline options: DefinitionOptions<R>? = null,
+): KoinDefinition<R> = composeViewModel { new(constructor) }.onOptions(options)
+
+/**
+ * @see ComposeViewModelOf
+ */
+inline fun <reified R : ComposeViewModel, reified T1, reified T2, reified T3, reified T4> Module.composeViewModelOf(
+    crossinline constructor: (T1, T2, T3, T4) -> R,
+    noinline options: DefinitionOptions<R>? = null,
+): KoinDefinition<R> = composeViewModel { new(constructor) }.onOptions(options)
+
+/**
+ * @see ComposeViewModelOf
+ */
+inline fun <reified R : ComposeViewModel, reified T1, reified T2, reified T3, reified T4, reified T5> Module.composeViewModelOf(
+    crossinline constructor: (T1, T2, T3, T4, T5) -> R,
+    noinline options: DefinitionOptions<R>? = null,
+): KoinDefinition<R> = composeViewModel { new(constructor) }.onOptions(options)
+
+/**
+ * @see ComposeViewModelOf
+ */
+inline fun <reified R : ComposeViewModel, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6> Module.composeViewModelOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6) -> R,
+    noinline options: DefinitionOptions<R>? = null,
+): KoinDefinition<R> = composeViewModel { new(constructor) }.onOptions(options)
+
+/**
+ * @see ComposeViewModelOf
+ */
+inline fun <reified R : ComposeViewModel, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7> Module.composeViewModelOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7) -> R,
+    noinline options: DefinitionOptions<R>? = null,
+): KoinDefinition<R> = composeViewModel { new(constructor) }.onOptions(options)
+
+/**
+ * @see ComposeViewModelOf
+ */
+inline fun <reified R : ComposeViewModel, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8> Module.composeViewModelOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8) -> R,
+    noinline options: DefinitionOptions<R>? = null,
+): KoinDefinition<R> = composeViewModel { new(constructor) }.onOptions(options)
+
+/**
+ * @see ComposeViewModelOf
+ */
+inline fun <reified R : ComposeViewModel, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9> Module.composeViewModelOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9) -> R,
+    noinline options: DefinitionOptions<R>? = null,
+): KoinDefinition<R> = composeViewModel { new(constructor) }.onOptions(options)
+
+/**
+ * @see ComposeViewModelOf
+ */
+inline fun <reified R : ComposeViewModel, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10> Module.composeViewModelOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10) -> R,
+    noinline options: DefinitionOptions<R>? = null,
+): KoinDefinition<R> = composeViewModel { new(constructor) }.onOptions(options)
+
+/**
+ * @see ComposeViewModelOf
+ */
+inline fun <reified R : ComposeViewModel, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11> Module.composeViewModelOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11) -> R,
+    noinline options: DefinitionOptions<R>? = null,
+): KoinDefinition<R> = composeViewModel { new(constructor) }.onOptions(options)
+
+/**
+ * @see ComposeViewModelOf
+ */
+inline fun <reified R : ComposeViewModel, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12> Module.composeViewModelOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12) -> R,
+    noinline options: DefinitionOptions<R>? = null,
+): KoinDefinition<R> = composeViewModel { new(constructor) }.onOptions(options)
+
+/**
+ * @see ComposeViewModelOf
+ */
+inline fun <reified R : ComposeViewModel, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13> Module.composeViewModelOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13) -> R,
+    noinline options: DefinitionOptions<R>? = null,
+): KoinDefinition<R> = composeViewModel { new(constructor) }.onOptions(options)
+
+/**
+ * @see ComposeViewModelOf
+ */
+inline fun <reified R : ComposeViewModel, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14> Module.composeViewModelOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14) -> R,
+    noinline options: DefinitionOptions<R>? = null,
+): KoinDefinition<R> = composeViewModel { new(constructor) }.onOptions(options)
+
+/**
+ * @see ComposeViewModelOf
+ */
+inline fun <reified R : ComposeViewModel, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15> Module.composeViewModelOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15) -> R,
+    noinline options: DefinitionOptions<R>? = null,
+): KoinDefinition<R> = composeViewModel { new(constructor) }.onOptions(options)
+
+/**
+ * @see ComposeViewModelOf
+ */
+inline fun <reified R : ComposeViewModel, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16> Module.composeViewModelOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16) -> R,
+    noinline options: DefinitionOptions<R>? = null,
+): KoinDefinition<R> = composeViewModel { new(constructor) }.onOptions(options)
+
+/**
+ * @see ComposeViewModelOf
+ */
+inline fun <reified R : ComposeViewModel, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16, reified T17> Module.composeViewModelOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17) -> R,
+    noinline options: DefinitionOptions<R>? = null,
+): KoinDefinition<R> = composeViewModel { new(constructor) }.onOptions(options)
+
+/**
+ * @see ComposeViewModelOf
+ */
+inline fun <reified R : ComposeViewModel, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16, reified T17, reified T18> Module.composeViewModelOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18) -> R,
+    noinline options: DefinitionOptions<R>? = null,
+): KoinDefinition<R> = composeViewModel { new(constructor) }.onOptions(options)
+
+/**
+ * @see ComposeViewModelOf
+ */
+inline fun <reified R : ComposeViewModel, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16, reified T17, reified T18, reified T19> Module.composeViewModelOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19) -> R,
+    noinline options: DefinitionOptions<R>? = null,
+): KoinDefinition<R> = composeViewModel { new(constructor) }.onOptions(options)
+
+/**
+ * @see ComposeViewModelOf
+ */
+inline fun <reified R : ComposeViewModel, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16, reified T17, reified T18, reified T19, reified T20> Module.composeViewModelOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20) -> R,
+    noinline options: DefinitionOptions<R>? = null,
+): KoinDefinition<R> = composeViewModel { new(constructor) }.onOptions(options)
+
+/**
+ * @see ComposeViewModelOf
+ */
+inline fun <reified R : ComposeViewModel, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16, reified T17, reified T18, reified T19, reified T20, reified T21> Module.composeViewModelOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21) -> R,
+    noinline options: DefinitionOptions<R>? = null,
+): KoinDefinition<R> = composeViewModel { new(constructor) }.onOptions(options)
+
+/**
+ * @see ComposeViewModelOf
+ */
+inline fun <reified R : ComposeViewModel, reified T1, reified T2, reified T3, reified T4, reified T5, reified T6, reified T7, reified T8, reified T9, reified T10, reified T11, reified T12, reified T13, reified T14, reified T15, reified T16, reified T17, reified T18, reified T19, reified T20, reified T21, reified T22> Module.composeViewModelOf(
+    crossinline constructor: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22) -> R,
+    noinline options: DefinitionOptions<R>? = null,
+): KoinDefinition<R> = composeViewModel { new(constructor) }.onOptions(options)

--- a/projects/settings.gradle.kts
+++ b/projects/settings.gradle.kts
@@ -32,6 +32,7 @@ include(
     ":android:koin-android-test",
     // Compose
     ":compose:koin-compose",
+    ":compose:koin-compose-viewmodel",
     ":compose:koin-androidx-compose",
     ":compose:koin-androidx-compose-navigation",
     // Plugin


### PR DESCRIPTION
Trying to make an experimental feature that our team has used for a couple of years. This is the first of the feature which introduces the ComposableViewModel. This takes our concept and wraps Koin's capability to create these view models, which are tied to the lifecycle of the composable, which is good for fine-grain control. The next step is to add the Paternal and Child Composable View Model which allows the VM to survive as long as the parent is around. 