### PR TITLE
Scope declared instance

### DIFF
--- a/examples/androidx-samples/build.gradle
+++ b/examples/androidx-samples/build.gradle
@@ -68,7 +68,7 @@ dependencies {
     implementation "io.insert-koin:koin-core-coroutines"
     implementation "io.insert-koin:koin-androidx-workmanager"
     implementation "io.insert-koin:koin-androidx-navigation"
-    implementation "io.insert-koin:koin-androidx-startup"
+//    implementation "io.insert-koin:koin-androidx-startup"
     testImplementation "io.insert-koin:koin-test-junit4"
     testImplementation "io.insert-koin:koin-android-test"
 }

--- a/examples/androidx-samples/src/main/java/org/koin/sample/sandbox/MainApplication.kt
+++ b/examples/androidx-samples/src/main/java/org/koin/sample/sandbox/MainApplication.kt
@@ -61,8 +61,8 @@ class MainApplication : Application() {
             androidFileProperties()
             fragmentFactory()
             workManagerFactory()
-            lazyModules(allModules, dispatcher = IO)
-//            modules(allModules)
+//            lazyModules(allModules, dispatcher = IO)
+            modules(allModules)
         }
 
         //TODO Load/Unload Koin modules scenario cases

--- a/examples/androidx-samples/src/main/java/org/koin/sample/sandbox/MainApplication.kt
+++ b/examples/androidx-samples/src/main/java/org/koin/sample/sandbox/MainApplication.kt
@@ -1,51 +1,74 @@
 package org.koin.sample.sandbox
 
 import android.app.Application
+import android.os.StrictMode
 import androidx.work.WorkManager
 import androidx.work.await
+import kotlinx.coroutines.Dispatchers.IO
 import kotlinx.coroutines.runBlocking
 import org.koin.android.ext.koin.androidContext
 import org.koin.android.ext.koin.androidFileProperties
 import org.koin.android.ext.koin.androidLogger
 import org.koin.androidx.fragment.koin.fragmentFactory
 import org.koin.androidx.workmanager.koin.workManagerFactory
-import org.koin.androix.startup.KoinStartup
+import org.koin.core.context.GlobalContext.startKoin
+import org.koin.core.lazyModules
 import org.koin.core.logger.Level
-import org.koin.dsl.KoinAppDeclaration
+import org.koin.core.waitAllStartJobs
+import org.koin.mp.KoinPlatform
 import org.koin.sample.sandbox.di.allModules
 
 
+class MainApplication : Application() {
 
-class MainApplication : Application(), KoinStartup {
-
-    override fun onKoinStartup() : KoinAppDeclaration = {
-        androidLogger(Level.DEBUG)
-        androidContext(this@MainApplication)
-        androidFileProperties()
-        fragmentFactory()
-        workManagerFactory()
-        modules(allModules)
-    }
+//    override fun onKoinStartup() : KoinAppDeclaration = {
+//        androidLogger(Level.DEBUG)
+//        androidContext(this@MainApplication)
+//        androidFileProperties()
+//        fragmentFactory()
+//        workManagerFactory()
+//        modules(allModules)
+//    }
 
     companion object {
         var startTime: Long = 0
     }
 
     override fun onCreate() {
+        StrictMode.setThreadPolicy(
+            StrictMode.ThreadPolicy.Builder()
+                .detectDiskReads()
+                .detectDiskWrites()
+                .detectAll() // or .detectAll() for all detectable problems
+                .penaltyLog()
+                .build()
+        )
+        StrictMode.setVmPolicy(
+            StrictMode.VmPolicy.Builder()
+                .detectLeakedSqlLiteObjects()
+                .detectLeakedClosableObjects()
+                .penaltyLog()
+                .penaltyDeath()
+                .build()
+        )
         super.onCreate()
+
         startTime = System.currentTimeMillis()
-//        startKoin {
-//            androidLogger(Level.DEBUG)
-//            androidContext(this@MainApplication)
-//            androidFileProperties()
-//            fragmentFactory()
-//            workManagerFactory()
-//
+
+        startKoin {
+            androidLogger(Level.DEBUG)
+            androidContext(this@MainApplication)
+            androidFileProperties()
+            fragmentFactory()
+            workManagerFactory()
+            lazyModules(allModules, dispatcher = IO)
 //            modules(allModules)
-//        }
+        }
 
         //TODO Load/Unload Koin modules scenario cases
         cancelPendingWorkManager(this)
+
+        KoinPlatform.getKoin().waitAllStartJobs()
     }
 }
 
@@ -58,6 +81,6 @@ private fun cancelPendingWorkManager(mainApplication: MainApplication) {
         WorkManager.getInstance(mainApplication)
                 .cancelAllWork()
                 .result
-                .await()
+                .get()
     }
 }

--- a/examples/androidx-samples/src/main/java/org/koin/sample/sandbox/di/AppModule.kt
+++ b/examples/androidx-samples/src/main/java/org/koin/sample/sandbox/di/AppModule.kt
@@ -33,7 +33,7 @@ import org.koin.sample.sandbox.scope.ScopedFragment
 import org.koin.sample.sandbox.workmanager.SimpleWorker
 import org.koin.sample.sandbox.workmanager.SimpleWorkerService
 
