### PR TITLE
use inline value class to remove the runtime overhead of Qualifier

### DIFF
--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/qualifier/Qualifier.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/qualifier/Qualifier.kt
@@ -15,12 +15,15 @@
  */
 package org.koin.core.qualifier
 
+import kotlin.jvm.JvmInline
+
 /**
  * Help qualify a component
  */
-interface Qualifier {
+@JvmInline
+value class Qualifier(
     val value: QualifierValue
-}
+)
 
 typealias QualifierValue = String
 
@@ -34,6 +37,7 @@ fun <E : Enum<E>> named(enum: Enum<E>) = enum.qualifier
 fun qualifier(name: String) = StringQualifier(name)
 fun <E : Enum<E>> qualifier(enum: Enum<E>) = enum.qualifier
 
+@Suppress("FunctionName")
 fun _q(name: String) = StringQualifier(name)
 
 /**
@@ -49,6 +53,7 @@ inline fun <reified T> qualifier() = TypeQualifier(T::class)
 /**
  * Give a Type based qualifier
  */
+@Suppress("FunctionName")
 inline fun <reified T> _q() = TypeQualifier(T::class)
 
 val <E : Enum<E>> Enum<E>.qualifier

--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/qualifier/StringQualifier.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/qualifier/StringQualifier.kt
@@ -15,8 +15,5 @@
  */
 package org.koin.core.qualifier
 
-data class StringQualifier(override val value: QualifierValue) : Qualifier {
-    override fun toString(): String {
-        return value
-    }
-}
+@Suppress("FunctionName")
+fun StringQualifier(value: QualifierValue) : Qualifier = Qualifier(value)

--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/qualifier/TypeQualifier.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/qualifier/TypeQualifier.kt
@@ -18,25 +18,5 @@ package org.koin.core.qualifier
 import org.koin.ext.getFullName
 import kotlin.reflect.KClass
 
-class TypeQualifier(val type: KClass<*>) : Qualifier {
-    override val value: QualifierValue = type.getFullName()
-
-    override fun toString(): String {
-        return value
-    }
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (other == null || this::class != other::class) return false
-
-        other as TypeQualifier
-
-        if (value != other.value) return false
-
-        return true
-    }
-
-    override fun hashCode(): Int {
-        return value.hashCode()
-    }
-}
+@Suppress("FunctionName")
+fun TypeQualifier(type: KClass<*>) : Qualifier = Qualifier(type.getFullName())


### PR DESCRIPTION
`Qualifier` is ideally suited to be implemented as a value class. But the main problem is binary compatibility. The current implement is only source code compatible, not binary compatible. Maybe we should `internal` both `StringQualifier` & `TypeQualifier`, or deprecate them first.
This not a PR, but a suggestion to migrate `Qualifier` to value class.