### PR TITLE
Feat - AutoCloseable usage for VM Scope closure  + ViewModel Scope creation at VM Factory (ctor injection) + Options activation

### DIFF
--- a/examples/androidx-samples/src/main/java/org/koin/sample/sandbox/MainApplication.kt
+++ b/examples/androidx-samples/src/main/java/org/koin/sample/sandbox/MainApplication.kt
@@ -14,6 +14,7 @@ import org.koin.androidx.workmanager.koin.workManagerFactory
 import org.koin.core.context.GlobalContext.startKoin
 import org.koin.core.lazyModules
 import org.koin.core.logger.Level
+import org.koin.core.option.viewModelScopeFactory
 import org.koin.core.waitAllStartJobs
 import org.koin.dsl.KoinConfiguration
 import org.koin.dsl.koinConfiguration
@@ -66,6 +67,9 @@ class MainApplication : Application() {
             workManagerFactory()
 //            lazyModules(allModules, dispatcher = IO)
             modules(allModules)
+            options(
+                viewModelScopeFactory()
+            )
         }
 
         //TODO Load/Unload Koin modules scenario cases

--- a/examples/androidx-samples/src/main/java/org/koin/sample/sandbox/MainApplication.kt
+++ b/examples/androidx-samples/src/main/java/org/koin/sample/sandbox/MainApplication.kt
@@ -67,8 +67,9 @@ class MainApplication : Application() {
             workManagerFactory()
 //            lazyModules(allModules, dispatcher = IO)
             modules(allModules)
+
             options(
-//                viewModelScopeFactory()
+                viewModelScopeFactory()
             )
         }
 

--- a/examples/androidx-samples/src/main/java/org/koin/sample/sandbox/MainApplication.kt
+++ b/examples/androidx-samples/src/main/java/org/koin/sample/sandbox/MainApplication.kt
@@ -68,7 +68,7 @@ class MainApplication : Application() {
 //            lazyModules(allModules, dispatcher = IO)
             modules(allModules)
             options(
-                viewModelScopeFactory()
+//                viewModelScopeFactory()
             )
         }
 

--- a/examples/androidx-samples/src/main/java/org/koin/sample/sandbox/components/mvvm/MyScopeViewModel.kt
+++ b/examples/androidx-samples/src/main/java/org/koin/sample/sandbox/components/mvvm/MyScopeViewModel.kt
@@ -1,18 +1,14 @@
 package org.koin.sample.sandbox.components.mvvm
 
 import androidx.lifecycle.ViewModel
-import org.koin.core.component.KoinScopeComponent
-import org.koin.core.component.inject
-import org.koin.core.scope.Scope
 import org.koin.sample.sandbox.components.scope.Session
-import org.koin.viewmodel.scope.viewModelScope
 
 // use ViewModelScopeFactory
-//class MyScopeViewModel(val session: Session) : ViewModel()
+class MyScopeViewModel(val session: Session) : ViewModel()
 
 // not using Archetype here
-class MyScopeViewModel : ViewModel(), KoinScopeComponent {
-
-    override val scope: Scope = viewModelScope()
-    val session by inject<Session>()
-}
+//class MyScopeViewModel : ViewModel(), KoinScopeComponent {
+//
+//    override val scope: Scope = viewModelScope()
+//    val session by inject<Session>()
+//}

--- a/examples/androidx-samples/src/main/java/org/koin/sample/sandbox/components/mvvm/MyScopeViewModel.kt
+++ b/examples/androidx-samples/src/main/java/org/koin/sample/sandbox/components/mvvm/MyScopeViewModel.kt
@@ -1,19 +1,18 @@
 package org.koin.sample.sandbox.components.mvvm
 
 import androidx.lifecycle.ViewModel
+import org.koin.core.component.KoinScopeComponent
+import org.koin.core.component.inject
+import org.koin.core.scope.Scope
 import org.koin.sample.sandbox.components.scope.Session
+import org.koin.viewmodel.scope.viewModelScope
 
 // use ViewModelScopeFactory
-class MyScopeViewModel(val session: Session) : ViewModel()
+//class MyScopeViewModel(val session: Session) : ViewModel()
 
 // not using Archetype here
