### PR TITLE
Update Compose Multiplatform to 1.8.0-rc01

### DIFF
--- a/projects/compose/koin-compose-viewmodel-navigation/build.gradle.kts
+++ b/projects/compose/koin-compose-viewmodel-navigation/build.gradle.kts
@@ -1,8 +1,5 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-
 plugins {
+    alias(libs.plugins.androidLibrary)
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.jetbrainsCompose)
     alias(libs.plugins.compose.compiler)
@@ -12,9 +9,17 @@ val koinVersion: String by project
 version = koinVersion
 
 kotlin {
-    
+    androidTarget {
+        publishLibraryVariants("release")
+        compilations.all {
+            kotlinOptions.jvmTarget = "1.8"
+        }
+    }
+
     jvm {
-        withJava()
+        compilations.all {
+            kotlinOptions.jvmTarget = "11"
+        }
     }
 
     js(IR) {
@@ -37,16 +42,16 @@ kotlin {
     sourceSets {
         commonMain.dependencies {
             api(project(":compose:koin-compose-viewmodel"))
-//            api(project(":core:koin-core-viewmodel-navigation"))
             api(libs.jb.composeNavigation)
         }
     }
 }
 
-tasks.withType<KotlinCompile>().all {
-    compilerOptions {
-        jvmTarget.set(JvmTarget.JVM_1_8)
-    }
+val androidCompileSDK: String by project
+
+android {
+    namespace = "org.koin.compose.viewmodel.navigation"
+    compileSdk = androidCompileSDK.toInt()
 }
 
 tasks.withType<org.jetbrains.kotlin.gradle.targets.js.npm.tasks.KotlinNpmInstallTask>().configureEach {

--- a/projects/compose/koin-compose-viewmodel/build.gradle.kts
+++ b/projects/compose/koin-compose-viewmodel/build.gradle.kts
@@ -1,8 +1,5 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-
 plugins {
+    alias(libs.plugins.androidLibrary)
     alias(libs.plugins.kotlinMultiplatform)
     alias(libs.plugins.jetbrainsCompose)
     alias(libs.plugins.compose.compiler)
@@ -12,9 +9,17 @@ val koinVersion: String by project
 version = koinVersion
 
 kotlin {
-    
+    androidTarget {
+        publishLibraryVariants("release")
+        compilations.all {
+            kotlinOptions.jvmTarget = "1.8"
+        }
+    }
+
     jvm {
-        withJava()
+        compilations.all {
+            kotlinOptions.jvmTarget = "11"
+        }
     }
 
     js(IR) {
@@ -43,10 +48,11 @@ kotlin {
     }
 }
 
-tasks.withType<KotlinCompile>().all {
-    compilerOptions {
-        jvmTarget.set(JvmTarget.JVM_1_8)
-    }
+val androidCompileSDK: String by project
+
+android {
+    namespace = "org.koin.compose.viewmodel"
+    compileSdk = androidCompileSDK.toInt()
 }
 
 tasks.withType<org.jetbrains.kotlin.gradle.targets.js.npm.tasks.KotlinNpmInstallTask>().configureEach {

--- a/projects/compose/koin-compose/build.gradle.kts
+++ b/projects/compose/koin-compose/build.gradle.kts
@@ -1,9 +1,3 @@
-import org.gradle.kotlin.dsl.android
-import org.gradle.kotlin.dsl.api
-import org.gradle.kotlin.dsl.jvm
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-
 plugins {
     alias(libs.plugins.androidLibrary)
     alias(libs.plugins.kotlinMultiplatform)
@@ -15,10 +9,17 @@ val koinVersion: String by project
 version = koinVersion
 
 kotlin {
-    
-    jvm()
     androidTarget {
         publishLibraryVariants("release")
+        compilations.all {
+            kotlinOptions.jvmTarget = "1.8"
+        }
+    }
+
+    jvm {
+        compilations.all {
+            kotlinOptions.jvmTarget = "11"
+        }
     }
 
     js(IR) {
@@ -73,12 +74,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
-    }
-}
-
-tasks.withType<KotlinCompile>().all {
-    compilerOptions {
-        jvmTarget.set(JvmTarget.JVM_1_8)
     }
 }
 

--- a/projects/gradle/libs.versions.toml
+++ b/projects/gradle/libs.versions.toml
@@ -22,9 +22,9 @@ androidx-startup= "1.2.0"
 
 # Compose
 composeJetpackRuntime = "1.7.8"
-composeJB = "1.7.3"
+composeJB = "1.8.0-rc01"
 composeLifecycle = "2.8.4"
-composeNavigation = "2.8.0-alpha10" # 2.8.0-alpha02 to keep compose 1.6.11
+composeNavigation = "2.9.0-alpha17"
 jbCoreBundle = "1.0.1"
 jbSavedState = "1.2.2"
 


### PR DESCRIPTION
Fixes #2175

CMP 1.8 requires Java 11 bytecode for the desktop target, so in modules where it's used, I've updated the configuration to keep using Java 8 for Android while bumping the JVM target to 11.

I'm not sure why the Android target wasn't added to those KMP libraries before - please review if those changes make sense or not.