### PR TITLE
Module Mapping isolation fix 

### DIFF
--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/instance/InstanceFactory.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/instance/InstanceFactory.kt
@@ -70,16 +70,6 @@ abstract class InstanceFactory<T>(val beanDefinition: BeanDefinition<T>) : Locka
 
     abstract fun dropAll()
 
-//    @Suppress("NAME_SHADOWING")
-//    override fun equals(other: Any?): Boolean {
-//        val other = (other as? InstanceFactory<*>)?.beanDefinition
-//        return beanDefinition == other
-//    }
-//
-//    override fun hashCode(): Int {
-//        return beanDefinition.hashCode()
-//    }
-
     companion object {
         const val ERROR_SEPARATOR = "\n\t"
     }

--- a/projects/core/koin-core/src/commonTest/kotlin/org/koin/dsl/ModuleFactoryIsolationTest.kt
+++ b/projects/core/koin-core/src/commonTest/kotlin/org/koin/dsl/ModuleFactoryIsolationTest.kt
@@ -9,8 +9,7 @@ import kotlin.test.assertTrue
 
 val myValModule = module { single { Simple.ComponentA() } }
 
-val myGetModule : Module
-    get() = module { single { Simple.ComponentA() }  }
+val myGetModule : Module get() = module { single { Simple.ComponentA() }  }
 
 fun myFunModule() = module { single { Simple.ComponentA() }  }
 
@@ -37,4 +36,13 @@ class ModuleFactoryIsolationTest {
         assertEquals(aF.mappings.values.first().beanDefinition, bF.mappings.values.first().beanDefinition)
     }
 
+    @Test
+    fun testVariableIsolationAndInstanceFactoriesLocal(){
+        assertTrue(a.mappings != b.mappings)
+        assertEquals(a.mappings.values.first().beanDefinition, b.mappings.values.first().beanDefinition)
+    }
+
 }
+
+val ModuleFactoryIsolationTest.a : Module get() = myGetModule
+val ModuleFactoryIsolationTest.b : Module get() = myGetModule


### PR DESCRIPTION
Following work on 13e09130bf5ee1eac8ae665b6d58d3deb3de9bf3

Comment equals/hashcode on beandefinition to let have modules with same definition, but different instance factory