-val appModule = lazyModule {
+val appModule = module {
 
     singleOf(::SimpleServiceImpl) { bind<SimpleService>() }
     singleOf(::DumbServiceImpl) {
@@ -43,7 +43,7 @@ val appModule = lazyModule {
     factory { RandomId() }
 }
 
-val mvpModule = lazyModule {
+val mvpModule = module {
     //factory { (id: String) -> FactoryPresenter(id, get()) }
     factoryOf(::FactoryPresenter)
 
@@ -53,7 +53,7 @@ val mvpModule = lazyModule {
     }
 }
 
-val mvvmModule = lazyModule {
+val mvvmModule = module {
 
     viewModelOf(::SimpleViewModel)// { (id: String) -> SimpleViewModel(id, get()) }
     viewModelOf(::SimpleViewModel) { named("vm1") } //{ (id: String) -> SimpleViewModel(id, get()) }
@@ -93,7 +93,7 @@ val mvvmModule = lazyModule {
     }
 }
 
-val scopeModule = lazyModule {
+val scopeModule = module {
     scope(named(SCOPE_ID)) {
         scopedOf(::Session) {
             named(SCOPE_SESSION)
@@ -106,7 +106,7 @@ val scopeModule = lazyModule {
     }
 }
 
-val scopeModuleActivityA = lazyModule {
+val scopeModuleActivityA = module {
     scope<ScopedActivityA> {
         fragmentOf(::ScopedFragment)
         scopedOf(::Session)
@@ -117,19 +117,19 @@ val scopeModuleActivityA = lazyModule {
     }
 }
 
-val workerServiceModule = lazyModule {
+val workerServiceModule = module {
     singleOf(::SimpleWorkerService)
 }
 
-val workerScopedModule = lazyModule {
+val workerScopedModule = module {
     workerOf(::SimpleWorker)// { SimpleWorker(get(), androidContext(), it.get()) }
 }
 
-val navModule = lazyModule {
+val navModule = module {
     viewModelOf(::NavViewModel)
     viewModelOf(::NavViewModel2)
 }
 
-val allModules = lazyModule {
+val allModules = module {
     includes(appModule, mvpModule, mvvmModule , scopeModule , workerServiceModule , workerScopedModule , navModule , scopeModuleActivityA)
 }

--- a/examples/androidx-samples/src/main/java/org/koin/sample/sandbox/di/AppModule.kt
+++ b/examples/androidx-samples/src/main/java/org/koin/sample/sandbox/di/AppModule.kt
@@ -33,7 +33,7 @@ import org.koin.sample.sandbox.scope.ScopedFragment
 import org.koin.sample.sandbox.workmanager.SimpleWorker
 import org.koin.sample.sandbox.workmanager.SimpleWorkerService
 
-val appModule = module {
+val appModule = lazyModule {
 
     singleOf(::SimpleServiceImpl) { bind<SimpleService>() }
     singleOf(::DumbServiceImpl) {
@@ -43,7 +43,7 @@ val appModule = module {
     factory { RandomId() }
 }
 
-val mvpModule = module {
+val mvpModule = lazyModule {
     //factory { (id: String) -> FactoryPresenter(id, get()) }
     factoryOf(::FactoryPresenter)
 
@@ -53,7 +53,7 @@ val mvpModule = module {
     }
 }
 
-val mvvmModule = module {
+val mvvmModule = lazyModule {
 
     viewModelOf(::SimpleViewModel)// { (id: String) -> SimpleViewModel(id, get()) }
     viewModelOf(::SimpleViewModel) { named("vm1") } //{ (id: String) -> SimpleViewModel(id, get()) }
@@ -93,7 +93,7 @@ val mvvmModule = module {
     }
 }
 
-val scopeModule = module {
+val scopeModule = lazyModule {
     scope(named(SCOPE_ID)) {
         scopedOf(::Session) {
             named(SCOPE_SESSION)
@@ -106,7 +106,7 @@ val scopeModule = module {
     }
 }
 
-val scopeModuleActivityA = module {
+val scopeModuleActivityA = lazyModule {
     scope<ScopedActivityA> {
         fragmentOf(::ScopedFragment)
         scopedOf(::Session)
@@ -117,19 +117,19 @@ val scopeModuleActivityA = module {
     }
 }
 
-val workerServiceModule = module {
+val workerServiceModule = lazyModule {
     singleOf(::SimpleWorkerService)
 }
 
-val workerScopedModule = module {
+val workerScopedModule = lazyModule {
     workerOf(::SimpleWorker)// { SimpleWorker(get(), androidContext(), it.get()) }
 }
 
-val navModule = module {
+val navModule = lazyModule {
     viewModelOf(::NavViewModel)
     viewModelOf(::NavViewModel2)
 }
 
-val allModules = module {
+val allModules = lazyModule {
     includes(appModule, mvpModule, mvvmModule , scopeModule , workerServiceModule , workerScopedModule , navModule , scopeModuleActivityA)
 }

--- a/examples/androidx-samples/src/main/java/org/koin/sample/sandbox/workmanager/WorkManagerActivity.kt
+++ b/examples/androidx-samples/src/main/java/org/koin/sample/sandbox/workmanager/WorkManagerActivity.kt
@@ -89,7 +89,7 @@ class WorkManagerActivity : AppCompatActivity() {
         WorkManager.getInstance(this@WorkManagerActivity)
             .cancelAllWork()
             .result
-            .await()
+            .get()
 
         enqueueWork<SimpleWorker>(createData(42))
         enqueueWork<SimpleWorker>(createData(43))

--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/definition/BeanDefinition.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/definition/BeanDefinition.kt
@@ -128,3 +128,19 @@ inline fun <reified T> _createDefinition(
         secondaryTypes = secondaryTypes,
     )
 }
+
+inline fun <reified T> _createDeclaredDefinition(
+    kind: Kind = Kind.Singleton,
+    qualifier: Qualifier? = null,
+    secondaryTypes: List<KClass<*>> = emptyList(),
+    scopeQualifier: Qualifier,
+): BeanDefinition<T> {
+    return BeanDefinition(
+        scopeQualifier,
+        T::class,
+        qualifier,
+        { error("declared instance error ") },
+        kind,
+        secondaryTypes = secondaryTypes,
+    )
+}

--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/instance/DeclaredScopedInstance.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/instance/DeclaredScopedInstance.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017-Present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.koin.core.instance
+
+import org.koin.core.definition.BeanDefinition
+import org.koin.core.scope.Scope
+import org.koin.core.scope.ScopeID
+
+/**
+ * Declared Instance in scope - Value holder to get back the value for the given scope Id
+ * to avoid ScopedInstanceFactory where we need the bean definition to return a definition
+ *
+ * @author Arnaud Giuliani
+ */
+class DeclaredScopedInstance<T>(beanDefinition: BeanDefinition<T>, val scopeID : ScopeID) :
+    InstanceFactory<T>(beanDefinition) {
+
+    private var value : T? = null
+
+    fun setValue(v : T){
+        value = v
+    }
+
+    override fun get(context: ResolutionContext): T {
+        return value ?: error("Scoped instance not found for ${context.scope.id} in $beanDefinition")
+    }
+
+    override fun isCreated(context: ResolutionContext?): Boolean = value != null
+
+    override fun drop(scope: Scope?) {
+        value = null
+    }
+
+    override fun dropAll() {
+        value = null
+    }
+}

--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/scope/Scope.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/scope/Scope.kt
@@ -379,8 +379,10 @@ class Scope(
 
     /**
      * Declare a component definition from the given instance
-     * This result of declaring a scoped/single definition of type T, returning the given instance
+     * This result of declaring a scoped definition of type T, returning the given instance
      * (single definition of the current scope is root)
+     * 
+     * The instance will be drop at scope.close()
      *
      * @param instance The instance you're declaring.
      * @param qualifier Qualifier for this declaration
@@ -393,7 +395,7 @@ class Scope(
         secondaryTypes: List<KClass<*>> = emptyList(),
         allowOverride: Boolean = true,
     ) = KoinPlatformTools.synchronized(this) {
-        _koin.instanceRegistry.declareScopedInstance(
+        _koin.instanceRegistry.scopeDeclaredInstance(
             instance,
             qualifier,
             secondaryTypes,

--- a/projects/core/koin-core/src/commonTest/kotlin/org/koin/core/ScopeAPITest.kt
+++ b/projects/core/koin-core/src/commonTest/kotlin/org/koin/core/ScopeAPITest.kt
@@ -1,8 +1,13 @@
 package org.koin.core
 
 import org.koin.Simple
+import org.koin.Simple.ComponentA
+import org.koin.core.component.KoinScopeComponent
+import org.koin.core.component.createScope
 import org.koin.core.error.NoScopeDefFoundException
 import org.koin.core.error.ScopeAlreadyCreatedException
+import org.koin.core.logger.Level
+import org.koin.core.module.dsl.scopedOf
 import org.koin.core.qualifier.named
 import org.koin.core.scope.Scope
 import org.koin.core.scope.ScopeCallback
@@ -120,5 +125,29 @@ class ScopeAPITest {
         })
         scope1.close()
         assertTrue(closed)
+    }
+
+    class MyScopeComponent(private val _koin: Koin) : KoinScopeComponent {
+        override fun getKoin(): Koin = _koin
+        override val scope: Scope = createScope()
+    }
+
+    @Test
+    fun scope_clean_test() {
+        val koin = koinApplication {
+            printLogger(Level.DEBUG)
+        }.koin
+
+        val scopeComponent = MyScopeComponent(koin)
+        val scope = scopeComponent.scope
+        scope.declare("hello")
+
+        assertEquals("hello", scope.get<String>())
+        scope.close()
+
+        val scopeComponent2 = MyScopeComponent(koin)
+        val scope2 = scopeComponent2.scope
+
+        assertNull(scope2.getOrNull<String>())
     }
 }


### PR DESCRIPTION
Replace usage of ScopedInstance holder to limit usage of declared instance to current scope, and avoid any reuse.