### PR TITLE
Remove unnecessary workmanager dependency

### DIFF
--- a/projects/android/koin-androidx-startup/build.gradle.kts
+++ b/projects/android/koin-androidx-startup/build.gradle.kts
@@ -32,7 +32,7 @@ tasks.withType<KotlinCompile>().all {
 
 dependencies {
     api(project(":android:koin-android"))
-    api(libs.androidx.workmanager)
+    api(libs.androidx.startup)
 
     // Test
     testImplementation(libs.test.junit)


### PR DESCRIPTION
Use startup to replace workmanager, as workmanager is unnecessary dependency.