### PR TITLE
Feat - scope archetypes for Activity, Fragment & ViewModel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,14 +1,7 @@
 name: Build & Test
 
 on:
-  push:
-    branches:
-      - '*'
-      - '*/*'
   pull_request:
-    branches:
-      - '*'
-      - '*/*'
 
 concurrency:
   group: build-${{ github.ref }}
@@ -76,8 +69,8 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          distribution: 'zulu'
-          java-version: 17
+          distribution: temurin
+          java-version: '18'
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,8 +27,8 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          distribution: 'zulu'
-          java-version: 17
+          distribution: temurin
+          java-version: '18'
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,14 +1,7 @@
 name: Test Examples
 
 on:
-  push:
-    branches:
-      - '*'
-      - '*/*'
   pull_request:
-    branches:
-      - '*'
-      - '*/*'
 
 concurrency:
   group: test-examples-${{ github.ref }}

--- a/docs/reference/koin-android/scope.md
+++ b/docs/reference/koin-android/scope.md
@@ -73,9 +73,15 @@ class MyAdapter(val presenter : MyPresenter)
 module {
   // Declare scope for MyActivity
   scope<MyActivity> {
-    // get MyPresenter instance from current scope 
-    scoped { MyAdapter(get()) }
-    scoped { MyPresenter() }
+   // get MyPresenter instance from current scope 
+   scoped { MyAdapter(get()) }
+   scoped { MyPresenter() }
+  }
+ 
+  // or
+  activityScope {
+   scoped { MyAdapter(get()) }
+   scoped { MyPresenter() }
   }
 }
 ```
@@ -183,7 +189,11 @@ module {
     viewModelOf(::MyScopeViewModel)
     scope<MyScopeViewModel> {
         scopedOf(::Session)
-    }    
+    }
+    // or
+    viewModelScope {
+        scopedOf(::Session)
+    }
 }
 
 class MyScopeViewModel : ScopeViewModel() {
@@ -229,6 +239,50 @@ class MyScopeViewModel : ViewModel(), KoinScopeComponent {
     override fun onCleared() {
         super.onCleared()
         scope.close()
+    }
+}
+```
+### Scope Archetypes (4.1.0) [Experimental]
+
+As new feature, you can now declare scope by archetype: you don't require to define a scope against a type but against an "archetype". You can declare a scope for "Activity", "Fragment" and "ViewModel":
+
+```kotlin
+
+module {
+ activityScope {
+  // scoped instances for an An activity
+ }
+
+ activityRetainedScope {
+  // scoped instances for an An activity, retained scope
+ }
+
+ fragmentScope {
+  // scoped instances for Fragment
+ }
+
+ viewModelScope {
+  // scoped instances for ViewModel
+ }
+}
+```
+
+This will help reuse instances in between scopes easily. No need to use a specific type like `scope<>{ }`, apart if you need scope on a precise object.
+
+Use the regular `activityScope()`, `activityRetainedScope()` and `fragmentScope()` delegates function to create API. Those will trigger scope archetypes. Also you can use Koin's `ScopeActivity` or `ScopeFragment` classes.
+
+For ViewModel's scope, you can use `ScopeViewModel` class, or deal yourself with the API and `viewModelScope()` function:
+
+```kotlin
+class MyViewModel : ViewModel(), KoinScopeComponent {
+
+    override val scope: Scope = viewModelScope()
+
+    override fun onCleared() {
+        // Close Koin scope here
+        scope.close()
+     
+        super.onCleared()
     }
 }
 ```

--- a/examples/androidx-samples/src/main/java/org/koin/sample/sandbox/components/mvvm/MyScopeViewModel.kt
+++ b/examples/androidx-samples/src/main/java/org/koin/sample/sandbox/components/mvvm/MyScopeViewModel.kt
@@ -3,14 +3,15 @@ package org.koin.sample.sandbox.components.mvvm
 import androidx.lifecycle.ViewModel
 import org.koin.core.component.KoinScopeComponent
 import org.koin.core.component.createScope
+import org.koin.core.component.inject
 import org.koin.core.scope.Scope
 import org.koin.sample.sandbox.components.scope.Session
 
