### PR TITLE
Update context-isolation.md

### DIFF
--- a/docs/reference/koin-core/context-isolation.md
+++ b/docs/reference/koin-core/context-isolation.md
@@ -40,7 +40,7 @@ object MyIsolatedKoinContext {
 Let's use `MyIsolatedKoinContext` to define our `IsolatedKoinComponent` class, a KoinComponent that will use our isolated context:
 
 ```kotlin
-abstract class IsolatedKoinComponent : KoinComponent {
+internal interface IsolatedKoinComponent : KoinComponent {
 
     // Override default Koin instance
     override fun getKoin(): Koin = MyIsolatedKoinContext.koin
@@ -50,7 +50,7 @@ abstract class IsolatedKoinComponent : KoinComponent {
 Everything is ready, just use `IsolatedKoinComponent` to retrieve instances from isolated context:
 
 ```kotlin
-class MyKoinComponent : IsolatedKoinComponent(){
+class MyKoinComponent : IsolatedKoinComponent{
     // inject & get will target MyKoinContext
 }
 ```

--- a/docs/reference/koin-core/context-isolation.md
+++ b/docs/reference/koin-core/context-isolation.md
@@ -28,7 +28,7 @@ The `MyIsolatedKoinContext` class is holding our Koin instance here:
 // Get a Context for your Koin instance
 object MyIsolatedKoinContext {
 
-    val koinApp = koinApplication {
+    private val koinApp = koinApplication {
         // declare used modules
         modules(coffeeAppModule)
     }
@@ -50,7 +50,7 @@ internal interface IsolatedKoinComponent : KoinComponent {
 Everything is ready, just use `IsolatedKoinComponent` to retrieve instances from isolated context:
 
 ```kotlin
-class MyKoinComponent : IsolatedKoinComponent{
+class MyKoinComponent : IsolatedKoinComponent {
     // inject & get will target MyKoinContext
 }
 ```


### PR DESCRIPTION
Just a better way avoiding abstraction so if your main Class that start the SDK needs the component you can use it along side with other Interface/ existing Abstraction.