### PR TITLE
KoinApplication Multiplatform Config - Logger + Androic context automatic injection

### DIFF
--- a/examples/gradle/versions.gradle
+++ b/examples/gradle/versions.gradle
@@ -2,7 +2,7 @@ ext {
     // Kotlin
     kotlin_version = '2.0.21'
     // Koin Versions
-    koin_version = '4.1.0-Beta2'
+    koin_version = '4.1.0-Beta3'
     koin_android_version = koin_version
     koin_compose_version = koin_version
 

--- a/projects/compose/koin-compose/api/android/koin-compose.api
+++ b/projects/compose/koin-compose/api/android/koin-compose.api
@@ -1,0 +1,65 @@
+public final class org/koin/compose/KoinApplicationKt {
+	public static final fun KoinApplication (Lkotlin/jvm/functions/Function1;Lorg/koin/core/logger/Level;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
+	public static final fun KoinContext (Lorg/koin/core/Koin;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
+	public static final fun KoinIsolatedContext (Lorg/koin/core/KoinApplication;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;I)V
+	public static final fun currentKoinScope (Landroidx/compose/runtime/Composer;I)Lorg/koin/core/scope/Scope;
+	public static final fun getKoin (Landroidx/compose/runtime/Composer;I)Lorg/koin/core/Koin;
+	public static final fun getLocalKoinApplication ()Landroidx/compose/runtime/ProvidableCompositionLocal;
+	public static final fun getLocalKoinScope ()Landroidx/compose/runtime/ProvidableCompositionLocal;
+}
+
+public final class org/koin/compose/application/CompositionKoinApplicationLoader : androidx/compose/runtime/RememberObserver {
+	public static final field $stable I
+	public fun <init> (Lorg/koin/core/KoinApplication;)V
+	public final fun getKoin ()Lorg/koin/core/Koin;
+	public final fun getKoinApplication ()Lorg/koin/core/KoinApplication;
+	public fun onAbandoned ()V
+	public fun onForgotten ()V
+	public fun onRemembered ()V
+	public final fun setKoin (Lorg/koin/core/Koin;)V
+}
+
+public final class org/koin/compose/application/RememberKoinApplicationKt {
+	public static final fun rememberKoinApplication (Lorg/koin/core/KoinApplication;Landroidx/compose/runtime/Composer;I)Lorg/koin/core/Koin;
+}
+
+public final class org/koin/compose/error/UnknownKoinContext : java/lang/Exception {
+	public static final field $stable I
+	public fun <init> ()V
+}
+
+public final class org/koin/compose/module/CompositionKoinModuleLoader : androidx/compose/runtime/RememberObserver {
+	public static final field $stable I
+	public fun <init> (Ljava/util/List;Lorg/koin/core/Koin;ZZ)V
+	public final fun getKoin ()Lorg/koin/core/Koin;
+	public final fun getModules ()Ljava/util/List;
+	public final fun getUnloadOnAbandoned ()Z
+	public final fun getUnloadOnForgotten ()Z
+	public fun onAbandoned ()V
+	public fun onForgotten ()V
+	public fun onRemembered ()V
+}
+
+public final class org/koin/compose/module/RememberModulesKt {
+	public static final fun rememberKoinModules (Ljava/lang/Boolean;Ljava/lang/Boolean;ZLkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;II)V
+}
+
+public final class org/koin/compose/scope/CompositionKoinScopeLoader : androidx/compose/runtime/RememberObserver {
+	public static final field $stable I
+	public fun <init> (Lorg/koin/core/scope/Scope;)V
+	public final fun getScope ()Lorg/koin/core/scope/Scope;
+	public fun onAbandoned ()V
+	public fun onForgotten ()V
+	public fun onRemembered ()V
+}
+
+public final class org/koin/compose/scope/KoinScopeKt {
+	public static final fun KoinScope (Ljava/lang/String;Lorg/koin/core/qualifier/Qualifier;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;I)V
+	public static final fun KoinScope (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;I)V
+	public static final fun OnKoinScope (Lorg/koin/core/scope/Scope;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;I)V
+}
+
+public final class org/koin/compose/scope/RememberScopesKt {
+	public static final fun rememberKoinScope (Lorg/koin/core/scope/Scope;Landroidx/compose/runtime/Composer;I)Lorg/koin/core/scope/Scope;
+}
+

--- a/projects/compose/koin-compose/api/jvm/koin-compose.api
+++ b/projects/compose/koin-compose/api/jvm/koin-compose.api
@@ -1,0 +1,65 @@
+public final class org/koin/compose/KoinApplicationKt {
+	public static final fun KoinApplication (Lkotlin/jvm/functions/Function1;Lorg/koin/core/logger/Level;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
+	public static final fun KoinContext (Lorg/koin/core/Koin;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
+	public static final fun KoinIsolatedContext (Lorg/koin/core/KoinApplication;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;I)V
+	public static final fun currentKoinScope (Landroidx/compose/runtime/Composer;I)Lorg/koin/core/scope/Scope;
+	public static final fun getKoin (Landroidx/compose/runtime/Composer;I)Lorg/koin/core/Koin;
+	public static final fun getLocalKoinApplication ()Landroidx/compose/runtime/ProvidableCompositionLocal;
+	public static final fun getLocalKoinScope ()Landroidx/compose/runtime/ProvidableCompositionLocal;
+}
+
+public final class org/koin/compose/application/CompositionKoinApplicationLoader : androidx/compose/runtime/RememberObserver {
+	public static final field $stable I
+	public fun <init> (Lorg/koin/core/KoinApplication;)V
+	public final fun getKoin ()Lorg/koin/core/Koin;
+	public final fun getKoinApplication ()Lorg/koin/core/KoinApplication;
+	public fun onAbandoned ()V
+	public fun onForgotten ()V
+	public fun onRemembered ()V
+	public final fun setKoin (Lorg/koin/core/Koin;)V
+}
+
+public final class org/koin/compose/application/RememberKoinApplicationKt {
+	public static final fun rememberKoinApplication (Lorg/koin/core/KoinApplication;Landroidx/compose/runtime/Composer;I)Lorg/koin/core/Koin;
+}
+
+public final class org/koin/compose/error/UnknownKoinContext : java/lang/Exception {
+	public static final field $stable I
+	public fun <init> ()V
+}
+
+public final class org/koin/compose/module/CompositionKoinModuleLoader : androidx/compose/runtime/RememberObserver {
+	public static final field $stable I
+	public fun <init> (Ljava/util/List;Lorg/koin/core/Koin;ZZ)V
+	public final fun getKoin ()Lorg/koin/core/Koin;
+	public final fun getModules ()Ljava/util/List;
+	public final fun getUnloadOnAbandoned ()Z
+	public final fun getUnloadOnForgotten ()Z
+	public fun onAbandoned ()V
+	public fun onForgotten ()V
+	public fun onRemembered ()V
+}
+
+public final class org/koin/compose/module/RememberModulesKt {
+	public static final fun rememberKoinModules (Ljava/lang/Boolean;Ljava/lang/Boolean;ZLkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;II)V
+}
+
+public final class org/koin/compose/scope/CompositionKoinScopeLoader : androidx/compose/runtime/RememberObserver {
+	public static final field $stable I
+	public fun <init> (Lorg/koin/core/scope/Scope;)V
+	public final fun getScope ()Lorg/koin/core/scope/Scope;
+	public fun onAbandoned ()V
+	public fun onForgotten ()V
+	public fun onRemembered ()V
+}
+
+public final class org/koin/compose/scope/KoinScopeKt {
+	public static final fun KoinScope (Ljava/lang/String;Lorg/koin/core/qualifier/Qualifier;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;I)V
+	public static final fun KoinScope (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;I)V
+	public static final fun OnKoinScope (Lorg/koin/core/scope/Scope;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;I)V
+}
+
+public final class org/koin/compose/scope/RememberScopesKt {
+	public static final fun rememberKoinScope (Lorg/koin/core/scope/Scope;Landroidx/compose/runtime/Composer;I)Lorg/koin/core/scope/Scope;
+}
+

--- a/projects/compose/koin-compose/build.gradle.kts
+++ b/projects/compose/koin-compose/build.gradle.kts
@@ -1,7 +1,11 @@
+import org.gradle.kotlin.dsl.android
+import org.gradle.kotlin.dsl.api
+import org.gradle.kotlin.dsl.jvm
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
+    alias(libs.plugins.androidLibrary)
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.jetbrainsCompose)
     alias(libs.plugins.compose.compiler)
@@ -12,8 +16,9 @@ version = koinVersion
 
 kotlin {
     jvmToolchain(1_8)
-    jvm {
-        withJava()
+    jvm()
+    android {
+        publishLibraryVariants("release")
     }
 
     js(IR) {
@@ -38,6 +43,36 @@ kotlin {
             api(project(":core:koin-core"))
             api(libs.jb.composeRuntime)
         }
+        androidMain.dependencies {
+            api(project(":android:koin-android"))
+            api(libs.androidx.composeRuntime)
+            api(libs.androidx.composeFoundation)
+        }
+        nativeMain.dependencies {
+        }
+        wasmJsMain.dependencies {
+        }
+        jsMain.dependencies {
+        }
+    }
+}
+
+val androidCompileSDK : String by project
+val androidMinSDK : String by project
+
+android {
+    namespace = "org.koin.compose"
+    compileSdk = androidCompileSDK.toInt()
+    defaultConfig {
+        minSdk = androidMinSDK.toInt()
+    }
+    buildFeatures {
+        buildConfig = false
+        compose = true
+    }
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
     }
 }
 

--- a/projects/compose/koin-compose/build.gradle.kts
+++ b/projects/compose/koin-compose/build.gradle.kts
@@ -17,7 +17,7 @@ version = koinVersion
 kotlin {
     jvmToolchain(1_8)
     jvm()
-    android {
+    androidTarget {
         publishLibraryVariants("release")
     }
 

--- a/projects/compose/koin-compose/src/androidMain/kotlin/org/koin/compose/KoinApplication.android.kt
+++ b/projects/compose/koin-compose/src/androidMain/kotlin/org/koin/compose/KoinApplication.android.kt
@@ -1,0 +1,21 @@
+package org.koin.compose
+
+import androidx.compose.runtime.Composable
+import org.koin.core.KoinApplication
+import org.koin.dsl.KoinConfiguration
+import androidx.compose.ui.platform.LocalContext
+import org.koin.android.ext.koin.androidContext
+import org.koin.android.ext.koin.androidLogger
+import org.koin.core.logger.Level
+import org.koin.dsl.koinConfiguration
+import org.koin.dsl.includes
+
+@Composable
+internal actual fun composeConfiguration(loggerLevel : Level,config : KoinApplication.() -> Unit) : KoinConfiguration {
+    val current = LocalContext.current
+    return koinConfiguration {
+        androidContext(current)
+        androidLogger(loggerLevel)
+        includes(config)
+    }
+}

--- a/projects/compose/koin-compose/src/commonMain/kotlin/org/koin/compose/application/CompositionKoinApplicationLoader.kt
+++ b/projects/compose/koin-compose/src/commonMain/kotlin/org/koin/compose/application/CompositionKoinApplicationLoader.kt
@@ -33,8 +33,12 @@ class CompositionKoinApplicationLoader(
 
     private fun start() {
         if (KoinPlatform.getKoinOrNull() == null){
-            koin = startKoin(koinApplication).koin
-            koin!!.logger.debug("$this -> started Koin Application $koinApplication")
+            try {
+                koin = startKoin(koinApplication).koin
+                koin!!.logger.debug("$this -> started Koin Application $koinApplication")
+            } catch (e: Exception) {
+                error("Can't start Koin from Compose context - $e")
+            }
         }
     }
 

--- a/projects/compose/koin-compose/src/jsMain/kotlin/org/koin/compose/KoinApplication.js.kt
+++ b/projects/compose/koin-compose/src/jsMain/kotlin/org/koin/compose/KoinApplication.js.kt
@@ -1,0 +1,16 @@
+package org.koin.compose
+
+import androidx.compose.runtime.Composable
+import org.koin.core.KoinApplication
+import org.koin.dsl.KoinConfiguration
+import org.koin.core.logger.Level
+import org.koin.dsl.koinConfiguration
+import org.koin.dsl.includes
+
+@Composable
+internal actual fun composeConfiguration(loggerLevel : Level,config : KoinApplication.() -> Unit) : KoinConfiguration {
+    return koinConfiguration {
+        printLogger(loggerLevel)
+        includes(config)
+    }
+}

--- a/projects/compose/koin-compose/src/jvmMain/kotlin/org/koin/compose/KoinApplication.jvm.kt
+++ b/projects/compose/koin-compose/src/jvmMain/kotlin/org/koin/compose/KoinApplication.jvm.kt
@@ -1,0 +1,16 @@
+package org.koin.compose
+
+import androidx.compose.runtime.Composable
+import org.koin.core.KoinApplication
+import org.koin.dsl.KoinConfiguration
+import org.koin.core.logger.Level
+import org.koin.dsl.koinConfiguration
+import org.koin.dsl.includes
+
+@Composable
+internal actual fun composeConfiguration(loggerLevel : Level,config : KoinApplication.() -> Unit) : KoinConfiguration {
+    return koinConfiguration {
+        printLogger(loggerLevel)
+        includes(config)
+    }
+}

--- a/projects/compose/koin-compose/src/nativeMain/kotlin/org/koin/compose/KoinApplication.native.kt
+++ b/projects/compose/koin-compose/src/nativeMain/kotlin/org/koin/compose/KoinApplication.native.kt
@@ -1,0 +1,16 @@
+package org.koin.compose
+
+import androidx.compose.runtime.Composable
+import org.koin.core.KoinApplication
+import org.koin.dsl.KoinConfiguration
+import org.koin.core.logger.Level
+import org.koin.dsl.koinConfiguration
+import org.koin.dsl.includes
+
+@Composable
+internal actual fun composeConfiguration(loggerLevel : Level,config : KoinApplication.() -> Unit) : KoinConfiguration {
+    return koinConfiguration {
+        printLogger(loggerLevel)
+        includes(config)
+    }
+}

--- a/projects/compose/koin-compose/src/wasmJsMain/kotlin/org/koin/compose/KoinApplication.wasmJS.kt
+++ b/projects/compose/koin-compose/src/wasmJsMain/kotlin/org/koin/compose/KoinApplication.wasmJS.kt
@@ -1,0 +1,16 @@
+package org.koin.compose
+
+import androidx.compose.runtime.Composable
+import org.koin.core.KoinApplication
+import org.koin.dsl.KoinConfiguration
+import org.koin.core.logger.Level
+import org.koin.dsl.koinConfiguration
+import org.koin.dsl.includes
+
+@Composable
+internal actual fun composeConfiguration(loggerLevel : Level,config : KoinApplication.() -> Unit) : KoinConfiguration {
+    return koinConfiguration {
+        printLogger(loggerLevel)
+        includes(config)
+    }
+}

--- a/projects/gradle/libs.versions.toml
+++ b/projects/gradle/libs.versions.toml
@@ -75,6 +75,7 @@ ktor3-testHost = { module = "io.ktor:ktor-server-test-host", version.ref = "ktor
 ktor-slf4j = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }
 # jetpack Compose
 androidx-composeRuntime = { module = "androidx.compose.runtime:runtime", version.ref = "composeJetpackRuntime" }
+androidx-composeFoundation = { module = "androidx.compose.foundation:foundation", version.ref = "composeJetpackRuntime" }
 androidx-composeViewModel = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "androidx-lifecycle" }
 androidx-composeNavigation = { module = "androidx.navigation:navigation-compose", version.ref = "androidx-navigation" }
 # jb Compose


### PR DESCRIPTION
Unlock capacity to help KoinApplication to have common DI modules config only.

Allow `KoinApplication` composable to hook current configuration to:
- preconfigure platform related logger
- inject Android context

