### PR TITLE
Use kotlin.time API

### DIFF
--- a/examples/android-perfs/src/main/java/org/koin/sample/android/main/MainActivity.kt
+++ b/examples/android-perfs/src/main/java/org/koin/sample/android/main/MainActivity.kt
@@ -8,6 +8,7 @@ import org.koin.benchmark.PerfLimit
 import org.koin.benchmark.PerfRunner.runAll
 import org.koin.sample.android.R
 import kotlin.coroutines.CoroutineContext
+import kotlin.time.Duration.Companion.milliseconds
 
 class MainActivity : AppCompatActivity(), CoroutineScope {
 
@@ -19,7 +20,7 @@ class MainActivity : AppCompatActivity(), CoroutineScope {
         title = "Android First Perfs"
 
         runBlocking {
-            val limits = PerfLimit(10.8, 0.185)
+            val limits = PerfLimit(10.8.milliseconds, 0.185.milliseconds)
 
             println("Perf Tolerance: $limits")
 
@@ -29,8 +30,8 @@ class MainActivity : AppCompatActivity(), CoroutineScope {
 
             val textWidget = findViewById<TextView>(R.id.text)
             var textReport = """
-                Start time: $startTime - max ${results.worstMaxStartTime} ms
-                Exec time: $execTime - max ${results.worstExecTime} ms
+                Start time: $startTime - max ${results.worstMaxStartTime}
+                Exec time: $execTime - max ${results.worstExecTime}
             """.trimIndent()
 
             if (!results.isOk) textReport += "\nTest Failed!"

--- a/examples/android-perfs/src/test/java/org/koin/benchmark/TestPerfRunner.kt
+++ b/examples/android-perfs/src/test/java/org/koin/benchmark/TestPerfRunner.kt
@@ -3,24 +3,25 @@ package org.koin.benchmark
 import junit.framework.TestCase.assertTrue
 import kotlinx.coroutines.runBlocking
 import org.junit.Test
+import kotlin.time.Duration.Companion.milliseconds
 
 class TestPerfRunner {
 
     /**
-     * Avg start time: 13.06
-     * Avg execution time: 0.158
+     * Avg start time: 13.06 ms
+     * Avg execution time: 0.158 ms
      */
 //    @Test
     fun main() = runBlocking {
-        val limits = PerfLimit(17.0, 0.175)
+        val limits = PerfLimit(17.milliseconds, 0.175.milliseconds)
 
         println("Perf Tolerance: $limits")
 
         val results = PerfRunner.runAll(this)
         results.applyLimits(limits)
 
-        assertTrue("Should start under ${results.worstMaxStartTime} ms", results.isStartOk)
-        assertTrue("Should exec under ${results.worstExecTime} ms", results.isExecOk)
+        assertTrue("Should start under ${results.worstMaxStartTime}", results.isStartOk)
+        assertTrue("Should exec under ${results.worstExecTime}", results.isExecOk)
     }
 
 }

--- a/examples/coffee-maker/src/main/kotlin/org/koin/example/CoffeeApp.kt
+++ b/examples/coffee-maker/src/main/kotlin/org/koin/example/CoffeeApp.kt
@@ -4,7 +4,7 @@ import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import org.koin.core.context.startKoin
 import org.koin.core.logger.Level
-import org.koin.core.time.measureDuration
+import kotlin.time.measureTime
 
 class CoffeeApp : KoinComponent {
     val maker: CoffeeMaker by inject()
@@ -17,8 +17,8 @@ fun main() {
     }
 
     val coffeeShop = CoffeeApp()
-    val duration = measureDuration {
+    val duration = measureTime {
         coffeeShop.maker.brew()
     }
-    println("Got Coffee in $duration ms")
+    println("Got Coffee in $duration")
 }

--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/Koin.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/Koin.kt
@@ -33,9 +33,9 @@ import org.koin.core.registry.PropertyRegistry
 import org.koin.core.registry.ScopeRegistry
 import org.koin.core.scope.Scope
 import org.koin.core.scope.ScopeID
-import org.koin.core.time.measureDuration
 import org.koin.mp.KoinPlatformTools
 import kotlin.reflect.KClass
+import kotlin.time.measureTime
 
 /**
  * Koin
@@ -326,9 +326,9 @@ class Koin {
      */
     fun createEagerInstances() {
         logger.debug("Create eager instances ...")
-        val duration = measureDuration {
+        val duration = measureTime {
             instanceRegistry.createAllEagerInstances()
         }
-        logger.debug("Created eager instances in $duration ms")
+        logger.debug("Created eager instances in $duration")
     }
 }

--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/KoinApplication.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/KoinApplication.kt
@@ -20,8 +20,8 @@ import org.koin.core.logger.Level
 import org.koin.core.logger.Logger
 import org.koin.core.module.KoinApplicationDslMarker
 import org.koin.core.module.Module
-import org.koin.core.time.measureDuration
 import org.koin.mp.KoinPlatformTools
+import kotlin.time.measureTime
 
 /**
  * Koin Application
@@ -58,9 +58,9 @@ class KoinApplication private constructor() {
      */
     fun modules(modules: List<Module>): KoinApplication {
         if (koin.logger.isAt(Level.INFO)) {
-            val duration = measureDuration { loadModules(modules) }
+            val duration = measureTime { loadModules(modules) }
             val count = koin.instanceRegistry.size()
-            koin.logger.display(Level.INFO, "Started $count definitions in $duration ms")
+            koin.logger.display(Level.INFO, "Started $count definitions in $duration")
         } else {
             loadModules(modules)
         }

--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/scope/Scope.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/scope/Scope.kt
@@ -28,13 +28,12 @@ import org.koin.core.module.KoinDslMarker
 import org.koin.core.parameter.ParametersDefinition
 import org.koin.core.parameter.ParametersHolder
 import org.koin.core.qualifier.Qualifier
-import org.koin.core.time.Timer
 import org.koin.ext.getFullName
-import org.koin.mp.KoinPlatformTimeTools
 import org.koin.mp.KoinPlatformTools
 import org.koin.mp.Lockable
 import org.koin.mp.ThreadLocal
 import kotlin.reflect.KClass
+import kotlin.time.measureTimedValue
 
 @Suppress("UNCHECKED_CAST")
 @OptIn(KoinInternalApi::class)
@@ -202,12 +201,11 @@ class Scope(
             val scopeId = if (isRoot) "" else "- scope:'$id"
             _koin.logger.display(Level.DEBUG, "|- '${clazz.getFullName()}'$qualifierString $scopeId...")
 
-            val start = KoinPlatformTimeTools.getTimeInNanoSeconds()
-            val instance = resolveInstance<T>(qualifier, clazz, parameters)
-            val stop = KoinPlatformTimeTools.getTimeInNanoSeconds()
-            val duration = (stop - start) / Timer.NANO_TO_MILLI
+            val (instance, duration) = measureTimedValue {
+                resolveInstance<T>(qualifier, clazz, parameters)
+            }
 
-            _koin.logger.display(Level.DEBUG, "|- '${clazz.getFullName()}' in $duration ms")
+            _koin.logger.display(Level.DEBUG, "|- '${clazz.getFullName()}' in $duration")
             instance
         } else {
             resolveInstance(qualifier, clazz, parameters)

--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/time/Measure.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/time/Measure.kt
@@ -29,6 +29,8 @@ import org.koin.mp.KoinPlatformTimeTools
  * @param code - code to execute
  * @return Time in milliseconds
  */
+@Suppress("DeprecatedCallableAddReplaceWith")
+@Deprecated("Use measureTime() from kotlin.time instead.")
 inline fun measureDuration(code: () -> Unit): TimeInMillis {
     return measureTimedValue(code).second
 }
@@ -38,11 +40,13 @@ inline fun measureDuration(code: () -> Unit): TimeInMillis {
  * @param code - code to execute
  * @return Pair Value & Time in milliseconds
  */
+@Deprecated("Use measureTimedValue() from kotlin.time instead.")
 inline fun <T> measureDurationForResult(code: () -> T): Pair<T, TimeInMillis> {
     val (value, duration) = measureTimedValue(code)
     return Pair(value, duration)
 }
 
+@Deprecated("Use measureTimedValue() from kotlin.time instead.")
 inline fun <T> measureTimedValue(code: () -> T): Pair<T, TimeInMillis> {
     val start = KoinPlatformTimeTools.getTimeInNanoSeconds()
     val value = code()
@@ -50,4 +54,5 @@ inline fun <T> measureTimedValue(code: () -> T): Pair<T, TimeInMillis> {
     return Pair(value, (stop - start) / Timer.NANO_TO_MILLI)
 }
 
+@Deprecated("Use kotlin.time.Duration instead.")
 typealias TimeInMillis = Double

--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/time/Timer.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/time/Timer.kt
@@ -6,6 +6,7 @@ import kotlin.time.Duration.Companion.ZERO
 import kotlin.time.DurationUnit
 import kotlin.time.toDuration
 
+@Deprecated("Use TimeSource.Monotonic instead.")
 class Timer {
 
     val start: Duration = KoinPlatformTimeTools.getTimeInNanoSeconds().toDuration(DurationUnit.NANOSECONDS)

--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/mp/KoinPlatformTimeTools.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/mp/KoinPlatformTimeTools.kt
@@ -15,6 +15,13 @@
  */
 package org.koin.mp
 
-expect object KoinPlatformTimeTools {
-    fun getTimeInNanoSeconds(): Long
+import kotlin.time.TimeSource
+
+@Deprecated("Use kotlin.time instead.")
+object KoinPlatformTimeTools {
+
+    @Suppress("DeprecatedCallableAddReplaceWith")
+    @Deprecated("Use TimeSource.Monotonic.markNow() instead.")
+    fun getTimeInNanoSeconds(): Long =
+        TimeSource.Monotonic.markNow().elapsedNow().inWholeNanoseconds
 }

--- a/projects/core/koin-core/src/commonTest/kotlin/org/koin/core/SetterInjectTest.kt
+++ b/projects/core/koin-core/src/commonTest/kotlin/org/koin/core/SetterInjectTest.kt
@@ -7,11 +7,11 @@ import org.koin.core.component.inject
 import org.koin.core.context.startKoin
 import org.koin.core.context.stopKoin
 import org.koin.core.scope.Scope
-import org.koin.core.time.measureDuration
 import org.koin.dsl.module
 import org.koin.ext.inject
 import kotlin.test.AfterTest
 import kotlin.test.Test
+import kotlin.time.measureTime
 
 class B : KoinScopeComponent {
     override val scope: Scope by lazy { createScope(this) }
@@ -56,30 +56,27 @@ class PlayTest {
             )
         }.koin
 
-        measureDuration("by inject") {
+        val byInjectDuration = measureTime {
             val ai = A_inj()
             ai.b
             ai.c
         }
+        println("by inject in $byInjectDuration")
 
-        measureDuration("prop get") {
+        val propGetDuration = measureTime {
             val a = A()
             a.b = koin.get()
             a.c = koin.get()
         }
+        println("prop get in $propGetDuration")
 
-        measureDuration("prop inject") {
+        val propInjectDuration = measureTime {
             val a = A()
             a::b.inject()
             a::c.inject()
         }
+        println("prop inject in $propInjectDuration")
 
         stopKoin()
     }
-}
-
-fun measureDuration(msg: String, code: () -> Unit): Double {
-    val duration = measureDuration(code)
-    println("$msg in $duration ms")
-    return duration
 }

--- a/projects/core/koin-core/src/commonTest/kotlin/org/koin/perfs/PerfsTest.kt
+++ b/projects/core/koin-core/src/commonTest/kotlin/org/koin/perfs/PerfsTest.kt
@@ -3,21 +3,17 @@
 // import kotlin.test.Test
 // import org.koin.core.annotation.KoinInternalApi
 // import org.koin.core.logger.*
-// import org.koin.core.time.Timer
 // import org.koin.dsl.koinApplication
-// import org.koin.mp.KoinPlatformTools
 // import org.koin.test.assertDefinitionsCount
+// import kotlin.time.measureTime
+// import kotlin.time.measureTimedValue
 //
-// @OptIn(KoinInternalApi::class)
 // class PerfsTest {
 //
 //    @Test
 //    fun empty_module_perfs() {
-//        val timerStart = Timer.start()
-//        val app = koinApplication()
-//        timerStart.stop()
-//        println("empty start in ${timerStart.getTimeInMillis()} ms")
-//
+//        val (app, duration) = measureTimedValue { koinApplication() }
+//        println("empty start in $duration")
 //        app.assertDefinitionsCount(0)
 //        app.close()
 //    }
@@ -29,22 +25,24 @@
 //    }
 //
 //    private fun runPerfs(log: Logger = EmptyLogger()) {
-//        val timerStart = Timer.start()
-//        val app = koinApplication {
-//            modules(perfModule400())
+//        val (app, startKoinAppDuration) = measureTimedValue {
+//            koinApplication {
+//                modules(perfModule400())
+//            }
 //        }
-//        timerStart.stop()
-//        println("perf400 - start in ${timerStart.getTimeInMillis()}")
+//
+//        println("perf400 - start in $startKoinAppDuration")
 //
 //        val koin = app.koin
 //
-//        val timerRun = Timer.start()
-//        koin.get<Perfs.A27>()
-//        koin.get<Perfs.B31>()
-//        koin.get<Perfs.C12>()
-//        koin.get<Perfs.D42>()
-//        timerRun.stop()
-//        println("perf400 - executed in ${timerRun.getTimeInMillis()}")
+//        val getDepsDuration = measureTime {
+//            koin.get<Perfs.A27>()
+//            koin.get<Perfs.B31>()
+//            koin.get<Perfs.C12>()
+//            koin.get<Perfs.D42>()
+//        }
+//
+//        println("perf400 - executed in $getDepsDuration")
 //
 //        app.close()
 //    }

--- a/projects/core/koin-core/src/jsMain/kotlin/org/koin/mp/PlatformTimeTools.kt
+++ b/projects/core/koin-core/src/jsMain/kotlin/org/koin/mp/PlatformTimeTools.kt
@@ -1,9 +1,0 @@
-package org.koin.mp
-
-import kotlin.time.TimeSource
-
-actual object KoinPlatformTimeTools {
-    actual fun getTimeInNanoSeconds(): Long {
-        return TimeSource.Monotonic.markNow().elapsedNow().inWholeNanoseconds
-    }
-}

--- a/projects/core/koin-core/src/jvmMain/kotlin/org/koin/core/instance/InstanceBuilder.kt
+++ b/projects/core/koin-core/src/jvmMain/kotlin/org/koin/core/instance/InstanceBuilder.kt
@@ -8,10 +8,10 @@ import org.koin.core.logger.Level
 import org.koin.core.parameter.ParametersHolder
 import org.koin.core.parameter.emptyParametersHolder
 import org.koin.core.scope.Scope
-import org.koin.core.time.measureDurationForResult
 import org.koin.ext.getFullName
 import java.lang.reflect.Constructor
 import kotlin.reflect.KClass
+import kotlin.time.measureTimedValue
 
 @KoinReflectAPI
 @Deprecated("Koin Reflection API is deprecated")
@@ -35,20 +35,20 @@ fun <T : Any> Scope.newInstance(kClass: KClass<T>, params: ParametersHolder): T 
         ?: error("No constructor found for class '${kClass.getFullName()}'")
 
     val args = if (logger.level == Level.DEBUG) {
-        val (_args, duration) = measureDurationForResult {
+        val (_args, duration) = measureTimedValue {
             getArguments(constructor, this, params)
         }
-        logger.debug("|- got arguments in $duration ms")
+        logger.debug("|- got arguments in $duration")
         _args
     } else {
         getArguments(constructor, this, params)
     }
 
     instance = if (logger.level == Level.DEBUG) {
-        val (_instance, duration) = measureDurationForResult {
+        val (_instance, duration) = measureTimedValue {
             createInstance(args, constructor)
         }
-        logger.debug("|- created instance in $duration ms")
+        logger.debug("|- created instance in $duration")
         _instance
     } else {
         createInstance(args, constructor)

--- a/projects/core/koin-core/src/jvmMain/kotlin/org/koin/mp/KoinPlatformTimeTools.kt
+++ b/projects/core/koin-core/src/jvmMain/kotlin/org/koin/mp/KoinPlatformTimeTools.kt
@@ -1,7 +1,0 @@
-package org.koin.mp
-
-actual object KoinPlatformTimeTools {
-    actual fun getTimeInNanoSeconds(): Long {
-        return System.nanoTime()
-    }
-}

--- a/projects/core/koin-core/src/jvmTest/kotlin/org/koin/core/DebugLogTest.kt
+++ b/projects/core/koin-core/src/jvmTest/kotlin/org/koin/core/DebugLogTest.kt
@@ -5,6 +5,7 @@ import org.koin.core.annotation.KoinInternalApi
 import org.koin.core.context.startKoin
 import org.koin.core.context.stopKoin
 import org.koin.core.logger.Level
+import kotlin.time.measureTime
 
 @OptIn(KoinInternalApi::class)
 class DebugLogTest {
@@ -16,14 +17,19 @@ class DebugLogTest {
         }.koin
 
         (1..10).forEach {
-            measureDuration("with if") {
+            val withIfDuration = measureTime {
                 if (koin.logger.isAt(Level.DEBUG)) {
                     koin.logger.debug(message { "test me" })
                 }
             }
-            measureDuration("with fct") {
+
+            println("with if in $withIfDuration")
+
+            val withFctDuration = measureTime {
                 koin.logger.log(Level.DEBUG) { "test me" }
             }
+
+            println("with fct in $withFctDuration")
         }
         stopKoin()
     }

--- a/projects/core/koin-core/src/jvmTest/kotlin/org/koin/core/instance/CreateAPITest.kt
+++ b/projects/core/koin-core/src/jvmTest/kotlin/org/koin/core/instance/CreateAPITest.kt
@@ -5,10 +5,10 @@ import org.junit.Test
 import org.koin.core.error.InstanceCreationException
 import org.koin.core.logger.Level
 import org.koin.core.parameter.parametersOf
-import org.koin.core.time.measureDuration
 import org.koin.dsl.koinApplication
 import org.koin.dsl.module
 import org.koin.dsl.single
+import kotlin.time.measureTime
 
 class CreateAPITest {
 
@@ -24,10 +24,10 @@ class CreateAPITest {
             )
         }.koin
 
-        val duration = measureDuration {
+        val duration = measureTime {
             koin.get<ComponentB>()
         }
-        println("create api in $duration ms")
+        println("create api in $duration")
 
         val createKoin = koinApplication {
             printLogger(Level.DEBUG)
@@ -39,10 +39,10 @@ class CreateAPITest {
             )
         }.koin
 
-        val createDuration = measureDuration {
+        val createDuration = measureTime {
             createKoin.get<ComponentB>()
         }
-        println("create api in $createDuration ms")
+        println("create api in $createDuration")
     }
 
     @Test

--- a/projects/core/koin-core/src/nativeMain/kotlin/org/koin/mp/KoinPlatformTimeTools.kt
+++ b/projects/core/koin-core/src/nativeMain/kotlin/org/koin/mp/KoinPlatformTimeTools.kt
@@ -1,9 +1,0 @@
-package org.koin.mp
-
-import kotlin.time.TimeSource
-
-actual object KoinPlatformTimeTools {
-    actual fun getTimeInNanoSeconds(): Long {
-        return TimeSource.Monotonic.markNow().elapsedNow().inWholeNanoseconds
-    }
-}

--- a/projects/core/koin-core/src/wasmJsMain/kotlin/org/koin/mp/PlatformTimeTools.kt
+++ b/projects/core/koin-core/src/wasmJsMain/kotlin/org/koin/mp/PlatformTimeTools.kt
@@ -1,9 +1,0 @@
-package org.koin.mp
-
-import kotlin.time.TimeSource
-
-actual object KoinPlatformTimeTools {
-    actual fun getTimeInNanoSeconds(): Long {
-        return TimeSource.Monotonic.markNow().elapsedNow().inWholeNanoseconds
-    }
-}

--- a/projects/core/koin-test/src/jvmMain/kotlin/org/koin/test/verify/VerifyModule.kt
+++ b/projects/core/koin-test/src/jvmMain/kotlin/org/koin/test/verify/VerifyModule.kt
@@ -3,8 +3,8 @@ package org.koin.test.verify
 import org.koin.core.annotation.KoinExperimentalAPI
 import org.koin.core.annotation.KoinInternalApi
 import org.koin.core.module.Module
-import org.koin.core.time.Timer
 import kotlin.reflect.KClass
+import kotlin.time.measureTime
 
 /**
  * Make a static verification about all declared classes constructors, to ensure they are all bound to an existing definition
@@ -63,16 +63,13 @@ object Verify {
      * @throws MissingKoinDefinitionException
      */
     fun verify(module: Module, extraTypes: List<KClass<*>> = listOf()) {
-        val timer = Timer.start()
+        val duration = measureTime {
+            val verification = Verification(module, extraTypes)
+            println("Verifying module '$module' ...")
+//            println("- index: ${verification.definitionIndex.size}")
+            verification.verify()
+        }
 
-        val verification = Verification(module, extraTypes)
-        println("Verifying module '$module' ...")
-//        println("- index: ${verification.definitionIndex.size}")
-        verification.verify()
-
-        timer.stop()
-        val time =
-            if (timer.getTimeInMillis() < 1000) "${timer.getTimeInMillis()} ms" else "${timer.getTimeInSeconds()} sec"
-        println("\n[SUCCESS] module '$this' has been verified in $time.")
+        println("\n[SUCCESS] module '$this' has been verified in $duration.")
     }
 }


### PR DESCRIPTION
_This PR is a duplicate of https://github.com/InsertKoinIO/koin/pull/1697._

--

Kotlin Time API is now [stable](https://kotlinlang.org/docs/whatsnew19.html#stable-time-api), so it's time to replace the self-made time API with it.

`KoinPlatformTimeTools` and other parts of "koin time API" have been marked as deprecated and hopefully they will be removed in the future, as they shouldn't have been part of the public API.