### PR TITLE
Fix broken link for “Kotlin with Koin Annotations” in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Here are the current available Koin project versions:
 
 You can find here tutorials to help you learn and get started with Koin framework:
 - [Kotlin](https://insert-koin.io/docs/quickstart/kotlin)
-- [Kotlin with Koin Annotations](https://insert-koin.io/docs/quickstart/kotlin-annotations)
+- [Kotlin with Koin Annotations](https://insert-koin.io/docs/reference/koin-annotations/start)
 - [Android](https://insert-koin.io/docs/quickstart/android-viewmodel)
 - [Android with Koin Annotations](https://insert-koin.io/docs/quickstart/android-annotations)
 - [Android Jetpack Compose](https://insert-koin.io/docs/quickstart/android-compose)


### PR DESCRIPTION
It seems that the following tutorial page is no longer available:

- Kotlin with Koin Annotations

This page is not listed under the [Quick Start](https://insert-koin.io/docs/quickstart/kotlin) section anymore:

<img width="267" alt="Screenshot 2025-03-05 at 16 32 30" src="https://github.com/user-attachments/assets/0f3c0618-867d-45cb-a169-dd56581b1fa5" />

Could you please confirm if the following page is now the correct reference?

https://insert-koin.io/docs/reference/koin-annotations/start

### Related Pull Request
- https://github.com/InsertKoinIO/koin-annotations/pull/241