+// not using Archetype here
 class MyScopeViewModel : ViewModel(), KoinScopeComponent {
 
     override val scope: Scope = createScope(this)
-
-    val session by scope.inject<Session>()
+    val session by inject<Session>()
 
     override fun onCleared() {
         super.onCleared()

--- a/examples/androidx-samples/src/main/java/org/koin/sample/sandbox/components/mvvm/MyScopeViewModel2.kt
+++ b/examples/androidx-samples/src/main/java/org/koin/sample/sandbox/components/mvvm/MyScopeViewModel2.kt
@@ -1,12 +1,13 @@
 package org.koin.sample.sandbox.components.mvvm
 
-import org.koin.androidx.scope.ScopeViewModel
+import org.koin.viewmodel.scope.ScopeViewModel
 import org.koin.core.annotation.KoinExperimentalAPI
+import org.koin.core.component.inject
 import org.koin.sample.sandbox.components.scope.Session
 
 @OptIn(KoinExperimentalAPI::class)
 class MyScopeViewModel2 : ScopeViewModel() {
 
-    val session by scope.inject<Session>()
+    val session by inject<Session>()
 
 }

--- a/examples/androidx-samples/src/main/java/org/koin/sample/sandbox/di/AppModule.kt
+++ b/examples/androidx-samples/src/main/java/org/koin/sample/sandbox/di/AppModule.kt
@@ -1,6 +1,9 @@
 package org.koin.sample.sandbox.di
 
 import org.koin.androidx.fragment.dsl.fragmentOf
+import org.koin.androidx.scope.dsl.activityScope
+import org.koin.androidx.scope.dsl.fragmentScope
+import org.koin.androidx.scope.dsl.retainedActivityScope
 // 4.0 deprecations
 //import org.koin.androidx.viewmodel.dsl.viewModel
 //import org.koin.androidx.viewmodel.dsl.viewModelOf
@@ -32,6 +35,7 @@ import org.koin.sample.sandbox.scope.ScopedActivityA
 import org.koin.sample.sandbox.scope.ScopedFragment
 import org.koin.sample.sandbox.workmanager.SimpleWorker
 import org.koin.sample.sandbox.workmanager.SimpleWorkerService
+import org.koin.viewmodel.scope.viewModelScope
 
 val appModule = module {
 
@@ -47,10 +51,13 @@ val mvpModule = module {
     //factory { (id: String) -> FactoryPresenter(id, get()) }
     factoryOf(::FactoryPresenter)
 
-    scope<MVPActivity> {
-        scopedOf(::ScopedPresenter)// { (id: String) -> ScopedPresenter(id, get()) }
-
+    activityScope {
+        scopedOf(::ScopedPresenter)
     }
+//    scope<MVPActivity> {
+//        scopedOf(::ScopedPresenter)// { (id: String) -> ScopedPresenter(id, get()) }
+//
+//    }
 }
 
 val mvvmModule = module {
@@ -66,31 +73,49 @@ val mvvmModule = module {
     viewModelOf(::ViewModelImpl) { bind<AbstractViewModel>() }
 
     viewModelOf(::MyScopeViewModel)
-    scope<MyScopeViewModel> {
-        scopedOf(::Session)
-    }
-
     viewModelOf(::MyScopeViewModel2)
-    scope<MyScopeViewModel2> {
+
+    viewModelScope {
         scopedOf(::Session)
         scopedOf(::SessionConsumer)
     }
 
+    scope<MyScopeViewModel> {
+        scopedOf(::Session)
+    }
+//
+//    scope<MyScopeViewModel2> {
+//        scopedOf(::Session)
+//        scopedOf(::SessionConsumer)
+//    }
+
     viewModelOf(::SavedStateViewModel) { named("vm2") }
 
     viewModel { (s : Session) -> SharedVM(s)}
-    scope<MVVMActivity> {
+
+    activityScope {
         scopedOf(::Session)
         fragmentOf(::MVVMFragment) // { MVVMFragment(get()) }
 
         scoped { MVVMPresenter1(get()) }
         scoped { MVVMPresenter2(get()) }
     }
-    scope<MVVMFragment> {
+    fragmentScope {
         scoped { (id: String) -> ScopedPresenter(id, get()) }
-        // to retrieve from parent
-//        scopedOf(::Session)
     }
+
+//    scope<MVVMActivity> {
+//        scopedOf(::Session)
+//        fragmentOf(::MVVMFragment) // { MVVMFragment(get()) }
+//
+//        scoped { MVVMPresenter1(get()) }
+//        scoped { MVVMPresenter2(get()) }
+//    }
+//    scope<MVVMFragment> {
+//        scoped { (id: String) -> ScopedPresenter(id, get()) }
+//        // to retrieve from parent
+////        scopedOf(::Session)
+//    }
 }
 
 val scopeModule = module {
@@ -107,14 +132,18 @@ val scopeModule = module {
 }
 
 val scopeModuleActivityA = module {
-    scope<ScopedActivityA> {
+    retainedActivityScope {
         fragmentOf(::ScopedFragment)
         scopedOf(::Session)
         scopedOf(::SessionActivity)
     }
-    scope<ScopedFragment> {
-
-    }
+//    scope<ScopedActivityA> {
+//        fragmentOf(::ScopedFragment)
+//        scopedOf(::Session)
+//        scopedOf(::SessionActivity)
+//    }
+//    scope<ScopedFragment> {
+//    }
 }
 
 val workerServiceModule = module {

--- a/examples/androidx-samples/src/main/java/org/koin/sample/sandbox/di/AppModule.kt
+++ b/examples/androidx-samples/src/main/java/org/koin/sample/sandbox/di/AppModule.kt
@@ -1,17 +1,22 @@
 package org.koin.sample.sandbox.di
 
-import org.koin.androidx.fragment.dsl.fragmentOf
-import org.koin.androidx.scope.dsl.activityScope
-import org.koin.androidx.scope.dsl.fragmentScope
-import org.koin.androidx.scope.dsl.retainedActivityScope
 // 4.0 deprecations
 //import org.koin.androidx.viewmodel.dsl.viewModel
 //import org.koin.androidx.viewmodel.dsl.viewModelOf
+import org.koin.androidx.fragment.dsl.fragmentOf
+import org.koin.androidx.scope.dsl.activityRetainedScope
+import org.koin.androidx.scope.dsl.activityScope
+import org.koin.androidx.scope.dsl.fragmentScope
 import org.koin.androidx.workmanager.dsl.workerOf
-import org.koin.core.module.dsl.*
-import org.koin.core.module.includes
+import org.koin.core.module.dsl.bind
+import org.koin.core.module.dsl.factoryOf
+import org.koin.core.module.dsl.named
+import org.koin.core.module.dsl.onClose
+import org.koin.core.module.dsl.scopedOf
+import org.koin.core.module.dsl.singleOf
+import org.koin.core.module.dsl.viewModel
+import org.koin.core.module.dsl.viewModelOf
 import org.koin.core.qualifier.named
-import org.koin.dsl.lazyModule
 import org.koin.dsl.module
 import org.koin.sample.sandbox.components.Counter
 import org.koin.sample.sandbox.components.SCOPE_ID
@@ -22,16 +27,22 @@ import org.koin.sample.sandbox.components.main.SimpleService
 import org.koin.sample.sandbox.components.main.SimpleServiceImpl
 import org.koin.sample.sandbox.components.mvp.FactoryPresenter
 import org.koin.sample.sandbox.components.mvp.ScopedPresenter
-import org.koin.sample.sandbox.components.mvvm.*
+import org.koin.sample.sandbox.components.mvvm.AbstractViewModel
+import org.koin.sample.sandbox.components.mvvm.MVVMPresenter1
+import org.koin.sample.sandbox.components.mvvm.MVVMPresenter2
+import org.koin.sample.sandbox.components.mvvm.MyScopeViewModel
+import org.koin.sample.sandbox.components.mvvm.MyScopeViewModel2
+import org.koin.sample.sandbox.components.mvvm.SavedStateBundleViewModel
+import org.koin.sample.sandbox.components.mvvm.SavedStateViewModel
+import org.koin.sample.sandbox.components.mvvm.SharedVM
+import org.koin.sample.sandbox.components.mvvm.SimpleViewModel
+import org.koin.sample.sandbox.components.mvvm.ViewModelImpl
 import org.koin.sample.sandbox.components.scope.Session
 import org.koin.sample.sandbox.components.scope.SessionActivity
 import org.koin.sample.sandbox.components.scope.SessionConsumer
-import org.koin.sample.sandbox.mvp.MVPActivity
-import org.koin.sample.sandbox.mvvm.MVVMActivity
 import org.koin.sample.sandbox.mvvm.MVVMFragment
 import org.koin.sample.sandbox.navigation.NavViewModel
 import org.koin.sample.sandbox.navigation.NavViewModel2
-import org.koin.sample.sandbox.scope.ScopedActivityA
 import org.koin.sample.sandbox.scope.ScopedFragment
 import org.koin.sample.sandbox.workmanager.SimpleWorker
 import org.koin.sample.sandbox.workmanager.SimpleWorkerService
@@ -91,7 +102,7 @@ val mvvmModule = module {
 
     viewModelOf(::SavedStateViewModel) { named("vm2") }
 
-    viewModel { (s : Session) -> SharedVM(s)}
+    viewModel { (s: Session) -> SharedVM(s) }
 
     activityScope {
         scopedOf(::Session)
@@ -132,7 +143,7 @@ val scopeModule = module {
 }
 
 val scopeModuleActivityA = module {
-    retainedActivityScope {
+    activityRetainedScope {
         fragmentOf(::ScopedFragment)
         scopedOf(::Session)
         scopedOf(::SessionActivity)
@@ -160,5 +171,14 @@ val navModule = module {
 }
 
 val allModules = module {
-    includes(appModule, mvpModule, mvvmModule , scopeModule , workerServiceModule , workerScopedModule , navModule , scopeModuleActivityA)
+    includes(
+        appModule,
+        mvpModule,
+        mvvmModule,
+        scopeModule,
+        workerServiceModule,
+        workerScopedModule,
+        navModule,
+        scopeModuleActivityA
+    )
 }

--- a/examples/gradle/versions.gradle
+++ b/examples/gradle/versions.gradle
@@ -2,7 +2,7 @@ ext {
     // Kotlin
     kotlin_version = '2.1.0'
     // Koin Versions
-    koin_version = '4.1.0-Beta6'
+    koin_version = '4.1.0-Beta7'
     koin_android_version = koin_version
     koin_compose_version = koin_version
 

--- a/projects/android/koin-android-compat/build.gradle.kts
+++ b/projects/android/koin-android-compat/build.gradle.kts
@@ -22,6 +22,9 @@ android {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
     }
+    publishing {
+        singleVariant("release") {}
+    }
 }
 
 tasks.withType<KotlinCompile>().all {

--- a/projects/android/koin-android-test/build.gradle.kts
+++ b/projects/android/koin-android-test/build.gradle.kts
@@ -22,6 +22,9 @@ android {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
     }
+    publishing {
+        singleVariant("release") {}
+    }
 }
 
 tasks.withType<KotlinCompile>().all {

--- a/projects/android/koin-android/api/koin-android.api
+++ b/projects/android/koin-android/api/koin-android.api
@@ -89,6 +89,12 @@ public final class org/koin/androidx/fragment/koin/KoinApplicationExtKt {
 	public static final fun fragmentFactory (Lorg/koin/core/KoinApplication;)V
 }
 
+public final class org/koin/androidx/scope/AndroidScopeArchetypesKt {
+	public static final fun getActivityRetainedScopeArchetype ()Lorg/koin/core/qualifier/TypeQualifier;
+	public static final fun getActivityScopeArchetype ()Lorg/koin/core/qualifier/TypeQualifier;
+	public static final fun getFragmentScopeArchetype ()Lorg/koin/core/qualifier/TypeQualifier;
+}
+
 public final class org/koin/androidx/scope/ComponentActivityExtKt {
 	public static final fun activityRetainedScope (Landroidx/activity/ComponentActivity;)Lkotlin/Lazy;
 	public static final fun activityScope (Landroidx/activity/ComponentActivity;)Lkotlin/Lazy;
@@ -147,6 +153,12 @@ public abstract class org/koin/androidx/scope/ScopeViewModel : androidx/lifecycl
 	public fun getScope ()Lorg/koin/core/scope/Scope;
 	protected fun onCleared ()V
 	public fun onCloseScope ()V
+}
+
+public final class org/koin/androidx/scope/dsl/AndroidScopeArchetypesDSLKt {
+	public static final fun activityRetainedScope (Lorg/koin/core/module/Module;Lkotlin/jvm/functions/Function1;)V
+	public static final fun activityScope (Lorg/koin/core/module/Module;Lkotlin/jvm/functions/Function1;)V
+	public static final fun fragmentScope (Lorg/koin/core/module/Module;Lkotlin/jvm/functions/Function1;)V
 }
 
 public final class org/koin/androidx/viewmodel/ext/android/ViewModelLazyKt {

--- a/projects/android/koin-android/build.gradle.kts
+++ b/projects/android/koin-android/build.gradle.kts
@@ -22,6 +22,12 @@ android {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
     }
+    testOptions {
+        unitTests {
+            isIncludeAndroidResources = true
+            isReturnDefaultValues = true
+        }
+    }
 }
 
 tasks.withType<KotlinCompile>().all {
@@ -46,6 +52,7 @@ dependencies {
     testImplementation(libs.test.junit)
     testImplementation(libs.test.mockito)
     testImplementation(libs.test.mockk)
+    testImplementation(libs.test.robolectric)
 }
 
 // android sources

--- a/projects/android/koin-android/build.gradle.kts
+++ b/projects/android/koin-android/build.gradle.kts
@@ -28,6 +28,9 @@ android {
             isReturnDefaultValues = true
         }
     }
+    publishing {
+        singleVariant("release") {}
+    }
 }
 
 tasks.withType<KotlinCompile>().all {

--- a/projects/android/koin-android/src/main/java/org/koin/androidx/fragment/dsl/ScopeSetExt.kt
+++ b/projects/android/koin-android/src/main/java/org/koin/androidx/fragment/dsl/ScopeSetExt.kt
@@ -22,9 +22,7 @@ import org.koin.core.qualifier.Qualifier
 import org.koin.dsl.ScopeDSL
 
 /**
- * ViewModel DSL Extension
- * Allow to declare a ViewModel - be later inject into Activity/Fragment with dedicated injector
- *
+ * Fragment Constructor DSL
  * @author Arnaud Giuliani
  *
  * @param qualifier - definition qualifier

--- a/projects/android/koin-android/src/main/java/org/koin/androidx/scope/AndroidScopeArchetypes.kt
+++ b/projects/android/koin-android/src/main/java/org/koin/androidx/scope/AndroidScopeArchetypes.kt
@@ -5,5 +5,5 @@ import androidx.fragment.app.Fragment
 import org.koin.core.qualifier.TypeQualifier
 
 val ActivityScopeArchetype = TypeQualifier(AppCompatActivity::class)
-val RetainedActivityScopeArchetype = TypeQualifier(RetainedScopeActivity::class)
+val ActivityRetainedScopeArchetype = TypeQualifier(RetainedScopeActivity::class)
 val FragmentScopeArchetype = TypeQualifier(Fragment::class)

--- a/projects/android/koin-android/src/main/java/org/koin/androidx/scope/AndroidScopeArchetypes.kt
+++ b/projects/android/koin-android/src/main/java/org/koin/androidx/scope/AndroidScopeArchetypes.kt
@@ -1,0 +1,9 @@
+package org.koin.androidx.scope
+
+import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.Fragment
+import org.koin.core.qualifier.TypeQualifier
+
+val ActivityScopeArchetype = TypeQualifier(AppCompatActivity::class)
+val RetainedActivityScopeArchetype = TypeQualifier(RetainedScopeActivity::class)
+val FragmentScopeArchetype = TypeQualifier(Fragment::class)

--- a/projects/android/koin-android/src/main/java/org/koin/androidx/scope/ComponentActivityExt.kt
+++ b/projects/android/koin-android/src/main/java/org/koin/androidx/scope/ComponentActivityExt.kt
@@ -18,17 +18,17 @@ package org.koin.androidx.scope
 import android.content.ComponentCallbacks
 import androidx.activity.ComponentActivity
 import androidx.activity.viewModels
+import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
-import androidx.lifecycle.lifecycleScope
 import org.koin.android.ext.android.getKoin
 import org.koin.android.scope.AndroidScopeComponent
 import org.koin.core.annotation.KoinInternalApi
 import org.koin.core.component.getScopeId
 import org.koin.core.component.getScopeName
+import org.koin.core.qualifier.TypeQualifier
 import org.koin.core.scope.Scope
 import org.koin.core.scope.ScopeCallback
-import org.koin.ext.getFullName
 
 /**
  * Provide Koin Scope tied to ComponentActivity
@@ -42,6 +42,7 @@ fun ComponentActivity.createScope(source: Any? = null): Scope = getKoin().create
 
 fun ComponentActivity.getScopeOrNull(): Scope? = getKoin().getScopeOrNull(getScopeId())
 
+
 /**
  * Create Scope for AppCompatActivity, given it's extending AndroidScopeComponent.
  * Also register it in AndroidScopeComponent.scope
@@ -50,11 +51,11 @@ fun ComponentActivity.createActivityScope(): Scope {
     if (this !is AndroidScopeComponent) {
         error("Activity should implement AndroidScopeComponent")
     }
-    return getKoin().getScopeOrNull(getScopeId()) ?: createScopeForCurrentLifecycle(this)
+    return getKoin().getScopeOrNull(getScopeId()) ?: createScopeForCurrentLifecycle(this, ActivityScopeArchetype)
 }
 
-internal fun ComponentCallbacks.createScopeForCurrentLifecycle(owner: LifecycleOwner): Scope {
-    val scope = getKoin().createScope(getScopeId(), getScopeName(), this)
+internal fun ComponentCallbacks.createScopeForCurrentLifecycle(owner: LifecycleOwner, scopeArchetype : TypeQualifier): Scope {
+    val scope = getKoin().createScope(getScopeId(), getScopeName(), this, scopeArchetype)
     scope.registerCallback(object : ScopeCallback{
         override fun onScopeClose(scope: Scope) {
             (owner as AndroidScopeComponent).onCloseScope()
@@ -70,8 +71,8 @@ internal fun LifecycleOwner.registerScopeForLifecycle(
     lifecycle.addObserver(
         object : DefaultLifecycleObserver {
             override fun onDestroy(owner: LifecycleOwner) {
-                super.onDestroy(owner)
                 scope.close()
+                super.onDestroy(owner)
             }
         }
     )
@@ -88,7 +89,7 @@ fun ComponentActivity.createActivityRetainedScope(): Scope {
 
     val scopeViewModel = viewModels<ScopeHandlerViewModel>().value
     if (scopeViewModel.scope == null) {
-        val scope = getKoin().createScope(getScopeId(), getScopeName())
+        val scope = getKoin().createScope(getScopeId(), getScopeName(), scopeArchetype = RetainedActivityScopeArchetype)
         scopeViewModel.scope = scope
     }
     return scopeViewModel.scope!!

--- a/projects/android/koin-android/src/main/java/org/koin/androidx/scope/ComponentActivityExt.kt
+++ b/projects/android/koin-android/src/main/java/org/koin/androidx/scope/ComponentActivityExt.kt
@@ -18,7 +18,6 @@ package org.koin.androidx.scope
 import android.content.ComponentCallbacks
 import androidx.activity.ComponentActivity
 import androidx.activity.viewModels
-import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import org.koin.android.ext.android.getKoin
@@ -89,7 +88,7 @@ fun ComponentActivity.createActivityRetainedScope(): Scope {
 
     val scopeViewModel = viewModels<ScopeHandlerViewModel>().value
     if (scopeViewModel.scope == null) {
-        val scope = getKoin().createScope(getScopeId(), getScopeName(), scopeArchetype = RetainedActivityScopeArchetype)
+        val scope = getKoin().createScope(getScopeId(), getScopeName(), scopeArchetype = ActivityRetainedScopeArchetype)
         scopeViewModel.scope = scope
     }
     return scopeViewModel.scope!!

--- a/projects/android/koin-android/src/main/java/org/koin/androidx/scope/FragmentExt.kt
+++ b/projects/android/koin-android/src/main/java/org/koin/androidx/scope/FragmentExt.kt
@@ -19,7 +19,9 @@ import androidx.fragment.app.Fragment
 import org.koin.android.ext.android.getKoin
 import org.koin.android.scope.AndroidScopeComponent
 import org.koin.core.component.getScopeId
+import org.koin.core.qualifier.TypeQualifier
 import org.koin.core.scope.Scope
+
 
 /**
  * Create Scope for Fragment, given it's extending AndroidScopeComponent.
@@ -30,7 +32,7 @@ fun Fragment.createFragmentScope(useParentActivityScope : Boolean = true): Scope
     if (this !is AndroidScopeComponent) {
         error("Fragment should implement AndroidScopeComponent")
     }
-    val scope = getKoin().getScopeOrNull(getScopeId()) ?: createScopeForCurrentLifecycle(this)
+    val scope = getKoin().getScopeOrNull(getScopeId()) ?: createScopeForCurrentLifecycle(this, FragmentScopeArchetype)
     if (useParentActivityScope){
         val activityScope: Scope? = (activity as? AndroidScopeComponent)?.scope
         if (activityScope != null) {

--- a/projects/android/koin-android/src/main/java/org/koin/androidx/scope/RetainedScopeActivity.kt
+++ b/projects/android/koin-android/src/main/java/org/koin/androidx/scope/RetainedScopeActivity.kt
@@ -19,6 +19,7 @@ import android.os.Bundle
 import androidx.annotation.LayoutRes
 import androidx.appcompat.app.AppCompatActivity
 import org.koin.android.scope.AndroidScopeComponent
+import org.koin.core.qualifier.TypeQualifier
 import org.koin.core.scope.Scope
 
 /**

--- a/projects/android/koin-android/src/main/java/org/koin/androidx/scope/dsl/AndroidScopeArchetypesDSL.kt
+++ b/projects/android/koin-android/src/main/java/org/koin/androidx/scope/dsl/AndroidScopeArchetypesDSL.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.koin.androidx.scope.dsl
+
+import org.koin.androidx.scope.ActivityScopeArchetype
+import org.koin.androidx.scope.FragmentScopeArchetype
+import org.koin.androidx.scope.RetainedActivityScopeArchetype
+import org.koin.core.annotation.KoinExperimentalAPI
+import org.koin.core.annotation.KoinInternalApi
+import org.koin.core.module.Module
+import org.koin.dsl.ScopeDSL
+
+@OptIn(KoinInternalApi::class)
+@KoinExperimentalAPI
+fun Module.activityScope(scopeSet: ScopeDSL.() -> Unit) {
+    val qualifier = ActivityScopeArchetype
+    ScopeDSL(qualifier, this).apply(scopeSet)
+}
+
+@OptIn(KoinInternalApi::class)
+@KoinExperimentalAPI
+fun Module.retainedActivityScope(scopeSet: ScopeDSL.() -> Unit) {
+    val qualifier = RetainedActivityScopeArchetype
+    ScopeDSL(qualifier, this).apply(scopeSet)
+}
+
+@OptIn(KoinInternalApi::class)
+@KoinExperimentalAPI
+fun Module.fragmentScope(scopeSet: ScopeDSL.() -> Unit) {
+    val qualifier = FragmentScopeArchetype
+    ScopeDSL(qualifier, this).apply(scopeSet)
+}

--- a/projects/android/koin-android/src/main/java/org/koin/androidx/scope/dsl/AndroidScopeArchetypesDSL.kt
+++ b/projects/android/koin-android/src/main/java/org/koin/androidx/scope/dsl/AndroidScopeArchetypesDSL.kt
@@ -17,7 +17,7 @@ package org.koin.androidx.scope.dsl
 
 import org.koin.androidx.scope.ActivityScopeArchetype
 import org.koin.androidx.scope.FragmentScopeArchetype
-import org.koin.androidx.scope.RetainedActivityScopeArchetype
+import org.koin.androidx.scope.ActivityRetainedScopeArchetype
 import org.koin.core.annotation.KoinExperimentalAPI
 import org.koin.core.annotation.KoinInternalApi
 import org.koin.core.module.Module
@@ -32,8 +32,8 @@ fun Module.activityScope(scopeSet: ScopeDSL.() -> Unit) {
 
 @OptIn(KoinInternalApi::class)
 @KoinExperimentalAPI
-fun Module.retainedActivityScope(scopeSet: ScopeDSL.() -> Unit) {
-    val qualifier = RetainedActivityScopeArchetype
+fun Module.activityRetainedScope(scopeSet: ScopeDSL.() -> Unit) {
+    val qualifier = ActivityRetainedScopeArchetype
     ScopeDSL(qualifier, this).apply(scopeSet)
 }
 

--- a/projects/android/koin-android/src/test/java/org/koin/test/android/scope/ActivityScopeArchetypeTest.kt
+++ b/projects/android/koin-android/src/test/java/org/koin/test/android/scope/ActivityScopeArchetypeTest.kt
@@ -1,0 +1,173 @@
+package org.koin.test.android.scope
+
+import androidx.activity.ComponentActivity
+import androidx.fragment.app.Fragment
+import org.junit.After
+import org.junit.Before
+import org.junit.runner.RunWith
+import org.koin.android.scope.AndroidScopeComponent
+import org.koin.androidx.scope.ActivityScopeArchetype
+import org.koin.androidx.scope.FragmentScopeArchetype
+import org.koin.androidx.scope.ActivityRetainedScopeArchetype
+import org.koin.androidx.scope.activityRetainedScope
+import org.koin.androidx.scope.activityScope
+import org.koin.androidx.scope.dsl.activityScope
+import org.koin.androidx.scope.dsl.fragmentScope
+import org.koin.androidx.scope.dsl.activityRetainedScope
+import org.koin.androidx.scope.fragmentScope
+import org.koin.core.annotation.KoinInternalApi
+import org.koin.core.component.getScopeId
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.core.logger.Level
+import org.koin.dsl.module
+import org.koin.mp.KoinPlatform
+import org.koin.test.android.scope.ScopeArchetypeDSLTest.MyFactoryClass
+import org.koin.test.android.scope.ScopeArchetypeDSLTest.MyScopedClass
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+
+class FakeActivity : ComponentActivity(), AndroidScopeComponent {
+
+    override val scope by activityScope()
+}
+
+class FakeFragment : Fragment(), AndroidScopeComponent {
+
+    override val scope by fragmentScope()
+}
+
+class FakeRetainedActivity : ComponentActivity(), AndroidScopeComponent {
+
+    override val scope by activityRetainedScope()
+}
+
+@RunWith(RobolectricTestRunner::class)
+@OptIn(KoinInternalApi::class)
+class ActivityScopeArchetypeTest {
+
+    @Before
+    fun setup() {
+        startKoin { printLogger(Level.DEBUG) }
+    }
+
+    @After
+    fun stop(){
+        stopKoin()
+    }
+
+    @Test
+    fun `activityScope creates scope with ActivityScopeArchetype`() {
+        val koin = KoinPlatform.getKoin()
+        val activity = FakeActivity()
+
+        val scope = activity.scope
+
+        assertSame(koin.getScope(activity.getScopeId()), scope)
+        assert(scope.scopeArchetype == ActivityScopeArchetype)
+    }
+
+    @Test
+    fun `activityScope resolve scope with ActivityScopeArchetype`() {
+        val koin = KoinPlatform.getKoin()
+        val module = module {
+            activityScope {
+                scoped { MyScopedClass() }
+                factory { MyFactoryClass(get()) }
+            }
+        }
+        koin.loadModules(listOf(module))
+
+        val activity = FakeActivity()
+
+        val scope = activity.scope
+        val mf = scope.get<MyFactoryClass>()
+        assertEquals(mf.ms,scope.get<MyScopedClass>())
+    }
+
+    @Test
+    fun `fragmentScope creates scope with ActivityScopeArchetype`() {
+        val koin = KoinPlatform.getKoin()
+        val fragment = FakeFragment()
+
+        val scope = fragment.scope
+
+        assertSame(koin.getScope(fragment.getScopeId()), scope)
+        assert(scope.scopeArchetype == FragmentScopeArchetype)
+    }
+
+    @Test
+    fun `fragmentScope resolves scope with ActivityScopeArchetype`() {
+        val koin = KoinPlatform.getKoin()
+        val module = module {
+            fragmentScope {
+                scoped { MyScopedClass() }
+                factory { MyFactoryClass(get()) }
+            }
+        }
+        koin.loadModules(listOf(module))
+
+        val fragment = FakeFragment()
+
+        val scope = fragment.scope
+        val mf = scope.get<MyFactoryClass>()
+        assertEquals(mf.ms,scope.get<MyScopedClass>())
+    }
+
+    @Test
+    fun `activityRetainedScope creates scope with RetainedActivityScopeArchetype`() {
+
+        val controller = Robolectric.buildActivity(FakeRetainedActivity::class.java).setup()
+        val activity = controller.get()
+
+        val koin = KoinPlatform.getKoin()
+
+        val scope = activity.activityRetainedScope().value
+
+        assertSame(koin.getScope(activity.getScopeId()), scope)
+        assert(scope.scopeArchetype == ActivityRetainedScopeArchetype)
+    }
+
+    @Test
+    fun `activityRetainedScope resolves scope with RetainedActivityScopeArchetype`() {
+
+        val controller = Robolectric.buildActivity(FakeRetainedActivity::class.java).setup()
+        val activity = controller.get()
+
+        val koin = KoinPlatform.getKoin()
+        val module = module {
+            activityRetainedScope {
+                scoped { MyScopedClass() }
+                factory { MyFactoryClass(get()) }
+            }
+        }
+        koin.loadModules(listOf(module))
+
+        val scope = activity.activityRetainedScope().value
+        val mf = scope.get<MyFactoryClass>()
+        assertEquals(mf.ms,scope.get<MyScopedClass>())
+    }
+
+    @Test
+    fun `wrong activity scope`() {
+        val controller = Robolectric.buildActivity(FakeRetainedActivity::class.java).setup()
+        val activity = controller.get()
+
+        val koin = KoinPlatform.getKoin()
+        val module = module {
+            activityScope {
+                scoped { MyScopedClass() }
+                factory { MyFactoryClass(get()) }
+            }
+        }
+        koin.loadModules(listOf(module))
+
+        val scope = activity.activityRetainedScope().value
+        val mf = scope.getOrNull<MyFactoryClass>()
+        assertNull(mf)
+    }
+}

--- a/projects/android/koin-android/src/test/java/org/koin/test/android/scope/ScopeArchetypeDSLTest.kt
+++ b/projects/android/koin-android/src/test/java/org/koin/test/android/scope/ScopeArchetypeDSLTest.kt
@@ -1,0 +1,61 @@
+package org.koin.test.android.scope
+
+import org.koin.androidx.scope.ActivityScopeArchetype
+import org.koin.androidx.scope.FragmentScopeArchetype
+import org.koin.androidx.scope.ActivityRetainedScopeArchetype
+import org.koin.androidx.scope.dsl.activityScope
+import org.koin.androidx.scope.dsl.fragmentScope
+import org.koin.androidx.scope.dsl.activityRetainedScope
+import org.koin.core.annotation.KoinInternalApi
+import org.koin.dsl.module
+import kotlin.test.Test
+
+@OptIn(KoinInternalApi::class)
+class ScopeArchetypeDSLTest {
+
+    class MyScopedClass
+    class MyFactoryClass(val ms : MyScopedClass)
+
+    @Test
+    fun testArchetypeDSL_activity(){
+        val module = module {
+            activityScope {
+                scoped { MyScopedClass() }
+                factory { MyFactoryClass(get()) }
+            }
+        }
+
+        assert(module.mappings.values.all {
+            it.beanDefinition.scopeQualifier == ActivityScopeArchetype
+        })
+    }
+
+    @Test
+    fun testArchetypeDSL_activity_retained(){
+        val module = module {
+            activityRetainedScope {
+                scoped { MyScopedClass() }
+                factory { MyFactoryClass(get()) }
+            }
+        }
+
+        assert(module.mappings.values.all {
+            it.beanDefinition.scopeQualifier == ActivityRetainedScopeArchetype
+        })
+    }
+
+    @Test
+    fun testArchetypeDSL_fragment(){
+        val module = module {
+            fragmentScope {
+                scoped { MyScopedClass() }
+                factory { MyFactoryClass(get()) }
+            }
+        }
+
+        assert(module.mappings.values.all {
+            it.beanDefinition.scopeQualifier == FragmentScopeArchetype
+        })
+    }
+
+}

--- a/projects/android/koin-androidx-navigation/build.gradle.kts
+++ b/projects/android/koin-androidx-navigation/build.gradle.kts
@@ -22,6 +22,9 @@ android {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
     }
+    publishing {
+        singleVariant("release") {}
+    }
 }
 
 tasks.withType<KotlinCompile>().all {

--- a/projects/android/koin-androidx-startup/build.gradle.kts
+++ b/projects/android/koin-androidx-startup/build.gradle.kts
@@ -22,6 +22,9 @@ android {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
     }
+    publishing {
+        singleVariant("release") {}
+    }
 }
 
 tasks.withType<KotlinCompile>().all {

--- a/projects/android/koin-androidx-workmanager/build.gradle.kts
+++ b/projects/android/koin-androidx-workmanager/build.gradle.kts
@@ -22,6 +22,9 @@ android {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
     }
+    publishing {
+        singleVariant("release") {}
+    }
 }
 
 tasks.withType<KotlinCompile>().all {

--- a/projects/compose/koin-androidx-compose-navigation/api/koin-androidx-compose-navigation.api
+++ b/projects/compose/koin-androidx-compose-navigation/api/koin-androidx-compose-navigation.api
@@ -1,0 +1,4 @@
+public final class org/koin/androidx/compose/navigation/NavViewModelInternalsKt {
+	public static final fun defaultNavExtras (Landroidx/lifecycle/ViewModelStoreOwner;Landroidx/compose/runtime/Composer;I)Landroidx/lifecycle/viewmodel/CreationExtras;
+}
+

--- a/projects/compose/koin-androidx-compose-navigation/build.gradle.kts
+++ b/projects/compose/koin-androidx-compose-navigation/build.gradle.kts
@@ -30,6 +30,9 @@ android {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
     }
+    publishing {
+        singleVariant("release") {}
+    }
 }
 
 tasks.withType<KotlinCompile>().all {

--- a/projects/compose/koin-androidx-compose/build.gradle.kts
+++ b/projects/compose/koin-androidx-compose/build.gradle.kts
@@ -30,6 +30,9 @@ android {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
     }
+    publishing {
+        singleVariant("release") {}
+    }
 }
 
 tasks.withType<KotlinCompile>().all {

--- a/projects/core/koin-core-viewmodel/api/koin-core-viewmodel.api
+++ b/projects/core/koin-core-viewmodel/api/koin-core-viewmodel.api
@@ -29,3 +29,23 @@ public final class org/koin/viewmodel/factory/KoinViewModelFactory : androidx/li
 	public fun create (Lkotlin/reflect/KClass;Landroidx/lifecycle/viewmodel/CreationExtras;)Landroidx/lifecycle/ViewModel;
 }
 
+public abstract class org/koin/viewmodel/scope/ScopeViewModel : androidx/lifecycle/ViewModel, org/koin/core/component/KoinScopeComponent {
+	public fun <init> ()V
+	public fun getKoin ()Lorg/koin/core/Koin;
+	public fun getScope ()Lorg/koin/core/scope/Scope;
+	protected fun onCleared ()V
+	public fun onCloseScope ()V
+}
+
+public final class org/koin/viewmodel/scope/ScopeViewModelKt {
+	public static final fun viewModelScope (Landroidx/lifecycle/ViewModel;Lorg/koin/core/component/KoinScopeComponent;)Lorg/koin/core/scope/Scope;
+}
+
+public final class org/koin/viewmodel/scope/ViewModelScopeArchetypeDSLKt {
+	public static final fun viewModelScope (Lorg/koin/core/module/Module;Lkotlin/jvm/functions/Function1;)V
+}
+
+public final class org/koin/viewmodel/scope/ViewModelScopeArchetypeKt {
+	public static final fun getViewModelScopeArchetype ()Lorg/koin/core/qualifier/TypeQualifier;
+}
+

--- a/projects/core/koin-core-viewmodel/build.gradle.kts
+++ b/projects/core/koin-core-viewmodel/build.gradle.kts
@@ -40,6 +40,11 @@ kotlin {
             api(libs.jb.bundle)
             api(libs.jb.savedstate)
         }
+        commonTest.dependencies {
+            implementation(libs.kotlin.test)
+            implementation(libs.test.junit)
+            implementation(libs.test.mockk)
+        }
     }
 }
 

--- a/projects/core/koin-core-viewmodel/build.gradle.kts
+++ b/projects/core/koin-core-viewmodel/build.gradle.kts
@@ -15,6 +15,15 @@ kotlin {
         withJava()
     }
 
+    // Enable context receivers for all targets
+    targets.all {
+        compilations.all {
+            kotlinOptions {
+                freeCompilerArgs += listOf("-Xcontext-receivers")
+            }
+        }
+    }
+
     js(IR) {
         nodejs()
         browser()

--- a/projects/core/koin-core-viewmodel/src/commonMain/kotlin/org/koin/viewmodel/scope/ScopeViewModel.kt
+++ b/projects/core/koin-core-viewmodel/src/commonMain/kotlin/org/koin/viewmodel/scope/ScopeViewModel.kt
@@ -1,3 +1,5 @@
+@file:Suppress("CONTEXT_RECEIVERS_DEPRECATED")
+
 package org.koin.viewmodel.scope
 
 import androidx.lifecycle.ViewModel
@@ -19,7 +21,7 @@ import org.koin.core.scope.Scope
 @KoinExperimentalAPI
 abstract class ScopeViewModel : ViewModel(), KoinScopeComponent {
 
-    override val scope: Scope = createScope(source = this, scopeArchetype = ViewModelScopeArchetype)
+    override val scope: Scope = viewModelScope()
 
     /**
      * To override to add behavior before closing Scope
@@ -31,4 +33,9 @@ abstract class ScopeViewModel : ViewModel(), KoinScopeComponent {
         scope.close()
         super.onCleared()
     }
+}
+
+context(ViewModel)
+fun KoinScopeComponent.viewModelScope() : Scope {
+    return createScope(source = this, scopeArchetype = ViewModelScopeArchetype)
 }

--- a/projects/core/koin-core-viewmodel/src/commonMain/kotlin/org/koin/viewmodel/scope/ScopeViewModel.kt
+++ b/projects/core/koin-core-viewmodel/src/commonMain/kotlin/org/koin/viewmodel/scope/ScopeViewModel.kt
@@ -1,10 +1,10 @@
-package org.koin.androidx.scope
+package org.koin.viewmodel.scope
 
 import androidx.lifecycle.ViewModel
+import org.koin.core.annotation.KoinExperimentalAPI
 import org.koin.core.component.KoinScopeComponent
 import org.koin.core.component.createScope
 import org.koin.core.scope.Scope
-import org.koin.viewmodel.scope.ViewModelScopeArchetype
 
 /**
  * Class to help support Koin Scope in a ViewModel
@@ -16,7 +16,7 @@ import org.koin.viewmodel.scope.ViewModelScopeArchetype
  *
  * @author Arnaud Giuliani
  */
-@Deprecated("ScopeViewModel has been moved to org.koin.viewmodel.scope.ScopeViewModel (koin-core-viewmodel)", ReplaceWith(expression = "ScopeViewModel()", imports = ["org.koin.viewmodel.scope"]))
+@KoinExperimentalAPI
 abstract class ScopeViewModel : ViewModel(), KoinScopeComponent {
 
     override val scope: Scope = createScope(source = this, scopeArchetype = ViewModelScopeArchetype)

--- a/projects/core/koin-core-viewmodel/src/commonMain/kotlin/org/koin/viewmodel/scope/ViewModelScopeArchetype.kt
+++ b/projects/core/koin-core-viewmodel/src/commonMain/kotlin/org/koin/viewmodel/scope/ViewModelScopeArchetype.kt
@@ -13,24 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.koin.androidx.fragment.dsl
+package org.koin.viewmodel.scope
 
-import androidx.fragment.app.Fragment
-import org.koin.core.definition.Definition
-import org.koin.core.definition.KoinDefinition
-import org.koin.core.module.Module
-import org.koin.core.module.dsl.new
-import org.koin.core.qualifier.Qualifier
+import androidx.lifecycle.ViewModel
+import org.koin.core.qualifier.TypeQualifier
 
-/**
- * Fragment Constructor DSL
- *
- * @author Arnaud Giuliani
- *
- * @param qualifier - definition qualifier
- * @param definition - allow definition override
- */
-inline fun <reified T : Fragment> Module.fragment(
-    qualifier: Qualifier? = null,
-    noinline definition: Definition<T>
-): KoinDefinition<T> = factory(qualifier, definition)
+val ViewModelScopeArchetype = TypeQualifier(ViewModel::class)

--- a/projects/core/koin-core-viewmodel/src/commonMain/kotlin/org/koin/viewmodel/scope/ViewModelScopeArchetypeDSL.kt
+++ b/projects/core/koin-core-viewmodel/src/commonMain/kotlin/org/koin/viewmodel/scope/ViewModelScopeArchetypeDSL.kt
@@ -13,24 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.koin.androidx.fragment.dsl
+package org.koin.viewmodel.scope
 
-import androidx.fragment.app.Fragment
-import org.koin.core.definition.Definition
-import org.koin.core.definition.KoinDefinition
+import org.koin.core.annotation.KoinExperimentalAPI
+import org.koin.core.annotation.KoinInternalApi
 import org.koin.core.module.Module
-import org.koin.core.module.dsl.new
-import org.koin.core.qualifier.Qualifier
+import org.koin.dsl.ScopeDSL
 
-/**
- * Fragment Constructor DSL
- *
- * @author Arnaud Giuliani
- *
- * @param qualifier - definition qualifier
- * @param definition - allow definition override
- */
-inline fun <reified T : Fragment> Module.fragment(
-    qualifier: Qualifier? = null,
-    noinline definition: Definition<T>
-): KoinDefinition<T> = factory(qualifier, definition)
+@OptIn(KoinInternalApi::class)
+@KoinExperimentalAPI
+fun Module.viewModelScope(scopeSet: ScopeDSL.() -> Unit) {
+    val qualifier = ViewModelScopeArchetype
+    ScopeDSL(qualifier, this).apply(scopeSet)
+}

--- a/projects/core/koin-core-viewmodel/src/commonTest/kotlin/org/koin/viewmodel/scope/ScopeArchetypeDSLTest.kt
+++ b/projects/core/koin-core-viewmodel/src/commonTest/kotlin/org/koin/viewmodel/scope/ScopeArchetypeDSLTest.kt
@@ -1,0 +1,29 @@
+package org.koin.viewmodel.scope
+
+import org.koin.core.annotation.KoinInternalApi
+import org.koin.dsl.module
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+@OptIn(KoinInternalApi::class)
+class ScopeArchetypeDSLTest {
+
+    class MyScopedClass
+    class MyFactoryClass(val ms: MyScopedClass)
+    class MyViewModelClass : ScopeViewModel()
+
+    @Test
+    fun testArchetypeDSL_activity() {
+        val module = module {
+            viewModelScope {
+                scoped { MyScopedClass() }
+                factory { MyFactoryClass(get()) }
+            }
+        }
+
+        assertTrue(module.mappings.values.all {
+            it.beanDefinition.scopeQualifier == ViewModelScopeArchetype
+        })
+    }
+
+}

--- a/projects/core/koin-core-viewmodel/src/commonTest/kotlin/org/koin/viewmodel/scope/ScopeArchetypeTest.kt
+++ b/projects/core/koin-core-viewmodel/src/commonTest/kotlin/org/koin/viewmodel/scope/ScopeArchetypeTest.kt
@@ -1,0 +1,57 @@
+package org.koin.viewmodel.scope
+
+import org.koin.core.annotation.KoinInternalApi
+import org.koin.core.component.getScopeId
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.core.logger.Level
+import org.koin.dsl.module
+import org.koin.mp.KoinPlatform
+import org.koin.viewmodel.scope.ScopeArchetypeDSLTest.MyFactoryClass
+import org.koin.viewmodel.scope.ScopeArchetypeDSLTest.MyScopedClass
+import org.koin.viewmodel.scope.ScopeArchetypeDSLTest.MyViewModelClass
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(KoinInternalApi::class)
+class ScopeArchetypeTest {
+
+    @BeforeTest
+    fun setup() {
+        startKoin { printLogger(Level.DEBUG) }
+    }
+
+    @AfterTest
+    fun stop(){
+        stopKoin()
+    }
+
+    @Test
+    fun testViewModelScope_creation() {
+        val koin = KoinPlatform.getKoin()
+        val vm = MyViewModelClass()
+
+        val scope = vm.scope
+        assertEquals(scope.scopeArchetype,ViewModelScopeArchetype)
+        assertEquals(scope,koin.getScope(vm.getScopeId()))
+    }
+
+    @Test
+    fun testViewModelScope_resolution() {
+        val koin = KoinPlatform.getKoin()
+
+        val module = module {
+            viewModelScope {
+                scoped { MyScopedClass() }
+                factory { MyFactoryClass(get()) }
+            }
+        }
+        koin.loadModules(listOf(module))
+        val vm = MyViewModelClass()
+
+        assertEquals(vm.scope.get<MyFactoryClass>().ms, vm.scope.get<MyScopedClass>())
+    }
+
+}

--- a/projects/core/koin-core/api/koin-core.api
+++ b/projects/core/koin-core/api/koin-core.api
@@ -8,9 +8,9 @@ public final class org/koin/core/Koin {
 	public fun <init> ()V
 	public final fun close ()V
 	public final fun createEagerInstances ()V
-	public final fun createScope (Ljava/lang/String;Lorg/koin/core/qualifier/Qualifier;Ljava/lang/Object;)Lorg/koin/core/scope/Scope;
+	public final fun createScope (Ljava/lang/String;Lorg/koin/core/qualifier/Qualifier;Ljava/lang/Object;Lorg/koin/core/qualifier/TypeQualifier;)Lorg/koin/core/scope/Scope;
 	public final fun createScope (Lorg/koin/core/component/KoinScopeComponent;)Lorg/koin/core/scope/Scope;
-	public static synthetic fun createScope$default (Lorg/koin/core/Koin;Ljava/lang/String;Lorg/koin/core/qualifier/Qualifier;Ljava/lang/Object;ILjava/lang/Object;)Lorg/koin/core/scope/Scope;
+	public static synthetic fun createScope$default (Lorg/koin/core/Koin;Ljava/lang/String;Lorg/koin/core/qualifier/Qualifier;Ljava/lang/Object;Lorg/koin/core/qualifier/TypeQualifier;ILjava/lang/Object;)Lorg/koin/core/scope/Scope;
 	public final fun deleteProperty (Ljava/lang/String;)V
 	public final fun deleteScope (Ljava/lang/String;)V
 	public final fun get (Lkotlin/reflect/KClass;Lorg/koin/core/qualifier/Qualifier;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
@@ -78,9 +78,9 @@ public final class org/koin/core/component/KoinScopeComponent$DefaultImpls {
 
 public final class org/koin/core/component/KoinScopeComponentKt {
 	public static final fun createScope (Lorg/koin/core/component/KoinScopeComponent;Ljava/lang/Object;)Lorg/koin/core/scope/Scope;
-	public static final fun createScope (Lorg/koin/core/component/KoinScopeComponent;Ljava/lang/String;Ljava/lang/Object;)Lorg/koin/core/scope/Scope;
+	public static final fun createScope (Lorg/koin/core/component/KoinScopeComponent;Ljava/lang/String;Ljava/lang/Object;Lorg/koin/core/qualifier/TypeQualifier;)Lorg/koin/core/scope/Scope;
 	public static synthetic fun createScope$default (Lorg/koin/core/component/KoinScopeComponent;Ljava/lang/Object;ILjava/lang/Object;)Lorg/koin/core/scope/Scope;
-	public static synthetic fun createScope$default (Lorg/koin/core/component/KoinScopeComponent;Ljava/lang/String;Ljava/lang/Object;ILjava/lang/Object;)Lorg/koin/core/scope/Scope;
+	public static synthetic fun createScope$default (Lorg/koin/core/component/KoinScopeComponent;Ljava/lang/String;Ljava/lang/Object;Lorg/koin/core/qualifier/TypeQualifier;ILjava/lang/Object;)Lorg/koin/core/scope/Scope;
 	public static final fun getOrCreateScope (Lorg/koin/core/component/KoinScopeComponent;)Lkotlin/Lazy;
 	public static final fun getScopeId (Ljava/lang/Object;)Ljava/lang/String;
 	public static final fun getScopeName (Ljava/lang/Object;)Lorg/koin/core/qualifier/TypeQualifier;
@@ -293,6 +293,8 @@ public final class org/koin/core/instance/ResolutionContext {
 	public final fun getParameters ()Lorg/koin/core/parameter/ParametersHolder;
 	public final fun getQualifier ()Lorg/koin/core/qualifier/Qualifier;
 	public final fun getScope ()Lorg/koin/core/scope/Scope;
+	public final fun getScopeArchetype ()Lorg/koin/core/qualifier/TypeQualifier;
+	public final fun setScopeArchetype (Lorg/koin/core/qualifier/TypeQualifier;)V
 }
 
 public final class org/koin/core/instance/ScopedInstanceFactory : org/koin/core/instance/InstanceFactory {
@@ -500,8 +502,8 @@ public final class org/koin/core/registry/PropertyRegistryExtKt {
 public final class org/koin/core/registry/ScopeRegistry {
 	public static final field Companion Lorg/koin/core/registry/ScopeRegistry$Companion;
 	public fun <init> (Lorg/koin/core/Koin;)V
-	public final fun createScope (Ljava/lang/String;Lorg/koin/core/qualifier/Qualifier;Ljava/lang/Object;)Lorg/koin/core/scope/Scope;
-	public static synthetic fun createScope$default (Lorg/koin/core/registry/ScopeRegistry;Ljava/lang/String;Lorg/koin/core/qualifier/Qualifier;Ljava/lang/Object;ILjava/lang/Object;)Lorg/koin/core/scope/Scope;
+	public final fun createScope (Ljava/lang/String;Lorg/koin/core/qualifier/Qualifier;Ljava/lang/Object;Lorg/koin/core/qualifier/TypeQualifier;)Lorg/koin/core/scope/Scope;
+	public static synthetic fun createScope$default (Lorg/koin/core/registry/ScopeRegistry;Ljava/lang/String;Lorg/koin/core/qualifier/Qualifier;Ljava/lang/Object;Lorg/koin/core/qualifier/TypeQualifier;ILjava/lang/Object;)Lorg/koin/core/scope/Scope;
 	public final fun getRootScope ()Lorg/koin/core/scope/Scope;
 	public final fun getScopeDefinitions ()Ljava/util/Set;
 	public final fun getScopeOrNull (Ljava/lang/String;)Lorg/koin/core/scope/Scope;
@@ -513,8 +515,8 @@ public final class org/koin/core/registry/ScopeRegistry$Companion {
 }
 
 public final class org/koin/core/scope/Scope {
-	public fun <init> (Lorg/koin/core/qualifier/Qualifier;Ljava/lang/String;ZLorg/koin/core/Koin;)V
-	public synthetic fun <init> (Lorg/koin/core/qualifier/Qualifier;Ljava/lang/String;ZLorg/koin/core/Koin;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lorg/koin/core/qualifier/Qualifier;Ljava/lang/String;ZLorg/koin/core/qualifier/TypeQualifier;Lorg/koin/core/Koin;)V
+	public synthetic fun <init> (Lorg/koin/core/qualifier/Qualifier;Ljava/lang/String;ZLorg/koin/core/qualifier/TypeQualifier;Lorg/koin/core/Koin;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun close ()V
 	public final fun get (Lkotlin/reflect/KClass;Lorg/koin/core/qualifier/Qualifier;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
 	public static synthetic fun get$default (Lorg/koin/core/scope/Scope;Lkotlin/reflect/KClass;Lorg/koin/core/qualifier/Qualifier;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)Ljava/lang/Object;
@@ -529,6 +531,7 @@ public final class org/koin/core/scope/Scope {
 	public final fun getProperty (Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/Object;
 	public final fun getPropertyOrNull (Ljava/lang/String;)Ljava/lang/Object;
 	public final fun getScope (Ljava/lang/String;)Lorg/koin/core/scope/Scope;
+	public final fun getScopeArchetype ()Lorg/koin/core/qualifier/TypeQualifier;
 	public final fun getScopeQualifier ()Lorg/koin/core/qualifier/Qualifier;
 	public final fun getSourceValue ()Ljava/lang/Object;
 	public final fun getWithParameters (Lkotlin/reflect/KClass;Lorg/koin/core/qualifier/Qualifier;Lorg/koin/core/parameter/ParametersHolder;)Ljava/lang/Object;

--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/Koin.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/Koin.kt
@@ -182,17 +182,17 @@ class Koin {
      * @param scopeId
      * @param scopeDefinitionName
      */
-    fun createScope(scopeId: ScopeID, qualifier: Qualifier, source: Any? = null): Scope {
-        return scopeRegistry.createScope(scopeId, qualifier, source)
+    fun createScope(scopeId: ScopeID, qualifier: Qualifier, source: Any? = null, scopeArchetype : TypeQualifier? = null): Scope {
+        return scopeRegistry.createScope(scopeId, qualifier, source,scopeArchetype)
     }
 
     /**
      * Create a Scope instance
      * @param scopeId
      */
-    inline fun <reified T : Any> createScope(scopeId: ScopeID, source: Any? = null): Scope {
+    inline fun <reified T : Any> createScope(scopeId: ScopeID, source: Any? = null, scopeArchetype : TypeQualifier? = null): Scope {
         val qualifier = TypeQualifier(T::class)
-        return scopeRegistry.createScope(scopeId, qualifier, source)
+        return scopeRegistry.createScope(scopeId, qualifier, source, scopeArchetype)
     }
 
     /**

--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/component/KoinScopeComponent.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/component/KoinScopeComponent.kt
@@ -35,8 +35,8 @@ interface KoinScopeComponent : KoinComponent {
 fun <T : Any> T.getScopeId() = this::class.getFullName() + "@" + this.hashCode()
 fun <T : Any> T.getScopeName() = TypeQualifier(this::class)
 
-fun <T : KoinScopeComponent> T.createScope(scopeId : ScopeID, source: Any? = null): Scope {
-    return getKoin().createScope(scopeId, getScopeName(), source)
+fun <T : KoinScopeComponent> T.createScope(scopeId : ScopeID = getScopeId(), source: Any? = null, scopeArchetype : TypeQualifier? = null): Scope {
+    return getKoin().createScope(scopeId, getScopeName(), source, scopeArchetype)
 }
 
 fun <T : KoinScopeComponent> T.createScope(source: Any? = null): Scope {

--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/instance/ResolutionContext.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/instance/ResolutionContext.kt
@@ -19,6 +19,7 @@ import org.koin.core.annotation.KoinInternalApi
 import org.koin.core.logger.Logger
 import org.koin.core.parameter.ParametersHolder
 import org.koin.core.qualifier.Qualifier
+import org.koin.core.qualifier.TypeQualifier
 import org.koin.core.scope.Scope
 import org.koin.ext.getFullName
 import kotlin.reflect.KClass
@@ -35,6 +36,7 @@ class ResolutionContext(
     val parameters: ParametersHolder? = null,
 ){
     val debugTag = "t:'${clazz.getFullName()}' - q:'$qualifier'"
+    var scopeArchetype : TypeQualifier? = null
 }
 
 @KoinInternalApi

--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/instance/ScopedInstanceFactory.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/instance/ScopedInstanceFactory.kt
@@ -55,7 +55,7 @@ class ScopedInstanceFactory<T>(beanDefinition: BeanDefinition<T>, val holdInstan
     }
 
     override fun get(context: ResolutionContext): T {
-        if (context.scope.scopeQualifier != beanDefinition.scopeQualifier) {
+        if (context.scope.scopeQualifier != beanDefinition.scopeQualifier && context.scopeArchetype != beanDefinition.scopeQualifier) {
             error("Wrong Scope qualifier: trying to open instance for ${context.scope.id} in $beanDefinition")
         }
         KoinPlatformTools.synchronized(this) {

--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/module/Module.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/module/Module.kt
@@ -15,6 +15,7 @@
  */
 package org.koin.core.module
 
+import org.koin.core.annotation.KoinExperimentalAPI
 import org.koin.core.annotation.KoinInternalApi
 import org.koin.core.definition.*
 import org.koin.core.error.DefinitionOverrideException
@@ -55,7 +56,6 @@ class Module(
 
 
     @KoinInternalApi
-    // used by Ktor ext
     val scopes = LinkedHashSet<Qualifier>()
 
     @KoinInternalApi

--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/registry/InstanceRegistry.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/registry/InstanceRegistry.kt
@@ -16,6 +16,7 @@
 package org.koin.core.registry
 
 import org.koin.core.Koin
+import org.koin.core.annotation.KoinExperimentalAPI
 import org.koin.core.annotation.KoinInternalApi
 import org.koin.core.definition.BeanDefinition
 import org.koin.core.definition.IndexKey
@@ -102,6 +103,18 @@ class InstanceRegistry(val _koin: Koin) {
     ): InstanceFactory<*>? {
         val indexKey = indexKey(clazz, qualifier, scopeQualifier)
         return _instances[indexKey]
+    }
+
+    @KoinExperimentalAPI
+    internal fun <T> resolveScopeArchetypeInstance(
+        qualifier: Qualifier?,
+        klass: KClass<*>,
+        context: ResolutionContext
+    ) :T? {
+        return context.scope.scopeArchetype?.let {
+            context.scopeArchetype = it
+            resolveInstance(qualifier,klass,it,context)
+        }
     }
 
     internal fun <T> resolveInstance(
@@ -194,4 +207,6 @@ class InstanceRegistry(val _koin: Koin) {
     fun size(): Int {
         return _instances.size
     }
+
+
 }

--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/registry/ScopeRegistry.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/registry/ScopeRegistry.kt
@@ -20,6 +20,7 @@ import org.koin.core.annotation.KoinInternalApi
 import org.koin.core.error.ScopeAlreadyCreatedException
 import org.koin.core.module.Module
 import org.koin.core.qualifier.Qualifier
+import org.koin.core.qualifier.TypeQualifier
 import org.koin.core.qualifier._q
 import org.koin.core.scope.Scope
 import org.koin.core.scope.ScopeID
@@ -55,7 +56,7 @@ class ScopeRegistry(private val _koin: Koin) {
     }
 
     @PublishedApi
-    internal fun createScope(scopeId: ScopeID, qualifier: Qualifier, source: Any? = null): Scope {
+    internal fun createScope(scopeId: ScopeID, qualifier: Qualifier, source: Any? = null,scopeArchetype : TypeQualifier? = null): Scope {
         _koin.logger.debug("| (+) Scope - id:'$scopeId' q:'$qualifier'")
         if (!_scopeDefinitions.contains(qualifier)) {
             _koin.logger.debug("| Scope '$qualifier' not defined. Creating it ...")
@@ -64,7 +65,7 @@ class ScopeRegistry(private val _koin: Koin) {
         if (_scopes.contains(scopeId)) {
             throw ScopeAlreadyCreatedException("Scope with id '$scopeId' is already created")
         }
-        val scope = Scope(qualifier, scopeId, _koin = _koin)
+        val scope = Scope(qualifier, scopeId, _koin = _koin, scopeArchetype = scopeArchetype)
         source?.let {
             _koin.logger.debug("|- Scope source set id:'$scopeId' -> $source")
             scope.sourceValue = source

--- a/projects/core/koin-core/src/commonTest/kotlin/org/koin/core/ScopeArchetypeTest.kt
+++ b/projects/core/koin-core/src/commonTest/kotlin/org/koin/core/ScopeArchetypeTest.kt
@@ -1,0 +1,83 @@
+package org.koin.core
+
+import org.koin.core.annotation.KoinExperimentalAPI
+import org.koin.core.annotation.KoinInternalApi
+import org.koin.core.component.getScopeId
+import org.koin.core.logger.Level
+import org.koin.core.module.KoinDslMarker
+import org.koin.core.module.Module
+import org.koin.core.qualifier.TypeQualifier
+import org.koin.dsl.ScopeDSL
+import org.koin.dsl.koinApplication
+import org.koin.dsl.module
+import kotlin.reflect.KType
+import kotlin.reflect.typeOf
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class ScopeArchetypeTest {
+
+    open class Archetype
+    class ArchetypeExt : Archetype()
+    class ClassA
+
+    @KoinDslMarker
+    @OptIn(KoinInternalApi::class, KoinExperimentalAPI::class)
+    fun Module.scopeArchetype(scopeSet: ScopeDSL.() -> Unit){
+        val qualifier = TypeQualifier(Archetype::class)
+        ScopeDSL(qualifier, this).apply(scopeSet)
+    }
+
+    @OptIn(KoinInternalApi::class)
+    @Test
+    fun moduleArchetypeData(){
+        val scopeModule = module {
+            scopeArchetype {
+                scoped { ClassA() }
+            }
+        }
+        assertEquals(
+            scopeModule.mappings.values.first().beanDefinition.scopeQualifier, TypeQualifier(Archetype::class)
+        )
+    }
+
+    @Test
+    fun declareAndRunArchetype(){
+        val scopeModule = module {
+            scopeArchetype {
+                scoped { ClassA() }
+            }
+        }
+        val koin = koinApplication {
+            printLogger(Level.DEBUG)
+            modules(scopeModule)
+        }.koin
+
+        val archetypeExt = ArchetypeExt()
+        val scope = koin.createScope<ArchetypeExt>(archetypeExt.getScopeId(), archetypeExt,
+            TypeQualifier(Archetype::class))
+
+        val a = scope.getOrNull<ClassA>()
+        assertNotNull(a)
+    }
+
+    @Test
+    fun declareAndRunArchetypeWithoutSource(){
+        val scopeModule = module {
+            scopeArchetype {
+                scoped { ClassA() }
+            }
+        }
+        val koin = koinApplication {
+            printLogger(Level.DEBUG)
+            modules(scopeModule)
+        }.koin
+
+        val archetypeExt = ArchetypeExt()
+        val scope = koin.createScope<Archetype>(archetypeExt.getScopeId(), scopeArchetype = TypeQualifier(Archetype::class))
+
+        val a = scope.getOrNull<ClassA>()
+        assertNotNull(a)
+    }
+}

--- a/projects/gradle.properties
+++ b/projects/gradle.properties
@@ -19,7 +19,7 @@ org.jetbrains.compose.experimental.macos.enabled=true
 
 #Android
 android.useAndroidX=true
-androidMinSDK=14
-androidCompileSDK=34
+androidMinSDK=21
+androidCompileSDK=35
 android.nonTransitiveRClass=true
 

--- a/projects/gradle.properties
+++ b/projects/gradle.properties
@@ -11,7 +11,7 @@ kotlin.incremental.multiplatform=true
 kotlin.code.style=official
 
 #Koin
-koinVersion=4.1.0-Beta6
+koinVersion=4.1.0-Beta7
 
 #Compose
 org.jetbrains.compose.experimental.jscanvas.enabled=true

--- a/projects/gradle/libs.versions.toml
+++ b/projects/gradle/libs.versions.toml
@@ -11,7 +11,7 @@ dokka = "1.9.20"
 uuid = "0.8.4"
 
 # Android
-agp = "7.4.2"
+agp = "8.3.0"
 android-appcompat = "1.7.0"
 android-activity = "1.10.1"
 android-fragment = "1.8.6"
@@ -34,6 +34,7 @@ junit = "4.13.2"
 jupiter = "5.11.3"
 mockito = "4.8.0"
 mockk = "1.13.2"
+robolectric = "4.14.1"
 # Ktor
 ktor = "2.3.12" #to be removed after Koin 4.1
 ktor3 = "3.1.1"
@@ -55,6 +56,7 @@ test-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", ve
 test-jupiter = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "jupiter" }
 test-mockito = { module = "org.mockito:mockito-inline", version.ref = "mockito" }
 test-mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
+test-robolectric = {module = "org.robolectric:robolectric", version.ref = "robolectric"}
 # Android
 android-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "android-appcompat" }
 android-activity = { module = "androidx.activity:activity-ktx", version.ref = "android-activity" }

--- a/projects/gradle/wrapper/gradle-wrapper.properties
+++ b/projects/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Jan 15 18:40:40 CET 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
As new feature, you can now declare scope by archetype: you don't require to define a scope against a type but against an "archetype". You can declare a scope for "Activity", "Fragment" and "ViewModel":

```kotlin

module {
 activityScope {
  // scoped instances for an An activity
 }

 activityRetainedScope {
  // scoped instances for an An activity, retained scope
 }

 fragmentScope {
  // scoped instances for Fragment
 }

 viewModelScope {
  // scoped instances for ViewModel
 }
}
```

This will help reuse instances in between scopes easily. No need to use a specific type like `scope<>{ }`, apart if you need scope on a precise object.

Use the regular `activityScope()`, `activityRetainedScope()` and `fragmentScope()` delegates function to create API. Those will trigger scope archetypes. Also you can use Koin's `ScopeActivity` or `ScopeFragment` classes.

For ViewModel's scope, you can use `ScopeViewModel` class, or deal yourself with the API and `viewModelScope()` function:

```kotlin
class MyViewModel : ViewModel(), KoinScopeComponent {

    override val scope: Scope = viewModelScope()

    override fun onCleared() {
        // Close Koin scope here
        scope.close()
     
        super.onCleared()
    }
}
```