### PR TITLE
Update koin.md

### DIFF
--- a/docs/setup/koin.md
+++ b/docs/setup/koin.md
@@ -51,8 +51,8 @@ koin-core = { module = "io.insert-koin:koin-core" }
 ```
 ```kotlin
 dependencies {
-    implementation(platform(libs.koin.bom))
-    implementation(libs.koin.core)
+    implementation(project.dependencies.platform(libs.koin.bom))
+    implementation(project.dependencies.enforcedPlatform(libs.koin.core))
 }
 ```
 


### PR DESCRIPTION
`platform` is deprecated and will be remove on kotlin 2.1. @see https://youtrack.jetbrains.com/issue/KT-58759/Deprecate-platform-enforcedPlatform-and-other-related-to-Gradle-DependencyHandler-methods-in-KotlinDependencyHandler