### PR TITLE
Update android.md

### DIFF
--- a/docs/quickstart/android.md
+++ b/docs/quickstart/android.md
@@ -155,7 +155,7 @@ The `modules()` function in `startKoin` load the given list of modules
 
 ## Koin module: classic or constructor DSL?
 
-Here is the Koin moduel declaration for our app:
+Here is the Koin module declaration for our app:
 
 ```kotlin
 val appModule = module {


### PR DESCRIPTION
Fix misspelling `moduel` to `module`