### PR TITLE
check optional parameters during dependency verification

### DIFF
--- a/projects/core/koin-test/src/jvmMain/kotlin/org/koin/test/verify/Verification.kt
+++ b/projects/core/koin-test/src/jvmMain/kotlin/org/koin/test/verify/Verification.kt
@@ -140,7 +140,8 @@ class Verification(val module: Module, extraTypes: List<KClass<*>>, injections: 
             if (isWhiteList) {
                 println("| dependency '$ctorParamLabel' is whitelisted")
             }
-            val isDefinitionDeclared = hasDefinition || isParameterInjected || isWhiteList
+            val isOptionalParameter = constructorParameter.isOptional
+            val isDefinitionDeclared = hasDefinition || isParameterInjected || isWhiteList || isOptionalParameter
 
             val alreadyBoundFactory = verifiedFactories.keys.firstOrNull { ctorParamClass in listOf(it.beanDefinition.primaryType) + it.beanDefinition.secondaryTypes }
             val factoryDependencies = verifiedFactories[alreadyBoundFactory]


### PR DESCRIPTION
Shouldn't throw `MissingKoinDefinitionException` if the parameter is optional.