### PR TITLE
shouldn't inject parameters when qualifier is present

### DIFF
--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/scope/Scope.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/scope/Scope.kt
@@ -322,7 +322,7 @@ class Scope(
     }
 
     private inline fun <T> resolveFromInjectedParameters(ctx: ResolutionContext): T? {
-        return if (ctx.parameters == null) null
+        return if (ctx.parameters == null || ctx.qualifier != null) null
             else {
             _koin.logger.debug("|- ? ${ctx.debugTag} look in injected parameters")
             ctx.parameters.getOrNull(clazz = ctx.clazz)
@@ -331,7 +331,7 @@ class Scope(
 
     private inline fun <T> resolveFromStackedParameters(ctx: ResolutionContext): T? {
         val current = parameterStack?.get()
-        return if (current.isNullOrEmpty()) null
+        return if (current.isNullOrEmpty() || ctx.qualifier != null) null
          else {
             _koin.logger.debug("|- ? ${ctx.debugTag} look in stack parameters")
             val parameters = current.firstOrNull()


### PR DESCRIPTION
example:
```kotlin
module {
    single(named("echo")) { "Hello," + it.get<String>() }
}

koin.get<String>(named("echo")) { parametersOf("World!") } // this should be "Hello,World!", but we get "World!"
```

PS. this issue will effect multibinding with parameters:
```kotlin
module {
    declareSetMultibinding<String> {
        intoSet { it.get<String>() + "1" }
        intoSet { it.get<String>() + "2" }
    }
}
koin.getSetMultibinding<String> { parametersOf("set element prefix") }
```
multibinding #1951 