-//class MyScopeViewModel(val session: Session) : ViewModel(), KoinScopeComponent {
-//
-//    override val scope: Scope = createScope(this)
-//    val session by inject<Session>()
-//
-//    override fun onCleared() {
-//        super.onCleared()
-//        scope.close()
-//    }
-//}
+class MyScopeViewModel : ViewModel(), KoinScopeComponent {
+
+    override val scope: Scope = viewModelScope()
+    val session by inject<Session>()
+}

--- a/examples/androidx-samples/src/main/java/org/koin/sample/sandbox/components/mvvm/MyScopeViewModel.kt
+++ b/examples/androidx-samples/src/main/java/org/koin/sample/sandbox/components/mvvm/MyScopeViewModel.kt
@@ -1,20 +1,19 @@
 package org.koin.sample.sandbox.components.mvvm
 
 import androidx.lifecycle.ViewModel
-import org.koin.core.component.KoinScopeComponent
-import org.koin.core.component.createScope
-import org.koin.core.component.inject
-import org.koin.core.scope.Scope
 import org.koin.sample.sandbox.components.scope.Session
 
+// use ViewModelScopeFactory
+class MyScopeViewModel(val session: Session) : ViewModel()
+
 // not using Archetype here
-class MyScopeViewModel : ViewModel(), KoinScopeComponent {
-
-    override val scope: Scope = createScope(this)
-    val session by inject<Session>()
-
-    override fun onCleared() {
-        super.onCleared()
-        scope.close()
-    }
-}
+//class MyScopeViewModel(val session: Session) : ViewModel(), KoinScopeComponent {
+//
+//    override val scope: Scope = createScope(this)
+//    val session by inject<Session>()
+//
+//    override fun onCleared() {
+//        super.onCleared()
+//        scope.close()
+//    }
+//}

