### PR TITLE
Instance Factory isolation fix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,11 +27,11 @@ jobs:
       - name: Validate Gradle Wrapper
         uses: gradle/wrapper-validation-action@v1
 
-      - name: Set up JDK 11
+      - name: Set up JDK
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: 11
+          java-version: 17
     
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
@@ -50,11 +50,11 @@ jobs:
       - name: Validate Gradle Wrapper
         uses: gradle/wrapper-validation-action@v1
 
-      - name: Set up JDK 11
+      - name: Set up JDK
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: 11
+          java-version: 17
 
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
@@ -73,11 +73,11 @@ jobs:
       - name: Validate Gradle Wrapper
         uses: gradle/wrapper-validation-action@v1
 
-      - name: Set up JDK 11
+      - name: Set up JDK
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: 11
+          java-version: 17
 
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,11 +24,11 @@ jobs:
       - name: Validate Gradle Wrapper
         uses: gradle/wrapper-validation-action@v1
 
-      - name: Set up JDK 11
+      - name: Set up JDK
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: 11
+          java-version: 17
 
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,11 +27,11 @@ jobs:
       - name: Validate Gradle Wrapper
         uses: gradle/wrapper-validation-action@v1
 
-      - name: Set up JDK 11
+      - name: Set up JDK
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: 11
+          java-version: 17
     
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -17,11 +17,11 @@ jobs:
       - name: Validate Gradle Wrapper
         uses: gradle/wrapper-validation-action@v1
 
-      - name: Set up JDK 11
+      - name: Set up JDK
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: 11
+          java-version: 17
     
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2

--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/instance/InstanceFactory.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/instance/InstanceFactory.kt
@@ -70,15 +70,15 @@ abstract class InstanceFactory<T>(val beanDefinition: BeanDefinition<T>) : Locka
 
     abstract fun dropAll()
 
-    @Suppress("NAME_SHADOWING")
-    override fun equals(other: Any?): Boolean {
-        val other = (other as? InstanceFactory<*>)?.beanDefinition
-        return beanDefinition == other
-    }
-
-    override fun hashCode(): Int {
-        return beanDefinition.hashCode()
-    }
+//    @Suppress("NAME_SHADOWING")
+//    override fun equals(other: Any?): Boolean {
+//        val other = (other as? InstanceFactory<*>)?.beanDefinition
+//        return beanDefinition == other
+//    }
+//
+//    override fun hashCode(): Int {
+//        return beanDefinition.hashCode()
+//    }
 
     companion object {
         const val ERROR_SEPARATOR = "\n\t"

--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/registry/InstanceRegistry.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/registry/InstanceRegistry.kt
@@ -52,7 +52,7 @@ class InstanceRegistry(val _koin: Koin) {
 
     private fun addAllEagerInstances(module: Module) {
         module.eagerInstances.forEach { factory ->
-            eagerInstances[factory.hashCode()] = factory
+            eagerInstances[factory.beanDefinition.hashCode()] = factory
         }
     }
 

--- a/projects/core/koin-core/src/commonTest/kotlin/org/koin/core/OverrideAndCreateatStartTest.kt
+++ b/projects/core/koin-core/src/commonTest/kotlin/org/koin/core/OverrideAndCreateatStartTest.kt
@@ -1,11 +1,16 @@
 package org.koin.core
 
+import org.koin.core.annotation.KoinInternalApi
 import org.koin.core.context.startKoin
 import org.koin.core.context.stopKoin
+import org.koin.core.definition.IndexKey
+import org.koin.core.instance.InstanceFactory
 import org.koin.core.logger.Level
 import org.koin.dsl.module
+import org.koin.mp.KoinPlatform
 import kotlin.test.AfterTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 interface SomeClassInterface
@@ -45,8 +50,9 @@ class OverrideAndCreateatStartTest {
         stopKoin()
     }
 
+    @OptIn(KoinInternalApi::class)
     @Test
-    fun testMe() {
+    fun testDefinitionOverride() {
         startKoin {
             printLogger(Level.DEBUG)
             modules(moduleA + moduleB)
@@ -54,5 +60,9 @@ class OverrideAndCreateatStartTest {
 
         assertTrue(count == 1)
         assertTrue(created == "SomeClassB")
+        KoinPlatform.getKoin().instanceRegistry.instances.firstNotNullOf { (k: IndexKey,v: InstanceFactory<*>) ->
+            assertEquals(k, moduleB.mappings.keys.first())
+            assertEquals(v, moduleB.mappings.values.first())
+        }
     }
 }

--- a/projects/core/koin-core/src/commonTest/kotlin/org/koin/dsl/ModuleFactoryIsolationTest.kt
+++ b/projects/core/koin-core/src/commonTest/kotlin/org/koin/dsl/ModuleFactoryIsolationTest.kt
@@ -1,0 +1,40 @@
+package org.koin.dsl
+
+import org.koin.Simple
+import org.koin.core.annotation.KoinInternalApi
+import org.koin.core.module.Module
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+val myValModule = module { single { Simple.ComponentA() } }
+
+val myGetModule : Module
+    get() = module { single { Simple.ComponentA() }  }
+
+fun myFunModule() = module { single { Simple.ComponentA() }  }
+
+@OptIn(KoinInternalApi::class)
+class ModuleFactoryIsolationTest {
+
+    @Test
+    fun testVariableIsolationAndInstanceFactories(){
+        val a = myGetModule
+        val b = myGetModule
+
+        val aA = myValModule
+        val aB = myValModule
+
+        val aF = myFunModule()
+        val bF = myFunModule()
+
+        assertTrue(a.mappings != b.mappings)
+        assertEquals(a.mappings.values.first().beanDefinition, b.mappings.values.first().beanDefinition)
+
+        assertEquals(aA.mappings, aB.mappings)
+
+        assertTrue(aF.mappings != bF.mappings)
+        assertEquals(aF.mappings.values.first().beanDefinition, bF.mappings.values.first().beanDefinition)
+    }
+
+}


### PR DESCRIPTION
Avoid to compare directly with definition bean and have different factory instance with same definition, confused with same factory instance. One must override the other.