### PR TITLE
map & set multibinding

### DIFF
--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/Koin.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/Koin.kt
@@ -25,6 +25,8 @@ import org.koin.core.logger.EmptyLogger
 import org.koin.core.logger.Logger
 import org.koin.core.module.Module
 import org.koin.core.module.flatten
+import org.koin.core.module.mapMultibindingQualifier
+import org.koin.core.module.setMultibindingQualifier
 import org.koin.core.parameter.ParametersDefinition
 import org.koin.core.qualifier.Qualifier
 import org.koin.core.qualifier.TypeQualifier
@@ -151,6 +153,106 @@ class Koin {
         qualifier: Qualifier? = null,
         parameters: ParametersDefinition? = null,
     ): T? = scopeRegistry.rootScope.getOrNull(clazz, qualifier, parameters)
+
+    /**
+     * Lazy inject a Koin Map Multibinding instance
+     * @param qualifier
+     * @param parameters
+     *
+     * @return Lazy instance of type Map<K, V>
+     */
+    inline fun <reified K, reified V> injectMapMultibinding(
+        qualifier: Qualifier = mapMultibindingQualifier<K, V>(),
+        mode: LazyThreadSafetyMode = KoinPlatformTools.defaultLazyMode(),
+        noinline parameters: ParametersDefinition? = null,
+    ): Lazy<Map<K, V>> = scopeRegistry.rootScope.inject(qualifier, mode, parameters)
+
+    /**
+     * Lazy inject a Koin Set Multibinding instance
+     * @param qualifier
+     * @param parameters
+     *
+     * @return Lazy instance of type Set<E>
+     */
+    inline fun <reified E> injectSetMultibinding(
+        qualifier: Qualifier = setMultibindingQualifier<E>(),
+        mode: LazyThreadSafetyMode = KoinPlatformTools.defaultLazyMode(),
+        noinline parameters: ParametersDefinition? = null,
+    ): Lazy<Set<E>> = scopeRegistry.rootScope.inject(qualifier, mode, parameters)
+
+    /**
+     * Lazy inject a Koin Map Multibinding instance if available
+     * @param qualifier
+     * @param parameters
+     *
+     * @return Lazy instance of type Map<K, V> or null
+     */
+    inline fun <reified K, reified V> injectMapMultibindingOrNull(
+        qualifier: Qualifier = mapMultibindingQualifier<K, V>(),
+        mode: LazyThreadSafetyMode = KoinPlatformTools.defaultLazyMode(),
+        noinline parameters: ParametersDefinition? = null,
+    ): Lazy<Map<K, V>?> = scopeRegistry.rootScope.injectOrNull(qualifier, mode, parameters)
+
+    /**
+     * Lazy inject a Koin Set Multibinding instance if available
+     * @param qualifier
+     * @param parameters
+     *
+     * @return Lazy instance of type Set<E> or null
+     */
+    inline fun <reified E> injectSetMultibindingOrNull(
+        qualifier: Qualifier = setMultibindingQualifier<E>(),
+        mode: LazyThreadSafetyMode = KoinPlatformTools.defaultLazyMode(),
+        noinline parameters: ParametersDefinition? = null,
+    ): Lazy<Set<E>?> = scopeRegistry.rootScope.injectOrNull(qualifier, mode, parameters)
+
+    /**
+     * Get a Koin Map Multibinding instance
+     * @param qualifier
+     * @param parameters
+     *
+     * @return instance of type Map<K, V>
+     */
+    inline fun <reified K, reified V> getMapMultibinding(
+        qualifier: Qualifier = mapMultibindingQualifier<K, V>(),
+        noinline parameters: ParametersDefinition? = null,
+    ): Map<K, V> = scopeRegistry.rootScope.get(qualifier, parameters)
+
+    /**
+     * Get a Koin Set Multibinding instance
+     * @param qualifier
+     * @param parameters
+     *
+     * @return instance of type Set<E>
+     */
+    inline fun <reified E> getSetMultibinding(
+        qualifier: Qualifier = setMultibindingQualifier<E>(),
+        noinline parameters: ParametersDefinition? = null,
+    ): Set<E> = scopeRegistry.rootScope.get(qualifier, parameters)
+
+    /**
+     * Get a Koin Map Multibinding instance if available
+     * @param qualifier
+     * @param parameters
+     *
+     * @return instance of type Map<K, V> or null
+     */
+    inline fun <reified K, reified V> getMapMultibindingOrNull(
+        qualifier: Qualifier = mapMultibindingQualifier<K, V>(),
+        noinline parameters: ParametersDefinition? = null,
+    ): Map<K, V>? = scopeRegistry.rootScope.getOrNull(qualifier, parameters)
+
+    /**
+     * Get a Koin Set Multibinding instance if available
+     * @param qualifier
+     * @param parameters
+     *
+     * @return instance of type Set<E> or null
+     */
+    inline fun <reified E> getSetMultibindingOrNull(
+        qualifier: Qualifier = setMultibindingQualifier<E>(),
+        noinline parameters: ParametersDefinition? = null,
+    ): Set<E>? = scopeRegistry.rootScope.getOrNull(qualifier, parameters)
 
     /**
      * Declare a component definition from the given instance
@@ -308,12 +410,12 @@ class Koin {
      * @param allowOverride - allow to override definitions
      * @param createEagerInstances - run instance creation for eager single definitions
      */
