### PR TITLE
Feat - New Compose Preview function to help local preview with parallel …

### DIFF
--- a/examples/sample-android-compose/src/main/java/org/koin/sample/androidx/compose/App.kt
+++ b/examples/sample-android-compose/src/main/java/org/koin/sample/androidx/compose/App.kt
@@ -1,5 +1,6 @@
 package org.koin.sample.androidx.compose
 
+import android.content.res.Configuration
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
@@ -9,17 +10,22 @@ import androidx.compose.material.Text
 import androidx.compose.material.TextField
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Devices
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import org.koin.androidx.compose.koinViewModel
 import org.koin.androidx.compose.scope.KoinActivityScope
+import org.koin.compose.KoinApplicationPreview
 import org.koin.compose.koinInject
 import org.koin.compose.module.rememberKoinModules
 import org.koin.compose.scope.KoinScope
+import org.koin.core.annotation.KoinExperimentalAPI
 import org.koin.core.parameter.parametersOf
 import org.koin.sample.androidx.compose.data.MyFactory
 import org.koin.sample.androidx.compose.data.MyInnerFactory
 import org.koin.sample.androidx.compose.data.MyScoped
 import org.koin.sample.androidx.compose.data.MySingle
+import org.koin.sample.androidx.compose.di.appModule
 import org.koin.sample.androidx.compose.di.secondModule
 import org.koin.sample.androidx.compose.viewmodel.SSHViewModel
 import org.koin.sample.androidx.compose.viewmodel.UserViewModel
@@ -79,6 +85,26 @@ fun MyScreen() {
         }
     }
 }
+@OptIn(KoinExperimentalAPI::class)
+@Preview(name = "1 - Pixel 2 XL", device = Devices.PIXEL_2_XL, locale = "en")
+@Preview(name = "2 - Pixel 5", device = Devices.PIXEL_5, locale = "en", uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Preview(name = "3 - Pixel 7 ", device = Devices.PIXEL_7, locale = "ru", uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+fun previewVMComposable(){
+    KoinApplicationPreview(application = { modules(appModule) }) {
+        ViewModelComposable()
+    }
+}
+
+@OptIn(KoinExperimentalAPI::class)
+@Preview(name = "3 - Pixel 7 ", device = Devices.PIXEL_7, locale = "ru", uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Preview(name = "4 - Pixel 7 Pro", device = Devices.PIXEL_7_PRO, locale = "fr")
+@Composable
+fun previewSingleComposable(){
+    KoinApplicationPreview(application = { modules(appModule) }) {
+        SingleComposable()
+    }
+}
 
 @Composable
 fun ViewModelComposable(
@@ -91,8 +117,8 @@ fun ViewModelComposable(
         clickComponent("ViewModel", myViewModel.id, parentStatus) {
             ButtonForCreate("-X- ViewModel") { created = !created }
         }
-        Text(text = "ViewModel - lastIds: " + myViewModel.lastIds)
-        myViewModel.saveId()
+//        Text(text = "ViewModel - lastIds: " + myViewModel.lastIds)
+//        myViewModel.saveId()
     } else {
         ButtonForCreate("(+) ViewModel") { created = !created }
     }

--- a/examples/sample-android-compose/src/main/java/org/koin/sample/androidx/compose/viewmodel/SSHViewModel.kt
+++ b/examples/sample-android-compose/src/main/java/org/koin/sample/androidx/compose/viewmodel/SSHViewModel.kt
@@ -7,15 +7,15 @@ import androidx.lifecycle.viewmodel.compose.SavedStateHandleSaveableApi
 import androidx.lifecycle.viewmodel.compose.saveable
 
 @OptIn(SavedStateHandleSaveableApi::class)
-class SSHViewModel(val id: String, private val savedStateHandle: SavedStateHandle) : ViewModel() {
+class SSHViewModel(val id: String,) : ViewModel() {
 
-    var lastIds by savedStateHandle.saveable {
-        mutableStateOf<Set<String>>(emptySet())
-    }
-
-    fun saveId(){
-        lastIds = lastIds + id
-    }
+//    var lastIds by savedStateHandle.saveable {
+//        mutableStateOf<Set<String>>(emptySet())
+//    }
+//
+//    fun saveId(){
+//        lastIds = lastIds + id
+//    }
 
     init {
         println("$this created '$id'")

--- a/projects/compose/koin-compose/src/commonMain/kotlin/org/koin/compose/KoinApplication.kt
+++ b/projects/compose/koin-compose/src/commonMain/kotlin/org/koin/compose/KoinApplication.kt
@@ -33,6 +33,7 @@ import org.koin.core.logger.Level
 import org.koin.core.scope.Scope
 import org.koin.dsl.KoinAppDeclaration
 import org.koin.dsl.KoinConfiguration
+import org.koin.dsl.koinApplication
 import org.koin.mp.KoinPlatform
 import org.koin.mp.KoinPlatformTools
 
@@ -199,6 +200,28 @@ fun KoinIsolatedContext(
     context: KoinApplication,
     content: @Composable () -> Unit
 ) {
+    CompositionLocalProvider(
+        LocalKoinApplication provides context.koin,
+        LocalKoinScope provides context.koin.scopeRegistry.rootScope,
+        content = content
+    )
+}
+
+/**
+ * Composable Function to run a local Koin application and to help run Compose preview
+ * This function is lighter than KoinApplication, and allow parallel recomposition in Android Studio
+ *
+ * @param application - Koin application config
+ * @param content
+ */
+@OptIn(KoinInternalApi::class)
+@KoinExperimentalAPI
+@Composable
+fun KoinApplicationPreview(
+    application: KoinAppDeclaration,
+    content: @Composable () -> Unit
+) {
+    val context = koinApplication(application)
     CompositionLocalProvider(
         LocalKoinApplication provides context.koin,
         LocalKoinScope provides context.koin.scopeRegistry.rootScope,


### PR DESCRIPTION
Introduce `KoinApplicationPreview` dedicated to help preview Composable function, instead of using `KoinApplication`

New Compose Preview function to help parallel previews and lighter processing in Android Studio
(no more global context usage)

```kotlin
@Preview(name = "1 - Pixel 2 XL", device = Devices.PIXEL_2_XL, locale = "en")
@Preview(name = "2 - Pixel 5", device = Devices.PIXEL_5, locale = "en", uiMode = Configuration.UI_MODE_NIGHT_YES)
@Preview(name = "3 - Pixel 7 ", device = Devices.PIXEL_7, locale = "ru", uiMode = Configuration.UI_MODE_NIGHT_YES)
@Composable
fun previewVMComposable(){
    KoinApplicationPreview(application = { modules(appModule) }) {
        ViewModelComposable()
    }
}

@OptIn(KoinExperimentalAPI::class)
@Preview(name = "3 - Pixel 7 ", device = Devices.PIXEL_7, locale = "ru", uiMode = Configuration.UI_MODE_NIGHT_YES)
@Preview(name = "4 - Pixel 7 Pro", device = Devices.PIXEL_7_PRO, locale = "fr")
@Composable
fun previewSingleComposable(){
    KoinApplicationPreview(application = { modules(appModule) }) {
        SingleComposable()
    }
}
```

