### PR TITLE
Enum's name as qualifier

### DIFF
--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/qualifier/Qualifier.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/qualifier/Qualifier.kt
@@ -32,6 +32,7 @@ fun named(name: String) = StringQualifier(name)
 fun <E : Enum<E>> named(enum: Enum<E>) = enum.qualifier
 
 fun qualifier(name: String) = StringQualifier(name)
+
 fun <E : Enum<E>> qualifier(enum: Enum<E>) = enum.qualifier
 
 fun _q(name: String) = StringQualifier(name)
@@ -52,6 +53,4 @@ inline fun <reified T> qualifier() = TypeQualifier(T::class)
 inline fun <reified T> _q() = TypeQualifier(T::class)
 
 val <E : Enum<E>> Enum<E>.qualifier
-    get() : Qualifier {
-        return StringQualifier(toString().lowercase())
-    }
+    get() : Qualifier = StringQualifier(name)


### PR DESCRIPTION
enum class `toString` can be override, use enum's name as its qualifier