### PR TITLE
Fix compose context default context value

### DIFF
--- a/examples/sample-android-compose/src/main/java/org/koin/sample/androidx/compose/App.kt
+++ b/examples/sample-android-compose/src/main/java/org/koin/sample/androidx/compose/App.kt
@@ -14,6 +14,7 @@ import org.koin.androidx.compose.koinViewModel
 import org.koin.androidx.compose.scope.KoinActivityScope
 import org.koin.compose.koinInject
 import org.koin.compose.module.rememberKoinModules
+import org.koin.compose.scope.KoinScope
 import org.koin.core.parameter.parametersOf
 import org.koin.sample.androidx.compose.data.MyFactory
 import org.koin.sample.androidx.compose.data.MyInnerFactory
@@ -125,7 +126,7 @@ fun FactoryComposable(
     if (created) {
         clickComponent("Factory", myFactory.id, parentStatus) {
 
-            KoinActivityScope {
+            KoinScope<MyFactory>("factory_"+myFactory.id) {
                 InnerFactoryComposable(parentStatus)
                 ScopeComposable("SC_1", parentStatus)
                 ScopeComposable("SC_2", parentStatus)

--- a/examples/sample-android-compose/src/main/java/org/koin/sample/androidx/compose/MainActivity.kt
+++ b/examples/sample-android-compose/src/main/java/org/koin/sample/androidx/compose/MainActivity.kt
@@ -23,9 +23,7 @@ class MainActivity : ScopeActivity() {
 
         setContent {
             MaterialTheme {
-                KoinAndroidContext {
-                    App()
-                }
+                App()
             }
         }
     }

--- a/examples/sample-android-compose/src/main/java/org/koin/sample/androidx/compose/di/appModule.kt
+++ b/examples/sample-android-compose/src/main/java/org/koin/sample/androidx/compose/di/appModule.kt
@@ -20,6 +20,10 @@ val appModule = module {
 
 val WALLET_SCOPE = named("wallet")
 val secondModule = module {
+    scope<MyFactory>{
+        factoryOf(::MyInnerFactory)
+        scoped { MyScoped() }
+    }
     scope<MainActivity> {
         factoryOf(::MyInnerFactory)
         scoped { MyScoped() }

--- a/projects/compose/koin-androidx-compose/src/main/java/org/koin/androidx/compose/KoinAndroidContext.kt
+++ b/projects/compose/koin-androidx-compose/src/main/java/org/koin/androidx/compose/KoinAndroidContext.kt
@@ -47,6 +47,7 @@ import org.koin.mp.KoinPlatformTools
  * @author Arnaud Giuliani
  * @author jjkester
  */
+//TODO Deprecate in 4.1? - as we have default context
 @Composable
 fun KoinAndroidContext(
     content: @Composable () -> Unit


### PR DESCRIPTION
- set the initialized context value to avoid asking KoinContext or KoinAndroidContext setup
- no usage of remember to avoid keeping old value , in case of Scope (just use LocalProvider cache)
