### PR TITLE
Add RequestScope UUID to avoid collision over local hashcode

### DIFF
--- a/examples/hello-ktor/src/main/kotlin/org/koin/sample/Application.kt
+++ b/examples/hello-ktor/src/main/kotlin/org/koin/sample/Application.kt
@@ -21,7 +21,7 @@ fun main(args: Array<String>) {
 fun Application.mainModule() {
     install(CallLogging)
     install(Koin) {
-        slf4jLogger(Level.INFO)
+        printLogger(Level.DEBUG)
         modules(appModule)
     }
 

--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/component/KoinScopeComponent.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/component/KoinScopeComponent.kt
@@ -17,6 +17,7 @@ package org.koin.core.component
 
 import org.koin.core.qualifier.TypeQualifier
 import org.koin.core.scope.Scope
+import org.koin.core.scope.ScopeID
 import org.koin.ext.getFullName
 
 /**
@@ -33,6 +34,10 @@ interface KoinScopeComponent : KoinComponent {
 
 fun <T : Any> T.getScopeId() = this::class.getFullName() + "@" + this.hashCode()
 fun <T : Any> T.getScopeName() = TypeQualifier(this::class)
+
+fun <T : KoinScopeComponent> T.createScope(scopeId : ScopeID, source: Any? = null): Scope {
+    return getKoin().createScope(scopeId, getScopeName(), source)
+}
 
 fun <T : KoinScopeComponent> T.createScope(source: Any? = null): Scope {
     return getKoin().createScope(getScopeId(), getScopeName(), source)

--- a/projects/ktor/koin-ktor/src/main/kotlin/org/koin/ktor/plugin/RequestScope.kt
+++ b/projects/ktor/koin-ktor/src/main/kotlin/org/koin/ktor/plugin/RequestScope.kt
@@ -18,6 +18,8 @@ package org.koin.ktor.plugin
 import org.koin.core.Koin
 import org.koin.core.component.KoinScopeComponent
 import org.koin.core.component.createScope
+import org.koin.mp.KoinPlatformTools
+import org.koin.mp.generateId
 
 /**
  * Request Scope Holder
@@ -25,6 +27,7 @@ import org.koin.core.component.createScope
  * @author Arnaud Giuliani
  */
 class RequestScope(private val _koin: Koin) : KoinScopeComponent {
+    private val scopeId = "request_"+KoinPlatformTools.generateId()
     override fun getKoin(): Koin = _koin
-    override val scope = createScope()
+    override val scope = createScope(scopeId = scopeId)
 }


### PR DESCRIPTION
Add RequestScope UUID to avoid collision over local hashcode
Fix #1902 