### PR TITLE
Ktor requestscope function dsl

### DIFF
--- a/docs/reference/koin-ktor/ktor.md
+++ b/docs/reference/koin-ktor/ktor.md
@@ -37,12 +37,12 @@ fun Application.main() {
 }
 ```
 
-### Resolve from Ktor Request Scope (since 3.5.0)
+### Resolve from Ktor Request Scope (since 4.1.0)
 
-You can declare components to live within Ktor request scope timeline. For this, you just need to declare your component inside a `scope<ScopeRequest>` section. Given a `ScopeComponent` class to instantiate on RequestScope, let's declare it:
+You can declare components to live within Ktor request scope timeline. For this, you just need to declare your component inside a `requestScope` section. Given a `ScopeComponent` class to instantiate on ktor web request scope, let's declare it:
 
 ```kotlin
-scope<RequestScope>{
+requestScope {
     scopedOf(::ScopeComponent)
 }
 ```

--- a/examples/hello-ktor/src/main/kotlin/org/koin/sample/KoinAppModule.kt
+++ b/examples/hello-ktor/src/main/kotlin/org/koin/sample/KoinAppModule.kt
@@ -1,11 +1,16 @@
 package org.koin.sample
 
+import org.koin.core.module.KoinDslMarker
+import org.koin.core.module.Module
 import org.koin.core.module.dsl.bind
 import org.koin.core.module.dsl.createdAtStart
 import org.koin.core.module.dsl.scopedOf
 import org.koin.core.module.dsl.singleOf
+import org.koin.core.qualifier.TypeQualifier
+import org.koin.dsl.ScopeDSL
 import org.koin.dsl.module
 import org.koin.ktor.plugin.RequestScope
+import org.koin.module.requestScope
 
 val appModule = module {
     singleOf(::HelloServiceImpl){
@@ -14,7 +19,7 @@ val appModule = module {
     }
     singleOf(::HelloRepository)
 
-    scope<RequestScope>{
+    requestScope {
         scopedOf(::ScopeComponent)
     }
 }

--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/module/Module.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/module/Module.kt
@@ -54,8 +54,9 @@ class Module(
         get() = mappings.isNotEmpty()
 
 
-    @PublishedApi
-    internal val scopes = LinkedHashSet<Qualifier>()
+    @KoinInternalApi
+    // used by Ktor ext
+    val scopes = LinkedHashSet<Qualifier>()
 
     @KoinInternalApi
     val includedModules = mutableListOf<Module>()

--- a/projects/ktor/koin-ktor/src/main/kotlin/org/koin/module/ModuleExt.kt
+++ b/projects/ktor/koin-ktor/src/main/kotlin/org/koin/module/ModuleExt.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.koin.module
+
+import org.koin.core.annotation.KoinInternalApi
+import org.koin.core.module.KoinDslMarker
+import org.koin.core.module.Module
+import org.koin.core.qualifier.TypeQualifier
+import org.koin.dsl.ScopeDSL
+import org.koin.ktor.plugin.RequestScope
+
+/**
+ * Declare a scope<RequestScope> section, to define definitions in Request scope
+ *
+ * @author Arnaud Giuliani
+ */
+@OptIn(KoinInternalApi::class)
+@KoinDslMarker
+inline fun Module.requestScope(scopeSet: ScopeDSL.() -> Unit) {
+    val qualifier = TypeQualifier(RequestScope::class)
+    ScopeDSL(qualifier, this).apply(scopeSet)
+    scopes.add(qualifier)
+}

--- a/projects/ktor/koin-ktor3/src/main/kotlin/org/koin/module/ModuleExt.kt
+++ b/projects/ktor/koin-ktor3/src/main/kotlin/org/koin/module/ModuleExt.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.koin.module
+
+import org.koin.core.annotation.KoinInternalApi
+import org.koin.core.module.KoinDslMarker
+import org.koin.core.module.Module
+import org.koin.core.qualifier.TypeQualifier
+import org.koin.dsl.ScopeDSL
+import org.koin.ktor.plugin.RequestScope
+
+/**
+ * Declare a scope<RequestScope> section, to define definitions in Request scope
+ *
+ * @author Arnaud Giuliani
+ */
+@OptIn(KoinInternalApi::class)
+@KoinDslMarker
+inline fun Module.requestScope(scopeSet: ScopeDSL.() -> Unit) {
+    val qualifier = TypeQualifier(RequestScope::class)
+    ScopeDSL(qualifier, this).apply(scopeSet)
+    scopes.add(qualifier)
+}


### PR DESCRIPTION
Add `requestScope` function to help declare definitions in web request timelife scope.

instead of using:
```kotlin
scope<RequestScope> {
        scopedOf(::ScopeComponent)
    }
```

it can be replaced:
```kotlin
requestScope {
        scopedOf(::ScopeComponent)
    }
```