### PR TITLE
fix(SLF4JLogger): add missing mapping for WARNING level

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Here are the current available Koin project versions:
 - Koin [![Maven Central](https://img.shields.io/maven-central/v/io.insert-koin/koin-core)](https://mvnrepository.com/artifact/io.insert-koin/koin-bom)
 - Koin for Compose [![Maven Central](https://img.shields.io/maven-central/v/io.insert-koin/koin-compose)](https://mvnrepository.com/artifact/io.insert-koin/koin-compose)
 - Koin Annotations [![Maven Central](https://img.shields.io/maven-central/v/io.insert-koin/koin-annotations)](https://mvnrepository.com/artifact/io.insert-koin/koin-bom)
-- Koin ![](https://img.shields.io/badge/3.5.x-LTS-blue) - Professional [Long Term Support](https://support.insert-koin.io) for Enterprises by Kotzilla
+- Koin ![](https://img.shields.io/badge/3.5.x-LTS-blue) - Official [Long Term Support](https://support.insert-koin.io) for Enterprises by Kotzilla
 
 
 

--- a/projects/ktor/koin-logger-slf4j/src/main/kotlin/org/koin/logger/SLF4JLogger.kt
+++ b/projects/ktor/koin-logger-slf4j/src/main/kotlin/org/koin/logger/SLF4JLogger.kt
@@ -35,6 +35,7 @@ class SLF4JLogger(level: Level = Level.INFO) : Logger(level) {
             Level.DEBUG -> logger.debug(msg)
             Level.INFO -> logger.info(msg)
             Level.ERROR -> logger.error(msg)
+            Level.WARNING -> logger.warn(msg)
             else -> logger.error(msg)
         }
     }


### PR DESCRIPTION
Atm some messages that supposed to be warnings (like definition overrides) are logged with `ERROR` level due to the missing mapping. This change addresses that.