### PR TITLE
Fix Scope closing concurrent access

### DIFF
--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/registry/InstanceRegistry.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/registry/InstanceRegistry.kt
@@ -34,6 +34,7 @@ import org.koin.core.qualifier.Qualifier
 import org.koin.core.scope.Scope
 import org.koin.core.scope.ScopeID
 import org.koin.mp.KoinPlatformTools.safeHashMap
+import kotlin.collections.toTypedArray
 import kotlin.reflect.KClass
 
 @Suppress("UNCHECKED_CAST")
@@ -159,13 +160,13 @@ class InstanceRegistry(val _koin: Koin) {
     }
 
     internal fun dropScopeInstances(scope: Scope) {
-        _instances.values.filterIsInstance<ScopedInstanceFactory<*>>().forEach { factory -> factory.drop(scope) }
+        val factories = _instances.values.toTypedArray()
+        factories.filterIsInstance<ScopedInstanceFactory<*>>().forEach { factory -> factory.drop(scope) }
     }
 
     internal fun close() {
-        _instances.forEach { (_, factory) ->
-            factory.dropAll()
-        }
+        val factories = _instances.values.toTypedArray()
+        factories.forEach { factory -> factory.dropAll() }
         _instances.clear()
     }
 

--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/registry/ScopeRegistry.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/registry/ScopeRegistry.kt
@@ -90,7 +90,7 @@ class ScopeRegistry(private val _koin: Koin) {
     }
 
     private fun closeAllScopes() {
-        _scopes.values.toList().forEach { scope ->
+        _scopes.values.toTypedArray().forEach { scope ->
             scope.close()
         }
     }


### PR DESCRIPTION
Extract factories array to allow iterate on it to drop resources. Should help fix #2058
Also add same way fix for closeAll #2032 / #1963