### PR TITLE
Removed usages of old "compile" gradle dependency configuration in docs

### DIFF
--- a/docs/quickstart/junit-test.md
+++ b/docs/quickstart/junit-test.md
@@ -17,9 +17,9 @@ First, add the Koin dependency like below:
 ```groovy
 dependencies {
     // Koin testing tools
-    testCompile "io.insert-koin:koin-test:$koin_version"
+    testImplementation "io.insert-koin:koin-test:$koin_version"
     // Needed JUnit version
-    testCompile "io.insert-koin:koin-test-junit4:$koin_version"
+    testImplementation "io.insert-koin:koin-test-junit4:$koin_version"
 }
 ```
 

--- a/docs/quickstart/kotlin.md
+++ b/docs/quickstart/kotlin.md
@@ -23,7 +23,7 @@ First, check that the `koin-core` dependency is added like below:
 dependencies {
     
     // Koin for Kotlin apps
-    compile "io.insert-koin:koin-core:$koin_version"
+    implementation "io.insert-koin:koin-core:$koin_version"
 }
 ```
 


### PR DESCRIPTION
- Since gradle [removed compile dependency configuration in version 7.0](https://docs.gradle.org/7.0.1/userguide/upgrading_version_6.html#sec:configuration_removal), I think its important to remove this configuration from the docs
- `testCompile` was changed to `testImplementation`
- `compile` was changed to `implementation`