-    fun loadModules(modules: List<Module>, allowOverride: Boolean = true, createEagerInstances : Boolean = false) {
+    fun loadModules(modules: List<Module>, allowOverride: Boolean = true, createEagerInstances: Boolean = false) {
         val flattedModules = flatten(modules)
         instanceRegistry.loadModules(flattedModules, allowOverride)
         scopeRegistry.loadScopes(flattedModules)
 
-        if (createEagerInstances){
+        if (createEagerInstances) {
             createEagerInstances()
         }
     }

--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/component/KoinComponent.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/component/KoinComponent.kt
@@ -16,6 +16,8 @@
 package org.koin.core.component
 
 import org.koin.core.Koin
+import org.koin.core.module.mapMultibindingQualifier
+import org.koin.core.module.setMultibindingQualifier
 import org.koin.core.parameter.ParametersDefinition
 import org.koin.core.qualifier.Qualifier
 import org.koin.mp.KoinPlatformTools
@@ -61,3 +63,51 @@ inline fun <reified T : Any> KoinComponent.inject(
     noinline parameters: ParametersDefinition? = null,
 ): Lazy<T> =
     lazy(mode) { get<T>(qualifier, parameters) }
+
+/**
+ * Get Koin Map Multibinding instance from Koin
+ * @param qualifier
+ * @param parameters
+ */
+inline fun <reified K, reified V> KoinComponent.getMapMultibinding(
+    qualifier: Qualifier = mapMultibindingQualifier<K, V>(),
+    noinline parameters: ParametersDefinition? = null,
+): Map<K, V> =
+    get(qualifier, parameters)
+
+/**
+ * Lazy inject Koin Map Multibinding instance from Koin
+ * @param qualifier
+ * @param mode - LazyThreadSafetyMode
+ * @param parameters
+ */
+inline fun <reified K, reified V> KoinComponent.injectMapMultibinding(
+    qualifier: Qualifier = mapMultibindingQualifier<K, V>(),
+    mode: LazyThreadSafetyMode = KoinPlatformTools.defaultLazyMode(),
+    noinline parameters: ParametersDefinition? = null,
+): Lazy<Map<K, V>> =
+    lazy(mode) { get<Map<K, V>>(qualifier, parameters) }
+
+/**
+ * Get Koin Set Multibinding instance from Koin
+ * @param qualifier
+ * @param parameters
+ */
+inline fun <reified E> KoinComponent.getSetMultibinding(
+    qualifier: Qualifier = setMultibindingQualifier<E>(),
+    noinline parameters: ParametersDefinition? = null,
+): Set<E> =
+    get(qualifier, parameters)
+
+/**
+ * Lazy inject Koin Set Multibinding instance from Koin
+ * @param qualifier
+ * @param mode - LazyThreadSafetyMode
+ * @param parameters
+ */
+inline fun <reified E> KoinComponent.injectSetMultibinding(
+    qualifier: Qualifier = setMultibindingQualifier<E>(),
+    mode: LazyThreadSafetyMode = KoinPlatformTools.defaultLazyMode(),
+    noinline parameters: ParametersDefinition? = null,
+): Lazy<Set<E>> =
+    lazy(mode) { get<Set<E>>(qualifier, parameters) }

--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/instance/OrderedInstanceFactory.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/instance/OrderedInstanceFactory.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017-Present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.koin.core.instance
+
+import org.koin.core.scope.Scope
+
+/**
+ * Instance holder with order
+ * Keep the order of instance definitions across modules
+ * @author luozejiaqun
+ */
+internal data class OrderedInstanceFactory<T>(
+    private val instanceFactory: InstanceFactory<T>,
+    private val order: Int,
+    private val ascending: Boolean,
+) : InstanceFactory<T>(instanceFactory.beanDefinition), Comparable<OrderedInstanceFactory<*>> {
+
+    override fun isCreated(context: ResolutionContext?): Boolean =
+        instanceFactory.isCreated(context)
+
+    override fun drop(scope: Scope?) {
+        instanceFactory.drop(scope)
+    }
+
+    override fun dropAll() {
+        instanceFactory.dropAll()
+    }
+
+    override fun create(context: ResolutionContext): T =
+        instanceFactory.create(context)
+
+    override fun get(context: ResolutionContext): T =
+        instanceFactory.get(context)
+
+    override fun compareTo(other: OrderedInstanceFactory<*>): Int {
+        require(ascending == other.ascending) {
+            "OrderedInstanceFactory can only be compared in same ascending order."
+        }
+        return if (ascending) {
+            order.compareTo(other.order)
+        } else {
+            other.order.compareTo(order)
+        }
+    }
+}
+
+internal fun InstanceFactory<*>.keepDefinitionOrderAcrossModules(ascending: Boolean) =
+    OrderedInstanceFactory(this, 0, ascending)

--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/module/Module.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/module/Module.kt
@@ -131,7 +131,12 @@ class Module(
         single<Map<K, V>>(qualifier) { parametersHolder ->
             MapMultibinding(isCreatedAtStart, this, qualifier, V::class, parametersHolder)
         }
-        return MapMultibindingElementDefinition<K, V>(qualifier, V::class, this, null).apply {
+        return MapMultibindingElementDefinition<K, V>(
+            multibindingQualifier = qualifier,
+            elementClass = V::class,
+            declareModule = this,
+            scopeQualifier = rootScopeQualifier,
+        ).apply {
             elementDefinition(this)
         }
     }
@@ -151,7 +156,12 @@ class Module(
         single<Set<E>>(qualifier) { parametersHolder ->
             SetMultibinding<E>(isCreatedAtStart, this, qualifier, E::class, parametersHolder)
         }
-        return SetMultibindingElementDefinition<E>(qualifier, E::class, this, null).apply {
+        return SetMultibindingElementDefinition<E>(
+            multibindingQualifier = qualifier,
+            elementClass = E::class,
+            declareModule = this,
+            scopeQualifier = rootScopeQualifier,
+        ).apply {
             elementDefinition(this)
         }
     }

--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/module/Module.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/module/Module.kt
@@ -116,6 +116,69 @@ class Module(
         return KoinDefinition(this, factory)
     }
 
+    /**
+     * Declare a Single Map<K, V> and inject an element to it with a given key
+     * @param key can't be null
+     * @param definition - the element definition function
+     */
+    inline fun <reified K : Any, reified V> intoMap(
+        key: K,
+        qualifier: Qualifier = mapMultibindingQualifier<K, V>(),
+        noinline definition: Definition<V>,
+    ): KoinDefinition<Map<K, V>> {
+        single(multibindingValueQualifier(qualifier, key), definition = definition)
+        single(multibindingIterateKeyQualifier(qualifier, key)) {
+            MultibindingIterateKey(key, multibindingValueQualifier(qualifier, key))
+        }
+        return declareMapMultibinding(qualifier)
+    }
+
+    /**
+     * Declare a Single Map<K, V> definition, the key type [K] can't be null
+     * @param qualifier can't be null
+     * @param createdAtStart
+     */
+    inline fun <reified K : Any, reified V> declareMapMultibinding(
+        qualifier: Qualifier = mapMultibindingQualifier<K, V>(),
+        createdAtStart: Boolean = false,
+    ): KoinDefinition<Map<K, V>> {
+        val isCreatedAtStart = createdAtStart || this._createdAtStart
+        return single<Map<K, V>>(qualifier) { parametersHolder ->
+            MapMultibinding(isCreatedAtStart, this, qualifier, V::class, parametersHolder)
+        }
+    }
+
+    /**
+     * Declare a Single Set<E> and inject an element to it
+     * @param definition - the element definition function
+     */
+    inline fun <reified E> intoSet(
+        qualifier: Qualifier = setMultibindingQualifier<E>(),
+        noinline definition: Definition<E>,
+    ): KoinDefinition<Set<E>> {
+        val key = SetMultibinding.getDistinctKey()
+        single(multibindingValueQualifier(qualifier, key), definition = definition)
+        single(multibindingIterateKeyQualifier(qualifier, key)) {
+            MultibindingIterateKey(key, multibindingValueQualifier(qualifier, key))
+        }
+        return declareSetMultibinding(qualifier)
+    }
+
+    /**
+     * Declare a Single Set<E> definition
+     * @param qualifier can't be null
+     * @param createdAtStart
+     */
+    inline fun <reified E> declareSetMultibinding(
+        qualifier: Qualifier = setMultibindingQualifier<E>(),
+        createdAtStart: Boolean = false,
+    ): KoinDefinition<Set<E>> {
+        val isCreatedAtStart = createdAtStart || this._createdAtStart
+        return single(qualifier) { parametersHolder ->
+            SetMultibinding(isCreatedAtStart, this, qualifier, E::class, parametersHolder)
+        }
+    }
+
     @KoinInternalApi
     fun indexPrimaryType(instanceFactory: InstanceFactory<*>) {
         val def = instanceFactory.beanDefinition

--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/module/Module.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/module/Module.kt
@@ -129,10 +129,18 @@ class Module(
     ): MapMultibindingElementDefinition<K, V> {
         val isCreatedAtStart = createdAtStart || this._createdAtStart
         single<Map<K, V>>(qualifier) { parametersHolder ->
-            MapMultibinding(isCreatedAtStart, this, qualifier, V::class, parametersHolder)
+            MapMultibinding(
+                createdAtStart = isCreatedAtStart,
+                scope = this,
+                qualifier = qualifier,
+                keyClass = K::class,
+                valueClass = V::class,
+                parametersHolder = parametersHolder,
+            )
         }
         return MapMultibindingElementDefinition<K, V>(
             multibindingQualifier = qualifier,
+            keyClass = K::class,
             elementClass = V::class,
             declareModule = this,
             scopeQualifier = rootScopeQualifier,

--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/module/Module.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/module/Module.kt
@@ -117,65 +117,42 @@ class Module(
     }
 
     /**
-     * Declare a Single Map<K, V> and inject an element to it with a given key
-     * @param key can't be null
-     * @param definition - the element definition function
-     */
-    inline fun <reified K : Any, reified V> intoMap(
-        key: K,
-        qualifier: Qualifier = mapMultibindingQualifier<K, V>(),
-        noinline definition: Definition<V>,
-    ): KoinDefinition<Map<K, V>> {
-        single(multibindingValueQualifier(qualifier, key), definition = definition)
-        single(multibindingIterateKeyQualifier(qualifier, key)) {
-            MultibindingIterateKey(key, multibindingValueQualifier(qualifier, key))
-        }
-        return declareMapMultibinding(qualifier)
-    }
-
-    /**
      * Declare a Single Map<K, V> definition, the key type [K] can't be null
      * @param qualifier can't be null
      * @param createdAtStart
+     * @param elementDefinition - call `intoMap` to inject elements
      */
-    inline fun <reified K : Any, reified V> declareMapMultibinding(
+    inline fun <reified K : Any, reified V : Any> declareMapMultibinding(
         qualifier: Qualifier = mapMultibindingQualifier<K, V>(),
         createdAtStart: Boolean = false,
-    ): KoinDefinition<Map<K, V>> {
+        elementDefinition: MapMultibindingElementDefinition<K, V>.() -> Unit = {},
+    ): MapMultibindingElementDefinition<K, V> {
         val isCreatedAtStart = createdAtStart || this._createdAtStart
-        return single<Map<K, V>>(qualifier) { parametersHolder ->
+        single<Map<K, V>>(qualifier) { parametersHolder ->
             MapMultibinding(isCreatedAtStart, this, qualifier, V::class, parametersHolder)
         }
-    }
-
-    /**
-     * Declare a Single Set<E> and inject an element to it
-     * @param definition - the element definition function
-     */
-    inline fun <reified E> intoSet(
-        qualifier: Qualifier = setMultibindingQualifier<E>(),
-        noinline definition: Definition<E>,
-    ): KoinDefinition<Set<E>> {
-        val key = SetMultibinding.getDistinctKey()
-        single(multibindingValueQualifier(qualifier, key), definition = definition)
-        single(multibindingIterateKeyQualifier(qualifier, key)) {
-            MultibindingIterateKey(key, multibindingValueQualifier(qualifier, key))
+        return MapMultibindingElementDefinition<K, V>(qualifier, V::class, this, null).apply {
+            elementDefinition(this)
         }
-        return declareSetMultibinding(qualifier)
     }
 
     /**
      * Declare a Single Set<E> definition
      * @param qualifier can't be null
      * @param createdAtStart
+     * @param elementDefinition - call `intoSet` to inject elements
      */
-    inline fun <reified E> declareSetMultibinding(
+    inline fun <reified E : Any> declareSetMultibinding(
         qualifier: Qualifier = setMultibindingQualifier<E>(),
         createdAtStart: Boolean = false,
-    ): KoinDefinition<Set<E>> {
+        elementDefinition: SetMultibindingElementDefinition<E>.() -> Unit = {},
+    ): SetMultibindingElementDefinition<E> {
         val isCreatedAtStart = createdAtStart || this._createdAtStart
-        return single(qualifier) { parametersHolder ->
-            SetMultibinding(isCreatedAtStart, this, qualifier, E::class, parametersHolder)
+        single<Set<E>>(qualifier) { parametersHolder ->
+            SetMultibinding<E>(isCreatedAtStart, this, qualifier, E::class, parametersHolder)
+        }
+        return SetMultibindingElementDefinition<E>(qualifier, E::class, this, null).apply {
+            elementDefinition(this)
         }
     }
 

--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/module/Multibinding.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/module/Multibinding.kt
@@ -30,6 +30,7 @@ import org.koin.core.parameter.ParametersHolder
 import org.koin.core.parameter.emptyParametersHolder
 import org.koin.core.qualifier.Qualifier
 import org.koin.core.qualifier.StringQualifier
+import org.koin.core.qualifier._q
 import org.koin.core.registry.ScopeRegistry.Companion.rootScopeQualifier
 import org.koin.core.scope.Scope
 import org.koin.ext.getFullName
@@ -41,19 +42,18 @@ import kotlin.reflect.KClass
  * @author - luozejiaqun
  */
 inline fun <reified K, reified V> mapMultibindingQualifier(): Qualifier =
-    StringQualifier("map_multibinding_${K::class.getFullName()}_${V::class.getFullName()}")
+    _q("MapMultibinding<${K::class.getFullName()}, ${V::class.getFullName()}>")
 
 inline fun <reified E> setMultibindingQualifier(): Qualifier =
-    StringQualifier("set_multibinding_${E::class.getFullName()}")
+    _q("SetMultibinding<${E::class.getFullName()}>")
 
 private fun <K> multibindingElementQualifier(multibindingQualifier: Qualifier, key: K): Qualifier =
-    StringQualifier("${multibindingQualifier.value}_of_$key")
+    _q("${multibindingQualifier.value} of $key")
 
 private fun <K> multibindingIterateKeyQualifier(
     multibindingQualifier: Qualifier,
     key: K
-): Qualifier =
-    StringQualifier("${multibindingQualifier.value}_iterate_$key")
+): Qualifier = _q("${multibindingQualifier.value} iterate of $key")
 
 class MapMultibindingKeyTypeException(msg: String) : Exception(msg)
 
@@ -345,7 +345,7 @@ internal class SetMultibinding<E>(
     override fun iterator(): Iterator<E> = elementSet.iterator()
 
     class Key(private val placeholder: Int) {
-        override fun toString(): String = "placeholder_$placeholder"
+        override fun toString(): String = "placeholder$placeholder"
     }
 
     companion object {

--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/module/Multibinding.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/module/Multibinding.kt
@@ -62,6 +62,8 @@ private class MultibindingIterateKey<T>(
     val multibindingQualifier: Qualifier,
 )
 
+private val multibindingKeyCollisionDetectModule = Module()
+
 class MapMultibindingElementDefinition<K : Any, E : Any> @PublishedApi internal constructor(
     private val multibindingQualifier: Qualifier,
     private val elementClass: KClass<E>,
@@ -142,12 +144,12 @@ class MapMultibindingElementDefinition<K : Any, E : Any> @PublishedApi internal 
     private fun indexPrimaryType(instanceFactory: InstanceFactory<*>): InstanceFactory<*>? {
         val def = instanceFactory.beanDefinition
         val mapping = indexKey(def.primaryType, def.qualifier, def.scopeQualifier)
-        return declareModule.mappings[mapping].apply {
+        return multibindingKeyCollisionDetectModule.mappings[mapping].apply {
             declareModule.saveMapping(mapping, instanceFactory)
+            multibindingKeyCollisionDetectModule.saveMapping(mapping, instanceFactory)
         }
     }
 
-    // TODO this only works for the same module, find a way to check across modules.
     private fun checkMultibindingKeyCollision(oldInstanceFactory: InstanceFactory<*>?, newKey: K) {
         if (oldInstanceFactory != null && needToCheckKeyType(newKey)) {
             val oldKey = (oldInstanceFactory.beanDefinition.definition(

--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/module/Multibinding.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/module/Multibinding.kt
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2017-Present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.koin.core.module
+
+import co.touchlab.stately.concurrency.AtomicInt
+import org.koin.core.parameter.ParametersHolder
+import org.koin.core.qualifier.Qualifier
+import org.koin.core.qualifier.StringQualifier
+import org.koin.core.scope.Scope
+import org.koin.ext.getFullName
+import kotlin.reflect.KClass
+
+/**
+ * Multibinding of Map & Set
+ *
+ * @author - luozejiaqun
+ */
+inline fun <reified K, reified V> mapMultibindingQualifier(): Qualifier =
+    StringQualifier("map_multibinding_${K::class.getFullName()}_${V::class.getFullName()}")
+
+inline fun <reified E> setMultibindingQualifier(): Qualifier =
+    StringQualifier("set_multibinding_${E::class.getFullName()}")
+
+@PublishedApi
+internal fun <K> multibindingValueQualifier(multibindingQualifier: Qualifier, key: K): Qualifier =
+    StringQualifier("${multibindingQualifier.value}_of_$key")
+
+@PublishedApi
+internal fun <K> multibindingIterateKeyQualifier(
+    multibindingQualifier: Qualifier,
+    key: K
+): Qualifier =
+    StringQualifier("${multibindingQualifier.value}_iterate_$key")
+
+@PublishedApi
+internal class MultibindingIterateKey<T>(val key: T, val valueQualifier: Qualifier)
+
+@PublishedApi
+internal class MapMultibinding<K : Any, V>(
+    createdAtStart: Boolean,
+    private val scope: Scope,
+    private val qualifier: Qualifier,
+    private val valueClass: KClass<*>,
+    private val parametersHolder: ParametersHolder,
+) : Map<K, V> {
+
+    init {
+        if (createdAtStart) {
+            values
+        }
+    }
+
+    override val keys: Set<K>
+        get() {
+            val multibindingKeys = mutableSetOf<K>()
+            scope.getAll<MultibindingIterateKey<*>>()
+                .mapNotNullTo(multibindingKeys) { multibindingIterateKey ->
+                    if (multibindingIterateKey.valueQualifier.value.startsWith(qualifier.value)) {
+                        multibindingIterateKey.key as? K
+                    } else {
+                        null
+                    }
+                }
+            return multibindingKeys
+        }
+
+    override val size: Int
+        get() = keys.size
+
+    override val values: Collection<V>
+        get() = keys.mapNotNull { get(it) }
+
+    override val entries: Set<Map.Entry<K, V>>
+        get() {
+            val filed = LinkedHashSet<Map.Entry<K, V>>()
+            keys.mapNotNullTo(filed) { Entry(it, get(it) ?: return@mapNotNullTo null) }
+            return filed
+        }
+
+    override fun containsKey(key: K): Boolean =
+        keys.contains(key)
+
+    override fun containsValue(value: V): Boolean =
+        values.contains(value)
+
+    override fun get(key: K): V? {
+        return scope.getOrNull(valueClass, multibindingValueQualifier(qualifier, key)) {
+            parametersHolder
+        }
+    }
+
+    override fun isEmpty(): Boolean = keys.isEmpty()
+
+    private class Entry<K, V>(override val key: K, override val value: V) : Map.Entry<K, V>
+}
+
+@PublishedApi
+internal class SetMultibinding<E>(
+    createdAtStart: Boolean,
+    private val scope: Scope,
+    private val qualifier: Qualifier,
+    private val valueClass: KClass<*>,
+    private val parametersHolder: ParametersHolder,
+) : Set<E> {
+    init {
+        if (createdAtStart) {
+            getAll()
+        }
+    }
+
+    override val size: Int
+        get() = getAllKeys().size
+
+    override fun contains(element: E): Boolean {
+        return getAll().contains(element)
+    }
+
+    override fun containsAll(elements: Collection<E>): Boolean {
+        return getAll().containsAll(elements)
+    }
+
+    override fun isEmpty(): Boolean = size == 0
+
+    override fun iterator(): Iterator<E> {
+        return getAll().iterator()
+    }
+
+    private fun getAllKeys(): Set<Key> {
+        val multibindingKeys = mutableSetOf<Key>()
+        scope.getAll<MultibindingIterateKey<*>>()
+            .mapNotNullTo(multibindingKeys) { multibindingIterateKey ->
+                if (multibindingIterateKey.valueQualifier.value.startsWith(qualifier.value)) {
+                    multibindingIterateKey.key as? Key
+                } else {
+                    null
+                }
+            }
+        return multibindingKeys
+    }
+
+    private fun getAll(): Set<E> {
+        val result = LinkedHashSet<E>()
+        getAllKeys().mapNotNullTo(result) { get(it) ?: return@mapNotNullTo null }
+        return result
+    }
+
+    private fun get(key: Key): E? {
+        return scope.getOrNull(valueClass, multibindingValueQualifier(qualifier, key)) {
+            parametersHolder
+        }
+    }
+
+    class Key(private val placeholder: Int) {
+        override fun toString(): String = "placeholder_$placeholder"
+    }
+
+    companion object {
+        private val accumulatingKey = AtomicInt(0)
+
+        fun getDistinctKey() = Key(accumulatingKey.incrementAndGet())
+    }
+}

--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/module/Multibinding.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/module/Multibinding.kt
@@ -111,6 +111,10 @@ class MapMultibindingElementDefinition<in K : Any, in E : Any> @PublishedApi int
 ) {
     private val isRootScope = scopeQualifier == rootScopeQualifier
 
+    fun intoMap(key: K, element: E) {
+        intoMap(key) { element }
+    }
+
     /**
      * the parameters of [definition] come from MapMultibinding creation
      *
@@ -277,6 +281,10 @@ class SetMultibindingElementDefinition<in E : Any> @PublishedApi internal constr
             declareModule,
             scopeQualifier
         )
+
+    fun intoSet(element: E) {
+        intoSet { element }
+    }
 
     /**
      * the parameters of [definition] come from SetMultibinding creation

--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/scope/Scope.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/scope/Scope.kt
@@ -24,6 +24,8 @@ import org.koin.core.instance.ResolutionContext
 import org.koin.core.logger.Level
 import org.koin.core.logger.Logger
 import org.koin.core.module.KoinDslMarker
+import org.koin.core.module.mapMultibindingQualifier
+import org.koin.core.module.setMultibindingQualifier
 import org.koin.core.parameter.ParametersDefinition
 import org.koin.core.parameter.ParametersHolder
 import org.koin.core.qualifier.Qualifier
@@ -159,6 +161,122 @@ class Scope(
         noinline parameters: ParametersDefinition? = null,
     ): T? {
         return getOrNull(T::class, qualifier, parameters)
+    }
+
+    /**
+     * Lazy inject a Koin Map Multibinding instance
+     * @param qualifier
+     * @param mode - LazyThreadSafetyMode
+     * @param parameters
+     *
+     * @return Lazy instance of type Map<K, V>
+     */
+    inline fun <reified K, reified V> injectMapMultibinding(
+        qualifier: Qualifier = mapMultibindingQualifier<K, V>(),
+        mode: LazyThreadSafetyMode = LazyThreadSafetyMode.SYNCHRONIZED,
+        noinline parameters: ParametersDefinition? = null,
+    ): Lazy<Map<K, V>> =
+        lazy(mode) { get<Map<K, V>>(qualifier, parameters) }
+
+    /**
+     * Lazy inject a Koin Set Multibinding instance
+     * @param qualifier
+     * @param mode - LazyThreadSafetyMode
+     * @param parameters
+     *
+     * @return Lazy instance of type Set<E>
+     */
+    inline fun <reified E> injectSetMultibinding(
+        qualifier: Qualifier = setMultibindingQualifier<E>(),
+        mode: LazyThreadSafetyMode = LazyThreadSafetyMode.SYNCHRONIZED,
+        noinline parameters: ParametersDefinition? = null,
+    ): Lazy<Set<E>> =
+        lazy(mode) { get<Set<E>>(qualifier, parameters) }
+
+    /**
+     * Lazy inject a Koin Map Multibinding instance
+     * @param qualifier
+     * @param mode - LazyThreadSafetyMode
+     * @param parameters
+     *
+     * @return Lazy instance of type Map<K, V> or null
+     */
+    inline fun <reified K, reified V> injectMapMultibindingOrNull(
+        qualifier: Qualifier = mapMultibindingQualifier<K, V>(),
+        mode: LazyThreadSafetyMode = LazyThreadSafetyMode.SYNCHRONIZED,
+        noinline parameters: ParametersDefinition? = null,
+    ): Lazy<Map<K, V>?> =
+        lazy(mode) { getOrNull<Map<K, V>>(qualifier, parameters) }
+
+    /**
+     * Lazy inject a Koin Set Multibinding instance
+     * @param qualifier
+     * @param mode - LazyThreadSafetyMode
+     * @param parameters
+     *
+     * @return Lazy instance of type Set<E> or null
+     */
+    inline fun <reified E> injectSetMultibindingOrNull(
+        qualifier: Qualifier = setMultibindingQualifier<E>(),
+        mode: LazyThreadSafetyMode = LazyThreadSafetyMode.SYNCHRONIZED,
+        noinline parameters: ParametersDefinition? = null,
+    ): Lazy<Set<E>?> =
+        lazy(mode) { getOrNull<Set<E>>(qualifier, parameters) }
+
+    /**
+     * Get a Koin Map Multibinding instance
+     * @param qualifier
+     * @param parameters
+     *
+     * @return instance of type Map<K, V>
+     */
+    inline fun <reified K, reified V> getMapMultibinding(
+        qualifier: Qualifier = mapMultibindingQualifier<K, V>(),
+        noinline parameters: ParametersDefinition? = null,
+    ): Map<K, V> {
+        return get(Map::class, qualifier, parameters)
+    }
+
+    /**
+     * Get a Koin Set Multibinding instance
+     * @param qualifier
+     * @param parameters
+     *
+     * @return instance of type Set<E>
+     */
+    inline fun <reified E> getSetMultibinding(
+        qualifier: Qualifier = setMultibindingQualifier<E>(),
+        noinline parameters: ParametersDefinition? = null,
+    ): Set<E> {
+        return get(Set::class, qualifier, parameters)
+    }
+
+    /**
+     * Get a Koin Map Multibinding instance
+     * @param qualifier
+     * @param parameters
+     *
+     * @return instance of type Map<K, V> or null
+     */
+    inline fun <reified K, reified V> getMapMultibindingOrNull(
+        qualifier: Qualifier = mapMultibindingQualifier<K, V>(),
+        noinline parameters: ParametersDefinition? = null,
+    ): Map<K, V>? {
+        return getOrNull(Map::class, qualifier, parameters)
+    }
+
+    /**
+     * Get a Koin Set Multibinding instance
+     * @param qualifier
+     * @param parameters
+     *
+     * @return instance of type Set<E> or null
+     */
+    inline fun <reified E> getSetMultibindingOrNull(
+        qualifier: Qualifier = setMultibindingQualifier<E>(),
+        noinline parameters: ParametersDefinition? = null,
+    ): Set<E>? {
+        return getOrNull(Set::class, qualifier, parameters)
     }
 
     /**

--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/dsl/ScopeDSL.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/dsl/ScopeDSL.kt
@@ -46,59 +46,36 @@ class ScopeDSL(val scopeQualifier: Qualifier, val module: Module) {
     }
 
     /**
-     * Declare a scoped Map<K, V> and inject an element to it with a given key
-     * @param key can't be null
-     * @param definition - the element definition function
-     */
-    inline fun <reified K : Any, reified V> intoMap(
-        key: K,
-        qualifier: Qualifier = mapMultibindingQualifier<K, V>(),
-        noinline definition: Definition<V>,
-    ): KoinDefinition<Map<K, V>> {
-        scoped(multibindingValueQualifier(qualifier, key), definition)
-        scoped(multibindingIterateKeyQualifier(qualifier, key)) {
-            MultibindingIterateKey(key, multibindingValueQualifier(qualifier, key))
-        }
-        return declareMapMultibinding(qualifier)
-    }
-
-    /**
      * Declare a scoped Map<K, V> definition, the key type [K] can't be null
      * @param qualifier can't be null
+     * @param elementDefinition - call `intoMap` to inject elements
      */
-    inline fun <reified K : Any, reified V> declareMapMultibinding(
+    inline fun <reified K : Any, reified V : Any> declareMapMultibinding(
         qualifier: Qualifier = mapMultibindingQualifier<K, V>(),
-    ): KoinDefinition<Map<K, V>> {
-        return scoped(qualifier) { parametersHolder ->
+        elementDefinition: MapMultibindingElementDefinition<K, V>.() -> Unit = {},
+    ): MapMultibindingElementDefinition<K, V> {
+        scoped<Map<K, V>>(qualifier) { parametersHolder ->
             MapMultibinding(false, this, qualifier, V::class, parametersHolder)
         }
-    }
-
-    /**
-     * Declare a scoped Set<E> and inject an element to it
-     * @param definition - the element definition function
-     */
-    inline fun <reified E> intoSet(
-        qualifier: Qualifier = setMultibindingQualifier<E>(),
-        noinline definition: Definition<E>,
-    ): KoinDefinition<Set<E>> {
-        val key = SetMultibinding.getDistinctKey()
-        scoped(multibindingValueQualifier(qualifier, key), definition = definition)
-        scoped(multibindingIterateKeyQualifier(qualifier, key)) {
-            MultibindingIterateKey(key, multibindingValueQualifier(qualifier, key))
+        return MapMultibindingElementDefinition<K, V>(qualifier, V::class, null, this).apply {
+            elementDefinition(this)
         }
-        return declareSetMultibinding(qualifier)
     }
 
     /**
      * Declare a scoped Set<E> definition
      * @param qualifier can't be null
+     * @param elementDefinition - call `intoSet` to inject elements
      */
-    inline fun <reified E> declareSetMultibinding(
+    inline fun <reified E : Any> declareSetMultibinding(
         qualifier: Qualifier = setMultibindingQualifier<E>(),
-    ): KoinDefinition<Set<E>> {
-        return scoped(qualifier) { parametersHolder ->
-            SetMultibinding(false, this, qualifier, E::class, parametersHolder)
+        elementDefinition: SetMultibindingElementDefinition<E>.() -> Unit = {},
+    ): SetMultibindingElementDefinition<E> {
+        scoped<Set<E>>(qualifier) { parametersHolder ->
+            SetMultibinding<E>(false, this, qualifier, E::class, parametersHolder)
+        }
+        return SetMultibindingElementDefinition<E>(qualifier, E::class, null, this).apply {
+            elementDefinition(this)
         }
     }
 }

--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/dsl/ScopeDSL.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/dsl/ScopeDSL.kt
@@ -55,10 +55,18 @@ class ScopeDSL(val scopeQualifier: Qualifier, val module: Module) {
         elementDefinition: MapMultibindingElementDefinition<K, V>.() -> Unit = {},
     ): MapMultibindingElementDefinition<K, V> {
         scoped<Map<K, V>>(qualifier) { parametersHolder ->
-            MapMultibinding(false, this, qualifier, V::class, parametersHolder)
+            MapMultibinding(
+                createdAtStart = false,
+                scope = this,
+                qualifier = qualifier,
+                keyClass = K::class,
+                valueClass = V::class,
+                parametersHolder = parametersHolder,
+            )
         }
         return MapMultibindingElementDefinition<K, V>(
             multibindingQualifier = qualifier,
+            keyClass = K::class,
             elementClass = V::class,
             declareModule = module,
             scopeQualifier = scopeQualifier,

--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/dsl/ScopeDSL.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/dsl/ScopeDSL.kt
@@ -57,7 +57,12 @@ class ScopeDSL(val scopeQualifier: Qualifier, val module: Module) {
         scoped<Map<K, V>>(qualifier) { parametersHolder ->
             MapMultibinding(false, this, qualifier, V::class, parametersHolder)
         }
-        return MapMultibindingElementDefinition<K, V>(qualifier, V::class, null, this).apply {
+        return MapMultibindingElementDefinition<K, V>(
+            multibindingQualifier = qualifier,
+            elementClass = V::class,
+            declareModule = module,
+            scopeQualifier = scopeQualifier,
+        ).apply {
             elementDefinition(this)
         }
     }
@@ -74,7 +79,12 @@ class ScopeDSL(val scopeQualifier: Qualifier, val module: Module) {
         scoped<Set<E>>(qualifier) { parametersHolder ->
             SetMultibinding<E>(false, this, qualifier, E::class, parametersHolder)
         }
-        return SetMultibindingElementDefinition<E>(qualifier, E::class, null, this).apply {
+        return SetMultibindingElementDefinition<E>(
+            multibindingQualifier = qualifier,
+            elementClass = E::class,
+            declareModule = module,
+            scopeQualifier = scopeQualifier,
+        ).apply {
             elementDefinition(this)
         }
     }

--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/dsl/ScopeDSL.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/dsl/ScopeDSL.kt
@@ -44,4 +44,61 @@ class ScopeDSL(val scopeQualifier: Qualifier, val module: Module) {
     ): KoinDefinition<T> {
         return module.factory(qualifier, definition, scopeQualifier)
     }
+
+    /**
+     * Declare a scoped Map<K, V> and inject an element to it with a given key
+     * @param key can't be null
+     * @param definition - the element definition function
+     */
+    inline fun <reified K : Any, reified V> intoMap(
+        key: K,
+        qualifier: Qualifier = mapMultibindingQualifier<K, V>(),
+        noinline definition: Definition<V>,
+    ): KoinDefinition<Map<K, V>> {
+        scoped(multibindingValueQualifier(qualifier, key), definition)
+        scoped(multibindingIterateKeyQualifier(qualifier, key)) {
+            MultibindingIterateKey(key, multibindingValueQualifier(qualifier, key))
+        }
+        return declareMapMultibinding(qualifier)
+    }
+
+    /**
+     * Declare a scoped Map<K, V> definition, the key type [K] can't be null
+     * @param qualifier can't be null
+     */
+    inline fun <reified K : Any, reified V> declareMapMultibinding(
+        qualifier: Qualifier = mapMultibindingQualifier<K, V>(),
+    ): KoinDefinition<Map<K, V>> {
+        return scoped(qualifier) { parametersHolder ->
+            MapMultibinding(false, this, qualifier, V::class, parametersHolder)
+        }
+    }
+
+    /**
+     * Declare a scoped Set<E> and inject an element to it
+     * @param definition - the element definition function
+     */
+    inline fun <reified E> intoSet(
+        qualifier: Qualifier = setMultibindingQualifier<E>(),
+        noinline definition: Definition<E>,
+    ): KoinDefinition<Set<E>> {
+        val key = SetMultibinding.getDistinctKey()
+        scoped(multibindingValueQualifier(qualifier, key), definition = definition)
+        scoped(multibindingIterateKeyQualifier(qualifier, key)) {
+            MultibindingIterateKey(key, multibindingValueQualifier(qualifier, key))
+        }
+        return declareSetMultibinding(qualifier)
+    }
+
+    /**
+     * Declare a scoped Set<E> definition
+     * @param qualifier can't be null
+     */
+    inline fun <reified E> declareSetMultibinding(
+        qualifier: Qualifier = setMultibindingQualifier<E>(),
+    ): KoinDefinition<Set<E>> {
+        return scoped(qualifier) { parametersHolder ->
+            SetMultibinding(false, this, qualifier, E::class, parametersHolder)
+        }
+    }
 }

--- a/projects/core/koin-core/src/commonTest/kotlin/org/koin/core/MapMultibindingTest.kt
+++ b/projects/core/koin-core/src/commonTest/kotlin/org/koin/core/MapMultibindingTest.kt
@@ -272,7 +272,7 @@ class MapMultibindingTest {
     }
 
     @Test
-    fun `override map multibinding elements with different keys but same toString`() {
+    fun `get exception when overriding map multibinding elements with different keys but same toString`() {
         data class MapKey(
             val name: String,
             val value: Int,
@@ -280,25 +280,25 @@ class MapMultibindingTest {
             override fun toString(): String = name
         }
 
-        val app = koinApplication {
-            modules(
-                module {
-                    declareMapMultibinding<MapKey, Simple.ComponentInterface1> {
-                        intoMap(MapKey(keyOfComponent1, 1)) { component1 }
-                    }
-                },
-            )
-        }
-        val koin = app.koin
-        val rootMap: Map<MapKey, Simple.ComponentInterface1> = koin.getMapMultibinding()
-        assertEquals(1, rootMap.size)
-        assertEquals(component1, rootMap[MapKey(keyOfComponent1, 1)])
-        assertNull(rootMap[MapKey(keyOfComponent1, 2)])
+        // declare in same module
         module {
             declareMapMultibinding<MapKey, Simple.ComponentInterface1> {
                 intoMap(MapKey(keyOfComponent1, 1)) { component1 }
                 assertFailsWith(MapMultibindingKeyTypeException::class) {
                     intoMap(MapKey(keyOfComponent1, 2)) { component1 }
+                }
+            }
+        }
+        // declare in different modules
+        module {
+            declareMapMultibinding<MapKey, Simple.ComponentInterface1> {
+                intoMap(MapKey(keyOfComponent2, 1)) { component1 }
+            }
+        }
+        module {
+            declareMapMultibinding<MapKey, Simple.ComponentInterface1> {
+                assertFailsWith(MapMultibindingKeyTypeException::class) {
+                    intoMap(MapKey(keyOfComponent2, 2)) { component1 }
                 }
             }
         }

--- a/projects/core/koin-core/src/commonTest/kotlin/org/koin/core/MultibindingTest.kt
+++ b/projects/core/koin-core/src/commonTest/kotlin/org/koin/core/MultibindingTest.kt
@@ -1,12 +1,15 @@
 package org.koin.core
 
 import org.koin.Simple
+import org.koin.core.parameter.parametersOf
 import org.koin.core.qualifier.named
 import org.koin.dsl.koinApplication
 import org.koin.dsl.module
+import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class MultibindingTest {
@@ -59,11 +62,9 @@ class MultibindingTest {
         val app = koinApplication {
             modules(
                 module {
-                    intoMap<String, Simple.ComponentInterface1>(keyOfComponent1) {
-                        component1
-                    }
-                    intoMap<String, Simple.ComponentInterface1>(keyOfComponent2) {
-                        component2
+                    declareMapMultibinding<String, Simple.ComponentInterface1> {
+                        intoMap(keyOfComponent1) { component1 }
+                        intoMap(keyOfComponent2) { component2 }
                     }
                 },
             )
@@ -75,10 +76,11 @@ class MultibindingTest {
         assertEquals(map, map2)
 
         assertEquals(2, map.size)
-        assertContains(map, keyOfComponent1)
+        assertContains(map, keyOfComponent2)
         assertContains(map, keyOfComponent2)
         assertEquals(component1, map[keyOfComponent1])
         assertEquals(component2, map[keyOfComponent2])
+        assertNull(map["invalid key"])
     }
 
     @Test
@@ -89,11 +91,9 @@ class MultibindingTest {
             modules(
                 module {
                     scope(scopeKey) {
-                        intoMap<String, Simple.ComponentInterface1>(keyOfComponent1) {
-                            component1
-                        }
-                        intoMap<String, Simple.ComponentInterface1>(keyOfComponent2) {
-                            component2
+                        declareMapMultibinding<String, Simple.ComponentInterface1> {
+                            intoMap(keyOfComponent1) { component1 }
+                            intoMap(keyOfComponent2) { component2 }
                         }
                     }
                 },
@@ -109,6 +109,7 @@ class MultibindingTest {
         assertEquals(2, map.size)
         assertEquals(component1, map[keyOfComponent1])
         assertEquals(component2, map[keyOfComponent2])
+        assertNull(map["invalid key"])
     }
 
     @Test
@@ -122,18 +123,14 @@ class MultibindingTest {
         val app = koinApplication {
             modules(
                 module {
-                    intoMap<String, Simple.ComponentInterface1>("rootComponent1") {
-                        rootComponent1
-                    }
-                    intoMap<String, Simple.ComponentInterface1>("rootComponent2") {
-                        rootComponent2
+                    declareMapMultibinding<String, Simple.ComponentInterface1> {
+                        intoMap("rootComponent1") { rootComponent1 }
+                        intoMap("rootComponent2") { rootComponent2 }
                     }
                     scope(scopeKey) {
-                        intoMap<String, Simple.ComponentInterface1>("scopeComponent1") {
-                            scopeComponent1
-                        }
-                        intoMap<String, Simple.ComponentInterface1>("scopeComponent2") {
-                            scopeComponent2
+                        declareMapMultibinding<String, Simple.ComponentInterface1> {
+                            intoMap("scopeComponent1") { scopeComponent1 }
+                            intoMap("scopeComponent2") { scopeComponent2 }
                         }
                     }
                 },
@@ -153,6 +150,7 @@ class MultibindingTest {
         assertEquals(rootComponent2, scopeMap["rootComponent2"])
         assertEquals(scopeComponent1, scopeMap["scopeComponent1"])
         assertEquals(scopeComponent2, scopeMap["scopeComponent2"])
+        assertNull(scopeMap["invalid key"])
     }
 
     @Test
@@ -199,11 +197,9 @@ class MultibindingTest {
         val app = koinApplication {
             modules(
                 module {
-                    intoSet<Simple.ComponentInterface1> {
-                        component1
-                    }
-                    intoSet<Simple.ComponentInterface1> {
-                        component2
+                    declareSetMultibinding<Simple.ComponentInterface1> {
+                        intoSet { component1 }
+                        intoSet { component2 }
                     }
                 },
             )
@@ -226,11 +222,9 @@ class MultibindingTest {
             modules(
                 module {
                     scope(scopeKey) {
-                        intoSet<Simple.ComponentInterface1> {
-                            component1
-                        }
-                        intoSet<Simple.ComponentInterface1> {
-                            component2
+                        declareSetMultibinding<Simple.ComponentInterface1> {
+                            intoSet { component1 }
+                            intoSet { component2 }
                         }
                     }
                 },
@@ -258,18 +252,14 @@ class MultibindingTest {
         val app = koinApplication {
             modules(
                 module {
-                    intoSet<Simple.ComponentInterface1> {
-                        rootComponent1
-                    }
-                    intoSet<Simple.ComponentInterface1> {
-                        rootComponent2
+                    declareSetMultibinding<Simple.ComponentInterface1> {
+                        intoSet { rootComponent1 }
+                        intoSet { rootComponent2 }
                     }
                     scope(scopeKey) {
-                        intoSet<Simple.ComponentInterface1> {
-                            scopeComponent1
-                        }
-                        intoSet<Simple.ComponentInterface1> {
-                            scopeComponent2
+                        declareSetMultibinding<Simple.ComponentInterface1> {
+                            intoSet { scopeComponent1 }
+                            intoSet { scopeComponent2 }
                         }
                     }
                 },

--- a/projects/core/koin-core/src/commonTest/kotlin/org/koin/core/MultibindingTest.kt
+++ b/projects/core/koin-core/src/commonTest/kotlin/org/koin/core/MultibindingTest.kt
@@ -1,0 +1,289 @@
+package org.koin.core
+
+import org.koin.Simple
+import org.koin.core.qualifier.named
+import org.koin.dsl.koinApplication
+import org.koin.dsl.module
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class MultibindingTest {
+    private val keyOfComponent1 = "component1"
+    private val keyOfComponent2 = "component2"
+    private val component1 = Simple.Component1()
+    private val component2 = Simple.Component2()
+
+    @Test
+    fun `declare map multibinding in root scope`() {
+        val app = koinApplication {
+            modules(
+                module {
+                    declareMapMultibinding<String, Simple.ComponentInterface1>()
+                },
+            )
+        }
+
+        val koin = app.koin
+        val map: Map<String, Simple.ComponentInterface1> = koin.getMapMultibinding()
+        val map2: Map<String, Simple.ComponentInterface1> = koin.getMapMultibinding()
+        assertEquals(map, map2)
+        assertTrue { map.isEmpty() }
+    }
+
+    @Test
+    fun `declare map multibinding in none root scope`() {
+        val scopeId = "myScope"
+        val scopeKey = named("KEY")
+        val app = koinApplication {
+            modules(
+                module {
+                    scope(scopeKey) {
+                        declareMapMultibinding<String, Simple.ComponentInterface1>()
+                    }
+                },
+            )
+        }
+
+        val koin = app.koin
+        val myScope = koin.createScope(scopeId, scopeKey)
+        val map: Map<String, Simple.ComponentInterface1> = myScope.getMapMultibinding()
+        val map2: Map<String, Simple.ComponentInterface1> = myScope.getMapMultibinding()
+        assertEquals(map, map2)
+        assertTrue { map.isEmpty() }
+    }
+
+    @Test
+    fun `inject some elements into map multibinding in root scope`() {
+        val app = koinApplication {
+            modules(
+                module {
+                    intoMap<String, Simple.ComponentInterface1>(keyOfComponent1) {
+                        component1
+                    }
+                    intoMap<String, Simple.ComponentInterface1>(keyOfComponent2) {
+                        component2
+                    }
+                },
+            )
+        }
+
+        val koin = app.koin
+        val map: Map<String, Simple.ComponentInterface1> = koin.getMapMultibinding()
+        val map2: Map<String, Simple.ComponentInterface1> = koin.getMapMultibinding()
+        assertEquals(map, map2)
+
+        assertEquals(2, map.size)
+        assertContains(map, keyOfComponent1)
+        assertContains(map, keyOfComponent2)
+        assertEquals(component1, map[keyOfComponent1])
+        assertEquals(component2, map[keyOfComponent2])
+    }
+
+    @Test
+    fun `inject some elements into map multibinding in none root scope`() {
+        val scopeId = "myScope"
+        val scopeKey = named("KEY")
+        val app = koinApplication {
+            modules(
+                module {
+                    scope(scopeKey) {
+                        intoMap<String, Simple.ComponentInterface1>(keyOfComponent1) {
+                            component1
+                        }
+                        intoMap<String, Simple.ComponentInterface1>(keyOfComponent2) {
+                            component2
+                        }
+                    }
+                },
+            )
+        }
+
+        val koin = app.koin
+        val myScope = koin.createScope(scopeId, scopeKey)
+        val map: Map<String, Simple.ComponentInterface1> = myScope.getMapMultibinding()
+        val map2: Map<String, Simple.ComponentInterface1> = myScope.getMapMultibinding()
+        assertEquals(map, map2)
+
+        assertEquals(2, map.size)
+        assertEquals(component1, map[keyOfComponent1])
+        assertEquals(component2, map[keyOfComponent2])
+    }
+
+    @Test
+    fun `map multibinding contains all elements that define in linked scope`() {
+        val rootComponent1 = Simple.Component1()
+        val rootComponent2 = Simple.Component2()
+        val scopeComponent1 = Simple.Component1()
+        val scopeComponent2 = Simple.Component2()
+        val scopeId = "myScope"
+        val scopeKey = named("KEY")
+        val app = koinApplication {
+            modules(
+                module {
+                    intoMap<String, Simple.ComponentInterface1>("rootComponent1") {
+                        rootComponent1
+                    }
+                    intoMap<String, Simple.ComponentInterface1>("rootComponent2") {
+                        rootComponent2
+                    }
+                    scope(scopeKey) {
+                        intoMap<String, Simple.ComponentInterface1>("scopeComponent1") {
+                            scopeComponent1
+                        }
+                        intoMap<String, Simple.ComponentInterface1>("scopeComponent2") {
+                            scopeComponent2
+                        }
+                    }
+                },
+            )
+        }
+
+        val koin = app.koin
+        val myScope = koin.createScope(scopeId, scopeKey)
+        val rootMap: Map<String, Simple.ComponentInterface1> = koin.getMapMultibinding()
+        val scopeMap: Map<String, Simple.ComponentInterface1> = myScope.getMapMultibinding()
+
+        assertEquals(2, rootMap.size)
+        assertEquals(rootComponent1, scopeMap["rootComponent1"])
+        assertEquals(rootComponent2, scopeMap["rootComponent2"])
+        assertEquals(4, scopeMap.size)
+        assertEquals(rootComponent1, scopeMap["rootComponent1"])
+        assertEquals(rootComponent2, scopeMap["rootComponent2"])
+        assertEquals(scopeComponent1, scopeMap["scopeComponent1"])
+        assertEquals(scopeComponent2, scopeMap["scopeComponent2"])
+    }
+
+    @Test
+    fun `declare set multibinding in root scope`() {
+        val app = koinApplication {
+            modules(
+                module {
+                    declareSetMultibinding<Simple.ComponentInterface1>()
+                },
+            )
+        }
+
+        val koin = app.koin
+        val set: Set<Simple.ComponentInterface1> = koin.getSetMultibinding()
+        val set2: Set<Simple.ComponentInterface1> = koin.getSetMultibinding()
+        assertEquals(set, set2)
+        assertTrue { set.isEmpty() }
+    }
+
+    @Test
+    fun `declare set multibinding in none root scope`() {
+        val scopeId = "myScope"
+        val scopeKey = named("KEY")
+        val app = koinApplication {
+            modules(
+                module {
+                    scope(scopeKey) {
+                        declareSetMultibinding<Simple.ComponentInterface1>()
+                    }
+                },
+            )
+        }
+
+        val koin = app.koin
+        val myScope = koin.createScope(scopeId, scopeKey)
+        val set: Set<Simple.ComponentInterface1> = myScope.getSetMultibinding()
+        val set2: Set<Simple.ComponentInterface1> = myScope.getSetMultibinding()
+        assertEquals(set, set2)
+        assertTrue { set.isEmpty() }
+    }
+
+    @Test
+    fun `inject some elements into set multibinding in root scope`() {
+        val app = koinApplication {
+            modules(
+                module {
+                    intoSet<Simple.ComponentInterface1> {
+                        component1
+                    }
+                    intoSet<Simple.ComponentInterface1> {
+                        component2
+                    }
+                },
+            )
+        }
+
+        val koin = app.koin
+        val set: Set<Simple.ComponentInterface1> = koin.getSetMultibinding()
+        val set2: Set<Simple.ComponentInterface1> = koin.getSetMultibinding()
+        assertEquals(set, set2)
+
+        assertEquals(2, set.size)
+        assertTrue { set.containsAll(listOf(component1, component2)) }
+    }
+
+    @Test
+    fun `inject some elements into set multibinding in none root scope`() {
+        val scopeId = "myScope"
+        val scopeKey = named("KEY")
+        val app = koinApplication {
+            modules(
+                module {
+                    scope(scopeKey) {
+                        intoSet<Simple.ComponentInterface1> {
+                            component1
+                        }
+                        intoSet<Simple.ComponentInterface1> {
+                            component2
+                        }
+                    }
+                },
+            )
+        }
+
+        val koin = app.koin
+        val myScope = koin.createScope(scopeId, scopeKey)
+        val set: Set<Simple.ComponentInterface1> = myScope.getSetMultibinding()
+        val set2: Set<Simple.ComponentInterface1> = myScope.getSetMultibinding()
+        assertEquals(set, set2)
+
+        assertEquals(2, set.size)
+        assertTrue { set.containsAll(listOf(component1, component2)) }
+    }
+
+    @Test
+    fun `set multibinding contains all elements that define in linked scope`() {
+        val rootComponent1 = Simple.Component1()
+        val rootComponent2 = Simple.Component2()
+        val scopeComponent1 = Simple.Component1()
+        val scopeComponent2 = Simple.Component2()
+        val scopeId = "myScope"
+        val scopeKey = named("KEY")
+        val app = koinApplication {
+            modules(
+                module {
+                    intoSet<Simple.ComponentInterface1> {
+                        rootComponent1
+                    }
+                    intoSet<Simple.ComponentInterface1> {
+                        rootComponent2
+                    }
+                    scope(scopeKey) {
+                        intoSet<Simple.ComponentInterface1> {
+                            scopeComponent1
+                        }
+                        intoSet<Simple.ComponentInterface1> {
+                            scopeComponent2
+                        }
+                    }
+                },
+            )
+        }
+
+        val koin = app.koin
+        val myScope = koin.createScope(scopeId, scopeKey)
+        val rootSet: Set<Simple.ComponentInterface1> = koin.getSetMultibinding()
+        val scopeSet: Set<Simple.ComponentInterface1> = myScope.getSetMultibinding()
+
+        assertEquals(2, rootSet.size)
+        assertTrue { rootSet.containsAll(listOf(rootComponent1, rootComponent2)) }
+        assertEquals(4, scopeSet.size)
+        assertTrue { scopeSet.containsAll(listOf(rootComponent1, rootComponent2, scopeComponent1, scopeComponent2)) }
+    }
+}

--- a/projects/core/koin-core/src/commonTest/kotlin/org/koin/core/SetMultibindingTest.kt
+++ b/projects/core/koin-core/src/commonTest/kotlin/org/koin/core/SetMultibindingTest.kt
@@ -1,0 +1,394 @@
+package org.koin.core
+
+import co.touchlab.stately.concurrency.AtomicInt
+import org.koin.Simple
+import org.koin.core.parameter.parametersOf
+import org.koin.core.qualifier._q
+import org.koin.core.qualifier.named
+import org.koin.dsl.koinApplication
+import org.koin.dsl.module
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class SetMultibindingTest {
+    private val component1 = Simple.Component1()
+    private val component2 = Simple.Component2()
+    private val scopeId = "myScope"
+    private val scopeKey = named("KEY")
+
+    @Test
+    fun `declare set multibinding in root scope`() {
+        val app = koinApplication {
+            modules(
+                module {
+                    declareSetMultibinding<Simple.ComponentInterface1>()
+                },
+            )
+        }
+
+        val koin = app.koin
+        val set: Set<Simple.ComponentInterface1> = koin.getSetMultibinding()
+        val set2: Set<Simple.ComponentInterface1> = koin.getSetMultibinding()
+        assertEquals(set, set2)
+        assertTrue { set.isEmpty() }
+    }
+
+    @Test
+    fun `declare set multibinding in none root scope`() {
+        val app = koinApplication {
+            modules(
+                module {
+                    scope(scopeKey) {
+                        declareSetMultibinding<Simple.ComponentInterface1>()
+                    }
+                },
+            )
+        }
+
+        val koin = app.koin
+        val myScope = koin.createScope(scopeId, scopeKey)
+        val set: Set<Simple.ComponentInterface1> = myScope.getSetMultibinding()
+        val set2: Set<Simple.ComponentInterface1> = myScope.getSetMultibinding()
+        assertEquals(set, set2)
+        assertTrue { set.isEmpty() }
+    }
+
+    @Test
+    fun `inject elements into set multibinding in root scope`() {
+        val app = koinApplication {
+            modules(
+                module {
+                    declareSetMultibinding<Simple.ComponentInterface1> {
+                        intoSet { component1 }
+                        intoSet { component2 }
+                    }
+                },
+            )
+        }
+
+        val koin = app.koin
+        val set: Set<Simple.ComponentInterface1> = koin.getSetMultibinding()
+        val set2: Set<Simple.ComponentInterface1> = koin.getSetMultibinding()
+        assertEquals(set, set2)
+
+        assertEquals(2, set.size)
+        assertTrue { set.containsAll(listOf(component1, component2)) }
+    }
+
+    @Test
+    fun `inject elements into set multibinding in none root scope`() {
+        val app = koinApplication {
+            modules(
+                module {
+                    scope(scopeKey) {
+                        declareSetMultibinding<Simple.ComponentInterface1> {
+                            intoSet { component1 }
+                            intoSet { component2 }
+                        }
+                    }
+                },
+            )
+        }
+
+        val koin = app.koin
+        val myScope = koin.createScope(scopeId, scopeKey)
+        val set: Set<Simple.ComponentInterface1> = myScope.getSetMultibinding()
+        val set2: Set<Simple.ComponentInterface1> = myScope.getSetMultibinding()
+        assertEquals(set, set2)
+
+        assertEquals(2, set.size)
+        assertTrue { set.containsAll(listOf(component1, component2)) }
+    }
+
+    @Test
+    fun `set multibinding contains all elements that define in linked scope`() {
+        val rootComponent1 = Simple.Component1()
+        val rootComponent2 = Simple.Component2()
+        val scopeComponent1 = Simple.Component1()
+        val scopeComponent2 = Simple.Component2()
+        val app = koinApplication {
+            modules(
+                module {
+                    declareSetMultibinding<Simple.ComponentInterface1> {
+                        intoSet { rootComponent1 }
+                        intoSet { rootComponent2 }
+                    }
+                    scope(scopeKey) {
+                        declareSetMultibinding<Simple.ComponentInterface1> {
+                            intoSet { scopeComponent1 }
+                            intoSet { scopeComponent2 }
+                        }
+                    }
+                },
+            )
+        }
+
+        val koin = app.koin
+        val myScope = koin.createScope(scopeId, scopeKey)
+        val rootSet: Set<Simple.ComponentInterface1> = koin.getSetMultibinding()
+        val scopeSet: Set<Simple.ComponentInterface1> = myScope.getSetMultibinding()
+
+        assertEquals(2, rootSet.size)
+        assertTrue { rootSet.containsAll(listOf(rootComponent1, rootComponent2)) }
+        assertEquals(4, scopeSet.size)
+        assertTrue {
+            scopeSet.containsAll(
+                listOf(
+                    rootComponent1,
+                    rootComponent2,
+                    scopeComponent1,
+                    scopeComponent2,
+                )
+            )
+        }
+        // in elements definition order
+        assertEquals(
+            listOf(
+                rootComponent1,
+                rootComponent2,
+                scopeComponent1,
+                scopeComponent2,
+            ),
+            scopeSet.toList()
+        )
+    }
+
+    @Test
+    fun `override set multibinding elements`() {
+        data class SetElement(
+            val value: Int = 0
+        ) {
+            var name = ""
+        }
+
+        val app = koinApplication {
+            modules(
+                module {
+                    declareSetMultibinding<SetElement> {
+                        intoSet { SetElement().apply { name = "element1" } }
+                        intoSet { SetElement().apply { name = "element2" } }
+                    }
+                },
+            )
+        }
+
+        val koin = app.koin
+        val rootSet: Set<SetElement> = koin.getSetMultibinding()
+        assertEquals(1, rootSet.size)
+        assertEquals("element2", (rootSet.first() as SetElement).name)
+        koin.loadModules(
+            listOf(
+                module {
+                    declareSetMultibinding<SetElement> {
+                        intoSet { SetElement().apply { name = "element1" } }
+                    }
+                }
+            )
+        )
+        assertEquals(1, rootSet.size)
+        assertEquals("element1", (rootSet.first() as SetElement).name)
+    }
+
+    @Test
+    fun `override set multibinding elements that define in linked scope`() {
+        data class SetElement(
+            val value: Int = 0
+        ) {
+            var name = ""
+        }
+
+        val app = koinApplication {
+            modules(
+                module {
+                    declareSetMultibinding<SetElement> {
+                        intoSet { SetElement().apply { name = "root" } }
+                    }
+                    scope(scopeKey) {
+                        declareSetMultibinding<SetElement> {
+                            intoSet { SetElement().apply { name = "scoped" } }
+                        }
+                    }
+                },
+            )
+        }
+
+        val koin = app.koin
+        val myScope = koin.createScope(scopeId, scopeKey)
+        val rootSet: Set<SetElement> = koin.getSetMultibinding()
+        val scopeSet: Set<SetElement> = myScope.getSetMultibinding()
+        assertEquals(1, rootSet.size)
+        assertEquals(1, scopeSet.size)
+        assertEquals("root", (rootSet.first() as SetElement).name)
+        assertEquals("scoped", (scopeSet.first() as SetElement).name)
+    }
+
+    @Test
+    fun `declare set multibinding elements in separated modules`() {
+        val app = koinApplication {
+            modules(
+                module {
+                    declareSetMultibinding<Simple.ComponentInterface1> {
+                        intoSet { component1 }
+                    }
+                    scope(scopeKey) {
+                        declareSetMultibinding<Simple.ComponentInterface1> {
+                            intoSet { component1 }
+                        }
+                    }
+                },
+                module {
+                    declareSetMultibinding<Simple.ComponentInterface1> {
+                        intoSet { component2 }
+                    }
+                    scope(scopeKey) {
+                        declareSetMultibinding<Simple.ComponentInterface1> {
+                            intoSet { component2 }
+                        }
+                    }
+                },
+            )
+        }
+
+        val koin = app.koin
+        val myScope = koin.createScope(scopeId, scopeKey)
+        val rootSet: Set<Simple.ComponentInterface1> = koin.getSetMultibinding()
+        val scopeSet: Set<Simple.ComponentInterface1> = myScope.getSetMultibinding()
+
+        for (set in listOf(rootSet, scopeSet)) {
+            assertEquals(2, set.size)
+            assertTrue { set.containsAll(listOf(component1, component2)) }
+        }
+    }
+
+    @Test
+    fun `declare set multibinding elements through different MultibindingElementDefinitions`() {
+        val app = koinApplication {
+            modules(
+                module {
+                    declareSetMultibinding<Simple.ComponentInterface1> {
+                        intoSet { component1 }
+                    }
+                    declareSetMultibinding<Simple.ComponentInterface1> {
+                        intoSet { component2 }
+                    }
+                    scope(scopeKey) {
+                        declareSetMultibinding<Simple.ComponentInterface1> {
+                            intoSet { component1 }
+                        }
+                        declareSetMultibinding<Simple.ComponentInterface1> {
+                            intoSet { component2 }
+                        }
+                    }
+                },
+            )
+        }
+
+        val koin = app.koin
+        val myScope = koin.createScope(scopeId, scopeKey)
+        val rootSet: Set<Simple.ComponentInterface1> = koin.getSetMultibinding()
+        val scopeSet: Set<Simple.ComponentInterface1> = myScope.getSetMultibinding()
+
+        for (set in listOf(rootSet, scopeSet)) {
+            assertEquals(2, set.size)
+            assertTrue { set.containsAll(listOf(component1, component2)) }
+        }
+    }
+
+    @Test
+    fun `declare set multibinding elements by MultibindingElementDefinition reference`() {
+        val app = koinApplication {
+            modules(
+                module {
+                    val setElementDefinition =
+                        declareSetMultibinding<Simple.ComponentInterface1>()
+                    setElementDefinition.intoSet { component1 }
+                    setElementDefinition.intoSet { component2 }
+                    scope(scopeKey) {
+                        val setElementDefinition =
+                            declareSetMultibinding<Simple.ComponentInterface1>()
+                        setElementDefinition.intoSet { component1 }
+                        setElementDefinition.intoSet { component2 }
+                    }
+                },
+            )
+        }
+
+        val koin = app.koin
+        val myScope = koin.createScope(scopeId, scopeKey)
+        val rootSet: Set<Simple.ComponentInterface1> = koin.getSetMultibinding()
+        val scopeSet: Set<Simple.ComponentInterface1> = myScope.getSetMultibinding()
+
+        for (set in listOf(rootSet, scopeSet)) {
+            assertEquals(2, set.size)
+            assertTrue { set.containsAll(listOf(component1, component2)) }
+        }
+    }
+
+    @Test
+    fun `declare multibinding with specific qualifier`() {
+        val app = koinApplication {
+            modules(
+                module {
+                    declareSetMultibinding<Simple.ComponentInterface1>(_q("set1")) {
+                        intoSet { component1 }
+                        intoSet { component2 }
+                    }
+                    declareSetMultibinding<Simple.ComponentInterface1>(_q("set2")) {
+                        intoSet { component1 }
+                        intoSet { component2 }
+                    }
+                },
+            )
+        }
+
+        val koin = app.koin
+        val myScope = koin.createScope(scopeId, scopeKey)
+        val rootSet: Set<Simple.ComponentInterface1> =
+            koin.getSetMultibinding(_q("set1"))
+        val scopeSet: Set<Simple.ComponentInterface1> =
+            myScope.getSetMultibinding(_q("set2"))
+
+        for (set in listOf(rootSet, scopeSet)) {
+            assertEquals(2, set.size)
+            assertTrue { set.containsAll(listOf(component1, component2)) }
+        }
+    }
+
+    @Test
+    fun `create set multibinding at start`() {
+        val accumulator = AtomicInt(0)
+        val app = koinApplication {
+            modules(
+                module {
+                    declareSetMultibinding<Int>(createdAtStart = true) {
+                        intoSet { accumulator.incrementAndGet() }
+                        intoSet { accumulator.incrementAndGet() }
+                    }
+                },
+            )
+        }
+
+        app.koin.getSetMultibinding<Int>()
+        assertEquals(2, accumulator.get())
+    }
+
+    @Test
+    fun `create set multibinding elements using parameters`() {
+        val app = koinApplication {
+            modules(
+                module {
+                    declareSetMultibinding<String> {
+                        intoSet { it.get<String>() + "1" }
+                        intoSet { it.get<String>() + "2" }
+                    }
+                },
+            )
+        }
+
+        assertTrue {
+            app.koin.getSetMultibinding<String> { parametersOf("set") }
+                .containsAll(listOf("set1", "set2"))
+        }
+    }
+}


### PR DESCRIPTION
Implement map & set multibinding just like dagger2.
Here is some implementation details:

Every MapMultibinding & SetMultibinding will involve 3 definitions:

1. the multibinding itself whose qualifier is mapMultibindingQualifier or setMultibindingQualifier
2. the element in multibinding whose qualifier is multibindingElementQualifier (use mapMultibindingQualifier/setMultibindingQualifier as prefix)
3. the MultibindingIterateKey which used to retrieve all elements, the key's qualifier is multibindingIterateKeyQualifier (also use mapMultibindingQualifier/setMultibindingQualifier as prefix)

When getting specific element from map multibinding, the map multibinding will try to retrieve the element through multibindingValueQualifier;
When getting all elements from map or set multibinding, the multibinding will first try to get all MultibindingIterateKeys and filter them based on multibindingQualifier, and then retrieve each element through multibindingElementQualifier.

The known problems:

1. the multibinding qualifier can't be null, since it's qualifier will be used as prefix of element & iterate key
2. the map multibinding doesn't support null as a key or value
3. ~~the elements order of multibiding is different with the order of element definitions~~ Now, both set & map multibinding elements are iterated in the order they are defined.

And just like dagger2, multibinding is inherited (because MultibindingIterateKey can be retrieved from getAll), current scope's multibinding can get all elements that define in linked scope.

Here are some use cases:

```kotlin
module {
    intoMap<String, Simple.ComponentInterface1>("keyOfComponent1") {
        Simple.Component1()
    }
    intoMap<String, Simple.ComponentInterface1>("keyOfComponent2") {
        Simple.Component2()
    }

    intoSet<Simple.ComponentInterface1> {
        Simple.Component1()
    }
    intoSet<Simple.ComponentInterface1> {
        Simple.Component2()
    }
}

val map: Map<String, Simple.ComponentInterface1> = koin.getMapMultibinding()
val set: Set<Simple.ComponentInterface1> = koin.getSetMultibinding()
```

issue #772 