--- a/examples/androidx-samples/src/main/java/org/koin/sample/sandbox/di/AppModule.kt
+++ b/examples/androidx-samples/src/main/java/org/koin/sample/sandbox/di/AppModule.kt
@@ -83,17 +83,18 @@ val mvvmModule = module {
     // viewModel<AbstractViewModel> { ViewModelImpl(get()) }
     viewModelOf(::ViewModelImpl) { bind<AbstractViewModel>() }
 
-    viewModelOf(::MyScopeViewModel)
     viewModelOf(::MyScopeViewModel2)
 
     viewModelScope {
+        viewModelOf(::MyScopeViewModel)
         scopedOf(::Session)
         scopedOf(::SessionConsumer)
     }
 
-    scope<MyScopeViewModel> {
-        scopedOf(::Session)
-    }
+//    scope<MyScopeViewModel> {
+//        scopedOf(::Session)
+//    }
+
 //
 //    scope<MyScopeViewModel2> {
 //        scopedOf(::Session)

--- a/examples/androidx-samples/src/main/java/org/koin/sample/sandbox/di/AppModule.kt
+++ b/examples/androidx-samples/src/main/java/org/koin/sample/sandbox/di/AppModule.kt
@@ -84,9 +84,12 @@ val mvvmModule = module {
     viewModelOf(::ViewModelImpl) { bind<AbstractViewModel>() }
 
     viewModelOf(::MyScopeViewModel2)
-    viewModelOf(::MyScopeViewModel)
+
+    // uses viewModelScopeFactory
+//    viewModelOf(::MyScopeViewModel)
 
     viewModelScope {
+        viewModelOf(::MyScopeViewModel)
         scopedOf(::Session)
         scopedOf(::SessionConsumer)
     }

--- a/examples/androidx-samples/src/main/java/org/koin/sample/sandbox/di/AppModule.kt
+++ b/examples/androidx-samples/src/main/java/org/koin/sample/sandbox/di/AppModule.kt
@@ -84,9 +84,9 @@ val mvvmModule = module {
     viewModelOf(::ViewModelImpl) { bind<AbstractViewModel>() }
 
     viewModelOf(::MyScopeViewModel2)
+    viewModelOf(::MyScopeViewModel)
 
     viewModelScope {
-        viewModelOf(::MyScopeViewModel)
         scopedOf(::Session)
         scopedOf(::SessionConsumer)
     }

--- a/examples/androidx-samples/src/main/java/org/koin/sample/sandbox/mvvm/MVVMActivity.kt
+++ b/examples/androidx-samples/src/main/java/org/koin/sample/sandbox/mvvm/MVVMActivity.kt
@@ -80,7 +80,7 @@ class MVVMActivity : ScopeActivity(contentLayoutId = R.layout.mvvm_activity) {
         assert(p1.ctx == this)
         assert(p2.ctx == getKoin().get<Application>())
 
-        assert(scopeVm1.session.id == scopeVm1.scope.get<Session>().id)
+//        assert(scopeVm1.session.id == scopeVm1.scope.get<Session>().id)
         assert(scopeVm2.session.id == scopeVm2.scope.get<Session>().id)
         assert(scopeVm2.scope.get<SessionConsumer>().getSessionId() == scopeVm2.scope.get<Session>().id)
         assert(scopeVm1.session.id != scopeVm2.session.id)

--- a/projects/core/koin-core-viewmodel/api/koin-core-viewmodel.api
+++ b/projects/core/koin-core-viewmodel/api/koin-core-viewmodel.api
@@ -29,16 +29,22 @@ public final class org/koin/viewmodel/factory/KoinViewModelFactory : androidx/li
 	public fun create (Lkotlin/reflect/KClass;Landroidx/lifecycle/viewmodel/CreationExtras;)Landroidx/lifecycle/ViewModel;
 }
 
+public final class org/koin/viewmodel/factory/ViewModelScopeAutoCloseable : java/lang/AutoCloseable {
+	public fun <init> (Ljava/lang/String;Lorg/koin/core/Koin;)V
+	public fun close ()V
+	public final fun getKoin ()Lorg/koin/core/Koin;
+	public final fun getScopeId ()Ljava/lang/String;
+}
+
 public abstract class org/koin/viewmodel/scope/ScopeViewModel : androidx/lifecycle/ViewModel, org/koin/core/component/KoinScopeComponent {
 	public fun <init> ()V
 	public fun getKoin ()Lorg/koin/core/Koin;
 	public fun getScope ()Lorg/koin/core/scope/Scope;
-	protected fun onCleared ()V
 	public fun onCloseScope ()V
 }
 
 public final class org/koin/viewmodel/scope/ScopeViewModelKt {
-	public static final fun viewModelScope (Landroidx/lifecycle/ViewModel;Lorg/koin/core/component/KoinScopeComponent;)Lorg/koin/core/scope/Scope;
+	public static final fun viewModelScope (Lorg/koin/core/component/KoinScopeComponent;)Lorg/koin/core/scope/Scope;
 }
 
 public final class org/koin/viewmodel/scope/ViewModelScopeArchetypeDSLKt {

--- a/projects/core/koin-core-viewmodel/src/commonMain/kotlin/org/koin/viewmodel/factory/KoinViewModelFactory.kt
+++ b/projects/core/koin-core-viewmodel/src/commonMain/kotlin/org/koin/viewmodel/factory/KoinViewModelFactory.kt
@@ -24,6 +24,7 @@ import org.koin.core.parameter.ParametersDefinition
 import org.koin.core.qualifier.Qualifier
 import org.koin.core.qualifier.TypeQualifier
 import org.koin.core.scope.Scope
+import org.koin.core.scope.ScopeID
 import org.koin.mp.KoinPlatformTools
 import org.koin.mp.generateId
 import org.koin.viewmodel.scope.ViewModelScopeArchetype
@@ -47,11 +48,15 @@ class KoinViewModelFactory(
         return if (!koin.optionRegistry.hasViewModelScopeFactory()){
             scope.getWithParameters(kClass, qualifier, androidParams)
         } else {
-            val scopeId = "${modelClass.simpleName}-${KoinPlatformTools.generateId()}"
+            val scopeId = getViewModelScopeId(modelClass)
             val vmScope = koin.createScope(scopeId, TypeQualifier(modelClass), null, ViewModelScopeArchetype)
             val vm : T = vmScope.getWithParameters(kClass, qualifier, androidParams)
             vm.addCloseable(ViewModelScopeAutoCloseable(scopeId,koin))
             vm
         }
     }
+
+    @KoinInternalApi
+    private fun <T : ViewModel> getViewModelScopeId(modelClass: KClass<T>) : ScopeID = "${modelClass.simpleName}-${KoinPlatformTools.generateId()}"
 }
+

--- a/projects/core/koin-core-viewmodel/src/commonMain/kotlin/org/koin/viewmodel/factory/KoinViewModelFactory.kt
+++ b/projects/core/koin-core-viewmodel/src/commonMain/kotlin/org/koin/viewmodel/factory/KoinViewModelFactory.kt
@@ -19,9 +19,14 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewmodel.CreationExtras
 import org.koin.core.annotation.KoinInternalApi
+import org.koin.core.option.hasViewModelScopeFactory
 import org.koin.core.parameter.ParametersDefinition
 import org.koin.core.qualifier.Qualifier
+import org.koin.core.qualifier.TypeQualifier
 import org.koin.core.scope.Scope
+import org.koin.mp.KoinPlatformTools
+import org.koin.mp.generateId
+import org.koin.viewmodel.scope.ViewModelScopeArchetype
 import kotlin.reflect.KClass
 
 /**
@@ -38,6 +43,15 @@ class KoinViewModelFactory(
     @OptIn(KoinInternalApi::class)
     override fun <T : ViewModel> create(modelClass: KClass<T>, extras: CreationExtras): T {
         val androidParams = AndroidParametersHolder(params, extras)
-        return scope.getWithParameters(kClass, qualifier, androidParams)
+        val koin = scope.getKoin()
+        return if (!koin.optionRegistry.hasViewModelScopeFactory()){
+            scope.getWithParameters(kClass, qualifier, androidParams)
+        } else {
+            val scopeId = "${modelClass.simpleName}-${KoinPlatformTools.generateId()}"
+            val vmScope = koin.createScope(scopeId, TypeQualifier(modelClass), null, ViewModelScopeArchetype)
+            val vm : T = vmScope.getWithParameters(kClass, qualifier, androidParams)
+            vm.addCloseable(ViewModelScopeAutoCloseable(scopeId,koin))
+            vm
+        }
     }
 }

--- a/projects/core/koin-core-viewmodel/src/commonMain/kotlin/org/koin/viewmodel/factory/ViewModelScopeAutoCloseable.kt
+++ b/projects/core/koin-core-viewmodel/src/commonMain/kotlin/org/koin/viewmodel/factory/ViewModelScopeAutoCloseable.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017-Present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.koin.viewmodel.factory
+
+import org.koin.core.Koin
+import org.koin.core.annotation.KoinInternalApi
+import org.koin.core.scope.ScopeID
+
+/**
+ * AutoCloseable for ViewModel's scope closure
+ * Help support on the fly ViewModel scope creation
+ *
+ * @author Arnaud Giuliani
+ */
+@KoinInternalApi
+class ViewModelScopeAutoCloseable(val scopeId : ScopeID, val koin : Koin) : AutoCloseable {
+    override fun close() {
+        koin.deleteScope(scopeId)
+    }
+}

--- a/projects/core/koin-core-viewmodel/src/commonMain/kotlin/org/koin/viewmodel/scope/ScopeViewModel.kt
+++ b/projects/core/koin-core-viewmodel/src/commonMain/kotlin/org/koin/viewmodel/scope/ScopeViewModel.kt
@@ -60,7 +60,7 @@ fun KoinScopeComponent.viewModelScope() : Scope {
     }
     val koin = getKoin()
     if (koin.optionRegistry.hasViewModelScopeFactory()){
-        koin.logger.warn("${this::class} is using viewModelScope() while you are using viewModelScopeFactory() option. Remove viewModelScope() usage to use constructor injection in your ViewModel.")
+        koin.logger.warn("${this::class} is using viewModelScope() while you are using viewModelScopeFactory() option. Remove viewModelScope() usage to use ViewModel constructor injection with automatic scope creation.")
     }
     val vmScope = createScope(source = this, scopeArchetype = ViewModelScopeArchetype)
     addCloseable(ViewModelScopeAutoCloseable(vmScope.id,vmScope.getKoin()))

--- a/projects/core/koin-core-viewmodel/src/commonMain/kotlin/org/koin/viewmodel/scope/ScopeViewModel.kt
+++ b/projects/core/koin-core-viewmodel/src/commonMain/kotlin/org/koin/viewmodel/scope/ScopeViewModel.kt
@@ -41,6 +41,12 @@ import org.koin.viewmodel.factory.ViewModelScopeAutoCloseable
 abstract class ScopeViewModel : ViewModel(), KoinScopeComponent {
 
     override val scope: Scope = viewModelScope()
+
+    /**
+     * To override to add behavior before closing Scope
+     */
+    @Deprecated("Not used anymore. Now close scope automatically with ViewModelScopeAutoCloseable")
+    open fun onCloseScope(){}
 }
 
 /**
@@ -54,7 +60,7 @@ fun KoinScopeComponent.viewModelScope() : Scope {
     }
     val koin = getKoin()
     if (koin.optionRegistry.hasViewModelScopeFactory()){
-        koin.logger.warn("${this::class} is using viewModelScope(), while you are using ViewModelScope Factory.")
+        koin.logger.warn("${this::class} is using viewModelScope() while you are using viewModelScopeFactory() option. Remove viewModelScope() usage to use constructor injection in your ViewModel.")
     }
     val vmScope = createScope(source = this, scopeArchetype = ViewModelScopeArchetype)
     addCloseable(ViewModelScopeAutoCloseable(vmScope.id,vmScope.getKoin()))

--- a/projects/core/koin-core/api/koin-core.api
+++ b/projects/core/koin-core/api/koin-core.api
@@ -18,6 +18,7 @@ public final class org/koin/core/Koin {
 	public final fun getExtensionManager ()Lorg/koin/core/extension/ExtensionManager;
 	public final fun getInstanceRegistry ()Lorg/koin/core/registry/InstanceRegistry;
 	public final fun getLogger ()Lorg/koin/core/logger/Logger;
+	public final fun getOptionRegistry ()Lorg/koin/core/registry/OptionRegistry;
 	public final fun getOrCreateScope (Ljava/lang/String;Lorg/koin/core/qualifier/Qualifier;Ljava/lang/Object;)Lorg/koin/core/scope/Scope;
 	public static synthetic fun getOrCreateScope$default (Lorg/koin/core/Koin;Ljava/lang/String;Lorg/koin/core/qualifier/Qualifier;Ljava/lang/Object;ILjava/lang/Object;)Lorg/koin/core/scope/Scope;
 	public final fun getOrNull (Lkotlin/reflect/KClass;Lorg/koin/core/qualifier/Qualifier;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
@@ -45,6 +46,7 @@ public final class org/koin/core/KoinApplication {
 	public final fun modules (Ljava/util/List;)Lorg/koin/core/KoinApplication;
 	public final fun modules (Lorg/koin/core/module/Module;)Lorg/koin/core/KoinApplication;
 	public final fun modules ([Lorg/koin/core/module/Module;)Lorg/koin/core/KoinApplication;
+	public final fun options ([Lkotlin/Pair;)Lorg/koin/core/KoinApplication;
 	public final fun printLogger (Lorg/koin/core/logger/Level;)Lorg/koin/core/KoinApplication;
 	public static synthetic fun printLogger$default (Lorg/koin/core/KoinApplication;Lorg/koin/core/logger/Level;ILjava/lang/Object;)Lorg/koin/core/KoinApplication;
 	public final fun properties (Ljava/util/Map;)Lorg/koin/core/KoinApplication;
@@ -412,6 +414,18 @@ public final class org/koin/core/module/dsl/OptionDSLKt {
 	public static final fun withOptions (Lorg/koin/core/definition/KoinDefinition;Lkotlin/jvm/functions/Function1;)Lorg/koin/core/definition/KoinDefinition;
 }
 
+public final class org/koin/core/option/KoinOption : java/lang/Enum {
+	public static final field VIEWMODEL_SCOPE_FACTORY Lorg/koin/core/option/KoinOption;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lorg/koin/core/option/KoinOption;
+	public static fun values ()[Lorg/koin/core/option/KoinOption;
+}
+
+public final class org/koin/core/option/KoinOptionKt {
+	public static final fun hasViewModelScopeFactory (Lorg/koin/core/registry/OptionRegistry;)Z
+	public static final fun viewModelScopeFactory ()Lkotlin/Pair;
+}
+
 public class org/koin/core/parameter/ParametersHolder {
 	public fun <init> ()V
 	public fun <init> (Ljava/util/List;Ljava/lang/Boolean;)V
@@ -483,6 +497,10 @@ public final class org/koin/core/registry/InstanceRegistry {
 	public final fun saveMapping (ZLjava/lang/String;Lorg/koin/core/instance/InstanceFactory;Z)V
 	public static synthetic fun saveMapping$default (Lorg/koin/core/registry/InstanceRegistry;ZLjava/lang/String;Lorg/koin/core/instance/InstanceFactory;ZILjava/lang/Object;)V
 	public final fun size ()I
+}
+
+public final class org/koin/core/registry/OptionRegistry {
+	public fun <init> ()V
 }
 
 public final class org/koin/core/registry/PropertyRegistry {

--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/Koin.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/Koin.kt
@@ -29,6 +29,7 @@ import org.koin.core.parameter.ParametersDefinition
 import org.koin.core.qualifier.Qualifier
 import org.koin.core.qualifier.TypeQualifier
 import org.koin.core.registry.InstanceRegistry
+import org.koin.core.registry.OptionRegistry
 import org.koin.core.registry.PropertyRegistry
 import org.koin.core.registry.ScopeRegistry
 import org.koin.core.scope.Scope
@@ -60,6 +61,9 @@ class Koin {
 
     @KoinInternalApi
     val extensionManager = ExtensionManager(this)
+
+    @KoinInternalApi
+    val optionRegistry = OptionRegistry()
 
     @KoinInternalApi
     var logger: Logger = EmptyLogger()

--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/KoinApplication.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/KoinApplication.kt
@@ -15,11 +15,13 @@
  */
 package org.koin.core
 
+import org.koin.core.annotation.KoinExperimentalAPI
 import org.koin.core.annotation.KoinInternalApi
 import org.koin.core.logger.Level
 import org.koin.core.logger.Logger
 import org.koin.core.module.KoinApplicationDslMarker
 import org.koin.core.module.Module
+import org.koin.core.option.KoinOption
 import org.koin.core.time.inMs
 import org.koin.mp.KoinPlatformTools
 import kotlin.time.measureTime
@@ -94,6 +96,17 @@ class KoinApplication private constructor() {
      */
     fun properties(values: Map<String, Any>): KoinApplication {
         koin.propertyRegistry.saveProperties(values)
+        return this
+    }
+
+    /**
+     * Activate Koin Feature Flag options
+     *
+     * @see KoinOption for available options
+     */
+    @KoinExperimentalAPI
+    fun options(vararg optionValue : Pair<KoinOption,Any>): KoinApplication {
+        koin.optionRegistry.setValues(optionValue.toMap())
         return this
     }
 

--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/option/KoinOption.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/option/KoinOption.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017-Present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.koin.core.option
+
+import org.koin.core.annotation.KoinExperimentalAPI
+import org.koin.core.annotation.KoinInternalApi
+import org.koin.core.registry.OptionRegistry
+
+/**
+ * Koin Options to be activated
+ */
+@KoinExperimentalAPI
+enum class KoinOption {
+    VIEWMODEL_SCOPE_FACTORY
+}
+
+@KoinExperimentalAPI
+fun viewModelScopeFactory(): Pair<KoinOption, Boolean> {
+    return KoinOption.VIEWMODEL_SCOPE_FACTORY to true
+}
+
+@OptIn(KoinExperimentalAPI::class)
+@KoinInternalApi
+fun OptionRegistry.hasViewModelScopeFactory() : Boolean = getOrNull<Boolean>(KoinOption.VIEWMODEL_SCOPE_FACTORY) == true

--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/registry/OptionRegistry.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/registry/OptionRegistry.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017-Present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.koin.core.registry
+
+import org.koin.core.annotation.KoinExperimentalAPI
+import org.koin.core.annotation.KoinInternalApi
+import org.koin.core.option.KoinOption
+
+/**
+ * Handle Default Flags values to let feature flag Koin parts
+ *
+ * @author Arnaud Giuliani
+ */
+@OptIn(KoinExperimentalAPI::class)
+@KoinInternalApi
+class OptionRegistry {
+
+    private val options = hashMapOf<KoinOption,Any>()
+
+    fun setValues(values: Map<KoinOption, Any>) {
+        options.putAll(values)
+    }
+
+    fun <T> getOrNull(op : KoinOption) : T?{
+        return options[op] as? T
+    }
+
+    fun <T> getOrDefault(op : KoinOption, default : T) : T{
+        return getOrNull<T>(op) as? T ?: default
+    }
+}

--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/registry/OptionRegistry.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/registry/OptionRegistry.kt
@@ -30,15 +30,15 @@ class OptionRegistry {
 
     private val options = hashMapOf<KoinOption,Any>()
 
-    fun setValues(values: Map<KoinOption, Any>) {
+    internal fun setValues(values: Map<KoinOption, Any>) {
         options.putAll(values)
     }
 
-    fun <T> getOrNull(op : KoinOption) : T?{
+    internal fun <T> getOrNull(op : KoinOption) : T?{
         return options[op] as? T
     }
 
-    fun <T> getOrDefault(op : KoinOption, default : T) : T{
+    internal fun <T> getOrDefault(op : KoinOption, default : T) : T{
         return getOrNull<T>(op) as? T ?: default
     }
 }

--- a/projects/core/koin-core/src/commonTest/kotlin/org/koin/core/KoinOptionsTest.kt
+++ b/projects/core/koin-core/src/commonTest/kotlin/org/koin/core/KoinOptionsTest.kt
@@ -1,0 +1,50 @@
+package org.koin.core
+
+import org.koin.core.annotation.KoinExperimentalAPI
+import org.koin.core.annotation.KoinInternalApi
+import org.koin.core.option.KoinOption
+import org.koin.core.option.hasViewModelScopeFactory
+import org.koin.core.option.viewModelScopeFactory
+import org.koin.dsl.koinApplication
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@OptIn(KoinExperimentalAPI::class, KoinInternalApi::class)
+class KoinOptionsTest {
+
+    @Test
+    fun has_no_koin_flag(){
+
+        val koin = koinApplication {
+        }.koin
+
+        assertNull(koin.optionRegistry.getOrNull<Boolean>(KoinOption.VIEWMODEL_SCOPE_FACTORY))
+        assertFalse(koin.optionRegistry.hasViewModelScopeFactory())
+    }
+
+    @Test
+    fun has_no_koin_flag_empty(){
+
+        val koin = koinApplication {
+            options()
+        }.koin
+
+        assertNull(koin.optionRegistry.getOrNull<Boolean>(KoinOption.VIEWMODEL_SCOPE_FACTORY))
+        assertFalse(koin.optionRegistry.hasViewModelScopeFactory())
+    }
+
+    @Test
+    fun can_set_koin_flag(){
+
+        val koin = koinApplication {
+            options(
+                viewModelScopeFactory()
+            )
+        }.koin
+
+        assertTrue(koin.optionRegistry.getOrNull<Boolean>(KoinOption.VIEWMODEL_SCOPE_FACTORY)!!)
+        assertTrue(koin.optionRegistry.hasViewModelScopeFactory())
+    }
+}


### PR DESCRIPTION
AutoCloseable usage for Scope closure 
- simplify `viewModelScope()` usage, by adding `ViewModelScopeAutoCloseable`
- no need anymore to close ViewModel scope by hand

---

Allow constructor injection from ViewModel's scope, created on the fly:
```kotlin
// will inject session from MyScopeViewModel's scope
class MyScopeViewModel(val session: Session) : ViewModel()
// close MyScopeViewModel's scope automatically

module {
    viewModelScope {
        viewModelOf(::MyScopeViewModel)
        scopedOf(::Session)
    }
}
```
Will require `ViewModel` class to be in `viewModelScope` section:


ViewModel Scope creation at VM Factory (ctor injection) can be activated as an option:
- with `options` in Koin, to activate VM scope creation from factory automatically, and allow VM scope ctor injection
- `viewModelScopeFactory` to activate the right flag

```kotlin
startKoin {

    options(
        // activate VM Scope creation from factory
        viewModelScopeFactory()
    )
}
```