### PR TITLE
Fix a small typo

### DIFF
--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/component/KoinComponent.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/component/KoinComponent.kt
@@ -34,7 +34,7 @@ interface KoinComponent {
 }
 
 /**
- * Get instance instance from Koin
+ * Get instance from Koin
  * @param qualifier
  * @param parameters
  */


### PR DESCRIPTION
I found a small typo in kdoc. Remove one "instance" from there.