### PR TITLE
Revert to compose-navigation 2.7.0-alpha07 supporting compose 1.6.11

### DIFF
--- a/projects/gradle/libs.versions.toml
+++ b/projects/gradle/libs.versions.toml
@@ -22,7 +22,7 @@ androidx-navigation = "2.7.7"
 # Compose
 composeJB = "1.6.11"
 composeLifecycle = "2.8.0"
-composeNavigation = "2.8.0-alpha08"
+composeNavigation = "2.7.0-alpha07"
 composeJetpackRuntime = "1.6.8"
 jbCoreBundle = "1.0.0"
 jbSavedState = "1.2.0"


### PR DESCRIPTION
- revert to compose navigation 2.7.0-alpha07 which supports compose 1.6.11
  - FIX https://github.com/InsertKoinIO/koin/issues/1929
- Note: compose navigation 2.8.0-alpha08 depends on compose 1.7.0-alpha01 causing conflicts with projects using compose 1.6.11