### PR TITLE
Update kmp.md

### DIFF
--- a/docs/reference/koin-mp/kmp.md
+++ b/docs/reference/koin-mp/kmp.md
@@ -141,4 +141,4 @@ struct ContentView: View {
 
 ### New Native Memory Management
 
-Activate experimental with root [gradle.properties](http://gradle.properties) properties:
+Activate experimental with root [gradle.properties](https://kotlinlang.org/docs/native-memory-manager.html).


### PR DESCRIPTION
Update of KMP Native Memory Management reference.

When I reading the references I try to access the link but it's not with the correct reference.

I think the official page Kotlin/Native memory management﻿ updated at 21 May 2024 is the correctly.