### PR TITLE
KoinMultiplatformApplication - Compose Application Start + Native Context binding

### DIFF
--- a/projects/compose/koin-compose/src/androidMain/kotlin/org/koin/compose/KoinApplication.android.kt
+++ b/projects/compose/koin-compose/src/androidMain/kotlin/org/koin/compose/KoinApplication.android.kt
@@ -20,9 +20,9 @@ import org.koin.dsl.includes
 
 @Composable
 internal actual fun composeMultiplatformConfiguration(loggerLevel : Level, config : KoinApplication.() -> Unit) : KoinConfiguration {
-    val current = LocalContext.current
+    val appContext = LocalContext.current.applicationContext ?: error("Android ApplicationContext not found!")
     return koinConfiguration {
-        androidContext(current)
+        androidContext(appContext)
         androidLogger(loggerLevel)
         includes(config)
     }

--- a/projects/compose/koin-compose/src/androidMain/kotlin/org/koin/compose/KoinApplication.android.kt
+++ b/projects/compose/koin-compose/src/androidMain/kotlin/org/koin/compose/KoinApplication.android.kt
@@ -19,7 +19,7 @@ import org.koin.dsl.koinConfiguration
 import org.koin.dsl.includes
 
 @Composable
-internal actual fun composeMultiplatformConfiguration(loggerLevel : Level, config : KoinApplication.() -> Unit) : KoinConfiguration {
+internal actual fun composeMultiplatformConfiguration(loggerLevel : Level, config : KoinConfiguration) : KoinConfiguration {
     val appContext = LocalContext.current.applicationContext ?: error("Android ApplicationContext not found in current Compose context!")
     return koinConfiguration {
         androidContext(appContext)

--- a/projects/compose/koin-compose/src/androidMain/kotlin/org/koin/compose/KoinApplication.android.kt
+++ b/projects/compose/koin-compose/src/androidMain/kotlin/org/koin/compose/KoinApplication.android.kt
@@ -20,7 +20,7 @@ import org.koin.dsl.includes
 
 @Composable
 internal actual fun composeMultiplatformConfiguration(loggerLevel : Level, config : KoinApplication.() -> Unit) : KoinConfiguration {
-    val appContext = LocalContext.current.applicationContext ?: error("Android ApplicationContext not found!")
+    val appContext = LocalContext.current.applicationContext ?: error("Android ApplicationContext not found in current Compose context!")
     return koinConfiguration {
         androidContext(appContext)
         androidLogger(loggerLevel)

--- a/projects/compose/koin-compose/src/commonMain/kotlin/org/koin/compose/KoinApplication.kt
+++ b/projects/compose/koin-compose/src/commonMain/kotlin/org/koin/compose/KoinApplication.kt
@@ -34,7 +34,6 @@ import org.koin.core.logger.Level
 import org.koin.core.scope.Scope
 import org.koin.dsl.KoinAppDeclaration
 import org.koin.dsl.KoinConfiguration
-import org.koin.dsl.koinApplication
 import org.koin.mp.KoinPlatform
 import org.koin.mp.KoinPlatformTools
 
@@ -105,9 +104,11 @@ private fun warningNoContext(ctx: Koin) {
 }
 
 /**
- * Start a new Koin Application and associate it for Compose context
- * if Koin's Default Context is already set,
+ * Start a new Koin Application context and setup Compose context
+ * if Koin's Default Context is already set, throw an error
  *
+ * Note: KoinApplication is calling composeMultiplatformConfiguration to help prepare/anticipate context setup, and avoid to have different configuration in KMP app
+ * this function takes care to setup Android context (androidContext, androidLogger) for you
  * @see composeMultiplatformConfiguration()
  *
  * @param application - Koin Application declaration lambda
@@ -121,12 +122,11 @@ private fun warningNoContext(ctx: Koin) {
 @OptIn(KoinInternalApi::class)
 @Composable
 fun KoinApplication(
-    application: KoinAppDeclaration,
+    application: KoinAppDeclaration, //Better to directly use KoinConfiguration class
     logLevel : Level = Level.INFO,
     content: @Composable () -> Unit
 ) {
-    val configuration = composeMultiplatformConfiguration(logLevel, config = application)
-    val koin = rememberKoinApplication(koinApplication(configuration))
+    val koin = rememberKoinApplication(application,logLevel)
     KoinContext(koin,content)
 }
 
@@ -135,6 +135,7 @@ fun KoinApplication(
  * - Help handle automatically Android Logger Anticipate Android context injection, to having to setup androidContext() and androidLogger
  */
 @Composable
+@PublishedApi
 internal expect fun composeMultiplatformConfiguration(loggerLevel : Level = Level.INFO, config : KoinApplication.() -> Unit) : KoinConfiguration
 
 /**

--- a/projects/compose/koin-compose/src/commonMain/kotlin/org/koin/compose/application/RememberKoinApplication.kt
+++ b/projects/compose/koin-compose/src/commonMain/kotlin/org/koin/compose/application/RememberKoinApplication.kt
@@ -24,20 +24,22 @@ import org.koin.core.Koin
 import org.koin.core.annotation.KoinInternalApi
 import org.koin.core.logger.Level
 import org.koin.dsl.KoinAppDeclaration
+import org.koin.dsl.KoinConfiguration
 import org.koin.dsl.koinApplication
 
-/**
- * Remember Koin Application to handle its closure if necessary
- *
- * @param koinApplication
- *
- * @author Arnaud Giuliani
- */
+@Composable
+internal inline fun rememberKoinApplication(noinline koinAppDeclaration: KoinAppDeclaration): Koin {
+    val wrapper = remember(koinAppDeclaration) {
+        CompositionKoinApplicationLoader(koinApplication(koinAppDeclaration))
+    }
+    return wrapper.koin ?: error("Koin context has not been initialized in rememberKoinApplication")
+}
+
 @OptIn(KoinInternalApi::class)
 @Composable
-inline fun rememberKoinApplication(noinline koinAppDeclaration: KoinAppDeclaration, logLevel: Level): Koin {
-    val configuration = composeMultiplatformConfiguration(logLevel, config = koinAppDeclaration)
-    val wrapper = remember(koinAppDeclaration,logLevel) {
+internal inline fun rememberKoinMPApplication(configuration: KoinConfiguration, logLevel: Level): Koin {
+    val configuration = composeMultiplatformConfiguration(logLevel, config = configuration)
+    val wrapper = remember(configuration,logLevel) {
         CompositionKoinApplicationLoader(koinApplication(configuration))
     }
     return wrapper.koin ?: error("Koin context has not been initialized in rememberKoinApplication")

--- a/projects/compose/koin-compose/src/commonMain/kotlin/org/koin/compose/application/RememberKoinApplication.kt
+++ b/projects/compose/koin-compose/src/commonMain/kotlin/org/koin/compose/application/RememberKoinApplication.kt
@@ -19,9 +19,12 @@ package org.koin.compose.application
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import org.koin.compose.composeMultiplatformConfiguration
 import org.koin.core.Koin
-import org.koin.core.KoinApplication
 import org.koin.core.annotation.KoinInternalApi
+import org.koin.core.logger.Level
+import org.koin.dsl.KoinAppDeclaration
+import org.koin.dsl.koinApplication
 
 /**
  * Remember Koin Application to handle its closure if necessary
@@ -32,9 +35,10 @@ import org.koin.core.annotation.KoinInternalApi
  */
 @OptIn(KoinInternalApi::class)
 @Composable
-inline fun rememberKoinApplication(koinApplication: KoinApplication): Koin {
-    val wrapper = remember {
-        CompositionKoinApplicationLoader(koinApplication)
+inline fun rememberKoinApplication(noinline koinAppDeclaration: KoinAppDeclaration, logLevel: Level): Koin {
+    val configuration = composeMultiplatformConfiguration(logLevel, config = koinAppDeclaration)
+    val wrapper = remember(koinAppDeclaration,logLevel) {
+        CompositionKoinApplicationLoader(koinApplication(configuration))
     }
     return wrapper.koin ?: error("Koin context has not been initialized in rememberKoinApplication")
 }

--- a/projects/compose/koin-compose/src/jsMain/kotlin/org/koin/compose/KoinApplication.js.kt
+++ b/projects/compose/koin-compose/src/jsMain/kotlin/org/koin/compose/KoinApplication.js.kt
@@ -10,7 +10,7 @@ import org.koin.dsl.includes
 import org.koin.mp.KoinPlatform
 
 @Composable
-internal actual fun composeMultiplatformConfiguration(loggerLevel : Level, config : KoinApplication.() -> Unit) : KoinConfiguration {
+internal actual fun composeMultiplatformConfiguration(loggerLevel : Level, config : KoinConfiguration) : KoinConfiguration {
     return koinConfiguration {
         printLogger(loggerLevel)
         includes(config)

--- a/projects/compose/koin-compose/src/jvmMain/kotlin/org/koin/compose/KoinApplication.jvm.kt
+++ b/projects/compose/koin-compose/src/jvmMain/kotlin/org/koin/compose/KoinApplication.jvm.kt
@@ -10,7 +10,7 @@ import org.koin.dsl.includes
 import org.koin.mp.KoinPlatform
 
 @Composable
-internal actual fun composeMultiplatformConfiguration(loggerLevel : Level, config : KoinApplication.() -> Unit) : KoinConfiguration {
+internal actual fun composeMultiplatformConfiguration(loggerLevel : Level, config : KoinConfiguration) : KoinConfiguration {
     return koinConfiguration {
         printLogger(loggerLevel)
         includes(config)

--- a/projects/compose/koin-compose/src/nativeMain/kotlin/org/koin/compose/KoinApplication.native.kt
+++ b/projects/compose/koin-compose/src/nativeMain/kotlin/org/koin/compose/KoinApplication.native.kt
@@ -10,7 +10,7 @@ import org.koin.dsl.includes
 import org.koin.mp.KoinPlatform
 
 @Composable
-internal actual fun composeMultiplatformConfiguration(loggerLevel : Level, config : KoinApplication.() -> Unit) : KoinConfiguration {
+internal actual fun composeMultiplatformConfiguration(loggerLevel : Level, config : KoinConfiguration) : KoinConfiguration {
     return koinConfiguration {
         printLogger(loggerLevel)
         includes(config)

--- a/projects/compose/koin-compose/src/wasmJsMain/kotlin/org/koin/compose/KoinApplication.wasmJS.kt
+++ b/projects/compose/koin-compose/src/wasmJsMain/kotlin/org/koin/compose/KoinApplication.wasmJS.kt
@@ -10,7 +10,7 @@ import org.koin.dsl.includes
 import org.koin.mp.KoinPlatform
 
 @Composable
-internal actual fun composeMultiplatformConfiguration(loggerLevel : Level, config : KoinApplication.() -> Unit) : KoinConfiguration {
+internal actual fun composeMultiplatformConfiguration(loggerLevel : Level, config : KoinConfiguration) : KoinConfiguration {
     return koinConfiguration {
         printLogger(loggerLevel)
         includes(config)

--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/dsl/KoinConfiguration.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/dsl/KoinConfiguration.kt
@@ -22,7 +22,9 @@ import org.koin.core.module.KoinApplicationDslMarker
 //TODO Koin 4.1 - KoinAppDeclaration migration type to KoinConfiguration
 
 /**
- * Koin Configuration holder - use the koinConfiguration() function to define Koin configuration:
+ * Koin Configuration class holder, intended to replace KoinAppDeclaration that is a typealias on extension function
+ *
+ * use the koinConfiguration() function to define Koin configuration:
  * koinConfiguration {
  *  modules(...)
  * }


### PR DESCRIPTION
The target is to propose an alternative to `KoinApplication` that runs over a simple Koin configuration. 

The new `KoinMultiplatformApplication` compose function start Koin + setup native logger and native context if needed. No need anymore to have a specific part for Android with `androidContext`/`androidLogger`
