### PR TITLE
[core] Ensure onClose callbacks are invoked in reversed initialization order

### DIFF
--- a/projects/core/koin-core/src/commonTest/kotlin/org/koin/dsl/CloseDefinitionTest.kt
+++ b/projects/core/koin-core/src/commonTest/kotlin/org/koin/dsl/CloseDefinitionTest.kt
@@ -1,8 +1,12 @@
 package org.koin.dsl
 
 import org.koin.Simple
+import org.koin.core.annotation.KoinInternalApi
 import org.koin.core.logger.Level
+import org.koin.core.qualifier.named
 import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 class CloseDefinitionTest {
@@ -49,5 +53,187 @@ class CloseDefinitionTest {
         koin.loadModules(listOf(module))
         koin.unloadModules(listOf(module))
         assertTrue(!closed)
+    }
+
+    @OptIn(KoinInternalApi::class)
+    @Test
+    fun test_onClose_order() {
+        val closeLog = mutableListOf<String>()
+
+        val module = module {
+            single { Simple.ComponentC(get()) } onClose {
+                if (it != null) {
+                    closeLog += "c"
+                }
+            }
+            single { Simple.ComponentA() } onClose {
+                if (it != null) {
+                    closeLog += "a"
+                }
+            }
+            single { Simple.ComponentB(get()) } onClose {
+                if (it != null) {
+                    closeLog += "b"
+                }
+            }
+        }
+
+        val koin = koinApplication {
+            printLogger(Level.DEBUG)
+            modules(
+                module,
+            )
+        }.koin
+
+        assertNotNull(koin.getOrNull<Simple.ComponentC>())
+        assertEquals(
+            expected = emptyList(), 
+            actual = closeLog,
+        )
+
+        // check instances sorting meets instantiation order
+        assertEquals(
+            expected = listOf(Simple.ComponentA::class, Simple.ComponentB::class, Simple.ComponentC::class),
+            actual = koin.instanceRegistry.instances.values.sorted().map { it.beanDefinition.primaryType },
+        )
+
+        koin.close()
+        assertEquals(
+            expected = listOf("c", "b", "a"), 
+            actual = closeLog,
+        )
+    }
+
+    @Test
+    fun test_onClose_order_unload() {
+        val closeLog = mutableListOf<String>()
+
+        val moduleFirst = module {
+            single { Simple.MySingle(42) } onClose {
+                if (it != null) {
+                    closeLog += "single"
+                }
+            }
+        }
+
+        val moduleSecond = module {
+            single { Simple.ComponentC(get()) } onClose {
+                if (it != null) {
+                    closeLog += "c"
+                }
+            }
+            single { Simple.ComponentA() } onClose {
+                if (it != null) {
+                    closeLog += "a"
+                }
+            }
+            single { Simple.ComponentB(get()) } onClose {
+                if (it != null) {
+                    closeLog += "b"
+                }
+            }
+        }
+
+        val koin = koinApplication {
+            printLogger(Level.DEBUG)
+            modules(
+                moduleFirst,
+                moduleSecond,
+            )
+        }.koin
+
+        assertNotNull(koin.getOrNull<Simple.MySingle>())
+        assertNotNull(koin.getOrNull<Simple.ComponentC>())
+        assertEquals(emptyList(), closeLog)
+
+        koin.unloadModules(listOf(moduleSecond))
+        assertEquals(
+            expected = listOf("c", "b", "a"), 
+            actual = closeLog,
+        )
+
+        koin.loadModules(listOf(moduleSecond))
+        assertNotNull(koin.getOrNull<Simple.ComponentC>())
+
+        koin.unloadModules(listOf(moduleSecond))
+        assertEquals(
+            expected = listOf("c", "b", "a", "c", "b", "a"),
+            actual = closeLog,
+        )
+
+        koin.close()
+        assertEquals(
+            expected = listOf("c", "b", "a", "c", "b", "a", "single"),
+            actual = closeLog,
+        )
+    }
+
+
+    @Test
+    fun test_onClose_order_scoped() {
+        val closeLog = mutableListOf<String>()
+
+        val scopeId = "_test_scope_id_"
+        val scopeKey = named("_test_scope_")
+
+        val module = module {
+            scope(scopeKey) {
+                scoped { Simple.ComponentC(get()) } onClose {
+                    if (it != null) {
+                        closeLog += "c"
+                    }
+                }
+                scoped { Simple.ComponentA() } onClose {
+                    if (it != null) {
+                        closeLog += "a"
+                    }
+                }
+                scoped { Simple.ComponentB(get()) } onClose {
+                    if (it != null) {
+                        closeLog += "b"
+                    }
+                }
+            }
+        }
+
+        val koin = koinApplication {
+            printLogger(Level.DEBUG)
+            modules(
+                module,
+            )
+        }.koin
+
+        assertEquals(
+            expected = emptyList(),
+            actual = closeLog,
+        )
+
+        koin.createScope(scopeId, scopeKey)
+        assertEquals(
+            expected = emptyList(),
+            actual = closeLog,
+        )
+
+        koin.getScope(scopeId).let {
+            assertNotNull(it.getOrNull<Simple.ComponentC>())
+            it.close()
+        }
+        assertEquals(
+            expected = listOf("c", "b", "a"),
+            actual = closeLog,
+        )
+
+        koin.createScope(scopeId, scopeKey)
+        assertNotNull(koin.getScope(scopeId).getOrNull<Simple.ComponentC>())
+        assertEquals(
+            expected = listOf("c", "b", "a"),
+            actual = closeLog,
+        )
+
+        koin.close()
+        assertEquals(
+            expected = listOf("c", "b", "a", "c", "b", "a"),
+            actual = closeLog,
+        )
     }
 }


### PR DESCRIPTION
Fixes #1510

`onClose` callback can be used to release allocated resources
like DB connections. Discussion #1507

Some beans can depend on each other.

An example: classic Web application consists of `Controller`, `Service`, `Database`.

In this case, instantiation order is:
  1. `Database`
  2. `Service` - implements business logic, requires `Database`
  3. `Controller` - REST controller, requires `Service`

On application graceful shutdown, `onClose` invocation order must be reversed:
  1. `Controller` - created last, destroyed first
  2. `Service` - destroyed after `Controller` to avoid use-after-close
  3. `Database` - destroyed after `Service` to avoid use-after-close

This commit delivers implementation of `onClose` calls ordering.

When instance factory creates its first instance, it means that all dependencies are also created. So it's enough to sort factories by 'first instance creation,' and then reverse the sequence when invoking `onClose`.

Implementation:
- global 'instance creation order' atomic counter is created
- each instance factory has 'instance creation order' position
- when factory creates its first instance
  - 'instance creation order' counter is incremented
  - the counter's value is saved into 'instance creation order' position of the factory
- factories can be sorted by 'instance creation order' position, this can be used to order `onClose` calls