### PR TITLE
Migration to lifecycle 2.9

### DIFF
--- a/projects/android/koin-android/src/main/java/org/koin/androidx/viewmodel/ext/android/ViewModelLazy.kt
+++ b/projects/android/koin-android/src/main/java/org/koin/androidx/viewmodel/ext/android/ViewModelLazy.kt
@@ -12,7 +12,7 @@ import org.koin.android.ext.android.getKoinScope
 import org.koin.core.annotation.KoinInternalApi
 import org.koin.core.parameter.ParametersDefinition
 import org.koin.core.qualifier.Qualifier
-import org.koin.viewmodel.BundleDefinition
+import org.koin.viewmodel.SavedStateDefinition
 import org.koin.viewmodel.resolveViewModel
 import org.koin.viewmodel.toExtras
 import kotlin.reflect.KClass
@@ -23,7 +23,7 @@ fun <T : ViewModel> ComponentActivity.viewModelForClass(
     clazz: KClass<T>,
     qualifier: Qualifier? = null,
     owner: ViewModelStoreOwner = this,
-    state: BundleDefinition? = null,
+    state: SavedStateDefinition? = null,
     key: String? = null,
     parameters: ParametersDefinition? = null,
 ): Lazy<T> {
@@ -47,7 +47,7 @@ fun <T : ViewModel> Fragment.viewModelForClass(
     clazz: KClass<T>,
     qualifier: Qualifier? = null,
     owner: () -> ViewModelStoreOwner = { this },
-    state: BundleDefinition? = null,
+    state: SavedStateDefinition? = null,
     key: String? = null,
     parameters: ParametersDefinition? = null,
 ): Lazy<T> {

--- a/projects/core/koin-core-viewmodel-navigation/build.gradle.kts
+++ b/projects/core/koin-core-viewmodel-navigation/build.gradle.kts
@@ -1,8 +1,5 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-
 plugins {
+    alias(libs.plugins.androidLibrary)
     alias(libs.plugins.kotlinMultiplatform)
 }
 
@@ -10,9 +7,17 @@ val koinVersion: String by project
 version = koinVersion
 
 kotlin {
-    
+    androidTarget {
+        publishLibraryVariants("release")
+        compilations.all {
+            kotlinOptions.jvmTarget = "1.8"
+        }
+    }
+
     jvm {
-        withJava()
+        compilations.all {
+            kotlinOptions.jvmTarget = "11"
+        }
     }
 
     js(IR) {
@@ -40,10 +45,11 @@ kotlin {
     }
 }
 
-tasks.withType<KotlinCompile>().all {
-    compilerOptions {
-        jvmTarget.set(JvmTarget.JVM_1_8)
-    }
+val androidCompileSDK: String by project
+
+android {
+    namespace = "org.koin.viewmodel.navigation"
+    compileSdk = androidCompileSDK.toInt()
 }
 
 apply(from = file("../../gradle/publish.gradle.kts"))

--- a/projects/core/koin-core-viewmodel/build.gradle.kts
+++ b/projects/core/koin-core-viewmodel/build.gradle.kts
@@ -1,8 +1,5 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-
 plugins {
+    alias(libs.plugins.androidLibrary)
     alias(libs.plugins.kotlinMultiplatform)
 }
 
@@ -10,9 +7,17 @@ val koinVersion: String by project
 version = koinVersion
 
 kotlin {
+    androidTarget {
+        publishLibraryVariants("release")
+        compilations.all {
+            kotlinOptions.jvmTarget = "1.8"
+        }
+    }
     
     jvm {
-        withJava()
+        compilations.all {
+            kotlinOptions.jvmTarget = "11"
+        }
     }
 
 //    // Enable context receivers for all targets
@@ -54,10 +59,11 @@ kotlin {
     }
 }
 
-tasks.withType<KotlinCompile>().all {
-    compilerOptions {
-        jvmTarget.set(JvmTarget.JVM_1_8)
-    }
+val androidCompileSDK: String by project
+
+android {
+    namespace = "org.koin.viewmodel"
+    compileSdk = androidCompileSDK.toInt()
 }
 
 apply(from = file("../../gradle/publish.gradle.kts"))

--- a/projects/core/koin-core-viewmodel/src/commonMain/kotlin/org/koin/viewmodel/BundleExt.kt
+++ b/projects/core/koin-core-viewmodel/src/commonMain/kotlin/org/koin/viewmodel/BundleExt.kt
@@ -15,14 +15,16 @@
  */
 package org.koin.viewmodel
 
-import androidx.core.bundle.Bundle
 import androidx.lifecycle.DEFAULT_ARGS_KEY
 import androidx.lifecycle.SAVED_STATE_REGISTRY_OWNER_KEY
 import androidx.lifecycle.VIEW_MODEL_STORE_OWNER_KEY
 import androidx.lifecycle.ViewModelStoreOwner
 import androidx.lifecycle.viewmodel.CreationExtras
 import androidx.lifecycle.viewmodel.MutableCreationExtras
+import androidx.savedstate.SavedState
 import androidx.savedstate.SavedStateRegistryOwner
+import androidx.savedstate.read
+import androidx.savedstate.savedState
 import org.koin.core.annotation.KoinInternalApi
 
 /**
@@ -32,16 +34,16 @@ import org.koin.core.annotation.KoinInternalApi
  */
 
 /**
- * Convert current Bundle to CreationExtras
+ * Convert current SavedState to CreationExtras
  * @param viewModelStoreOwner
  */
 @KoinInternalApi
-fun Bundle.toExtras(viewModelStoreOwner: ViewModelStoreOwner): CreationExtras? {
-    return if (keySet().isEmpty()) null
+fun SavedState.toExtras(viewModelStoreOwner: ViewModelStoreOwner): CreationExtras? = read {
+    return if (isEmpty()) null
     else {
         runCatching {
             MutableCreationExtras().also { extras ->
-                extras[DEFAULT_ARGS_KEY] = this
+                extras[DEFAULT_ARGS_KEY] = this@toExtras
                 extras[VIEW_MODEL_STORE_OWNER_KEY] = viewModelStoreOwner
                 extras[SAVED_STATE_REGISTRY_OWNER_KEY] = viewModelStoreOwner as SavedStateRegistryOwner
             }
@@ -50,7 +52,7 @@ fun Bundle.toExtras(viewModelStoreOwner: ViewModelStoreOwner): CreationExtras? {
 }
 
 //TODO Replace with CreationExtras API
-fun emptyState(): BundleDefinition = { Bundle() }
+fun emptyState(): SavedStateDefinition = { savedState() }
 
 //TODO Replace with CreationExtras API
-typealias BundleDefinition = () -> Bundle
+typealias SavedStateDefinition = () -> SavedState

--- a/projects/core/koin-fu-viewmodel/build.gradle.kts
+++ b/projects/core/koin-fu-viewmodel/build.gradle.kts
@@ -1,14 +1,20 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-
 plugins {
+    alias(libs.plugins.androidLibrary)
     alias(libs.plugins.kotlinMultiplatform)
 }
 
 kotlin {
-    
+    androidTarget {
+        publishLibraryVariants("release")
+        compilations.all {
+            kotlinOptions.jvmTarget = "1.8"
+        }
+    }
+
     jvm {
-        withJava()
+        compilations.all {
+            kotlinOptions.jvmTarget = "11"
+        }
     }
 
     sourceSets {
@@ -22,10 +28,11 @@ kotlin {
     }
 }
 
-tasks.withType<KotlinCompile>().all {
-    compilerOptions {
-            jvmTarget.set(JvmTarget.JVM_1_8)
-        }
+val androidCompileSDK: String by project
+
+android {
+    namespace = "org.koin.dsl.fu"
+    compileSdk = androidCompileSDK.toInt()
 }
 
 apply(from = file("../../gradle/publish.gradle.kts"))

--- a/projects/gradle/libs.versions.toml
+++ b/projects/gradle/libs.versions.toml
@@ -15,16 +15,20 @@ agp = "8.7.3"
 android-appcompat = "1.7.0"
 android-activity = "1.10.1"
 android-fragment = "1.8.6"
-androidx-lifecycle = "2.8.7"
 androidx-workmanager = "2.10.0"
-androidx-navigation = "2.8.9"
-androidx-startup= "1.2.0"
+androidx-startup = "1.2.0"
+
+# Lifecycle
+androidx-lifecycle = "2.9.0-beta01" # Keep in sync with "jb-lifecycle"
+jb-lifecycle = "2.9.0-alpha07"
+
+# Navigation
+androidx-navigation = "2.9.0-beta01" # Keep in sync with "jb-navigation"
+jb-navigation = "2.9.0-alpha17"
 
 # Compose
-composeJetpackRuntime = "1.7.8"
-composeJB = "1.8.0-rc01"
-composeLifecycle = "2.8.4"
-composeNavigation = "2.9.0-alpha17"
+androidx-compose = "1.8.0-rc03" # Keep in sync with "jb-compose"
+jb-compose = "1.8.0-rc01"
 
 # Test
 stately = "2.1.0"
@@ -46,6 +50,7 @@ benchmark = "0.4.13"
 kotlin-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
 extras-stately = { module = "co.touchlab:stately-concurrency", version.ref = "stately" }
 extras-stately-collections = { module = "co.touchlab:stately-concurrent-collections", version.ref = "stately" }
+uuid = { module = "com.benasher44:uuid", version.ref = "uuidVersion" }
 
 # Test
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
@@ -74,18 +79,17 @@ ktor3-netty = { module = "io.ktor:ktor-server-netty", version.ref = "ktor3" }
 ktor3-testHost = { module = "io.ktor:ktor-server-test-host", version.ref = "ktor3" }
 ktor-slf4j = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }
 # jetpack Compose
-androidx-composeRuntime = { module = "androidx.compose.runtime:runtime", version.ref = "composeJetpackRuntime" }
-androidx-composeFoundation = { module = "androidx.compose.foundation:foundation", version.ref = "composeJetpackRuntime" }
+androidx-composeRuntime = { module = "androidx.compose.runtime:runtime", version.ref = "androidx-compose" }
+androidx-composeFoundation = { module = "androidx.compose.foundation:foundation", version.ref = "androidx-compose" }
 androidx-composeViewModel = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "androidx-lifecycle" }
 androidx-composeNavigation = { module = "androidx.navigation:navigation-compose", version.ref = "androidx-navigation" }
 # jb Compose
-jb-composeRuntime = { module = "org.jetbrains.compose.runtime:runtime", version.ref = "composeJB" }
-jb-composeViewmodel = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "composeLifecycle" }
-jb-lifecycleViewmodel = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel", version.ref = "composeLifecycle" }
-jb-lifecycleViewmodelSavedState = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-savedstate", version.ref = "composeLifecycle" }
-jb-composeNavigation = { module = "org.jetbrains.androidx.navigation:navigation-compose", version.ref = "composeNavigation" }
-jb-navigation = { module = "org.jetbrains.androidx.navigation:navigation-common", version.ref = "composeNavigation" }
-uuid = { module = "com.benasher44:uuid", version.ref = "uuidVersion" }
+jb-composeRuntime = { module = "org.jetbrains.compose.runtime:runtime", version.ref = "jb-compose" }
+jb-composeViewmodel = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "jb-lifecycle" }
+jb-lifecycleViewmodel = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel", version.ref = "jb-lifecycle" }
+jb-lifecycleViewmodelSavedState = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-savedstate", version.ref = "jb-lifecycle" }
+jb-composeNavigation = { module = "org.jetbrains.androidx.navigation:navigation-compose", version.ref = "jb-navigation" }
+jb-navigation = { module = "org.jetbrains.androidx.navigation:navigation-common", version.ref = "jb-navigation" }
 # Benchmark
 benchmark-runtime = {module = "org.jetbrains.kotlinx:kotlinx-benchmark-runtime", version.ref = "benchmark"}
 
@@ -93,7 +97,7 @@ benchmark-runtime = {module = "org.jetbrains.kotlinx:kotlinx-benchmark-runtime",
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kotlinAndroid = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 androidLibrary = { id = "com.android.library", version.ref = "agp" }
-jetbrainsCompose = { id = "org.jetbrains.compose", version.ref = "composeJB" }
+jetbrainsCompose = { id = "org.jetbrains.compose", version.ref = "jb-compose" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 # Tools
 kotlinBinary = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version.ref = "binaryValidator" }


### PR DESCRIPTION
It's a followup of #2179 and #2183 from @zsmb13 

## Version Catalog

In the previous PRs reference to old verions aren't really removed. To make things more clear I orginized gradle catalog a bit - `androidx-*` for Google Jetpack references and `jb-*` for Multiplatofrm counterparts. These things should be in sync ideally, so grouping it should help with clarity.
The corect matches can be always found in multiplatform release notes (see "Dependencies" section). For example for latest release it's 
`org.jetbrains.compose*:1.8.0-rc01` -> `androidx.compose.*:1.8.0-rc03`
`org.jetbrains.androidx.lifecycle*:2.9.0-alpha07` -> `androidx.lifecycle*:2.9.0-beta01`
`org.jetbrains.androidx.navigation*:2.9.0-alpha17` -> `androidx.navigation*:2.9.0-beta01`

## New SavedState API

Due to Google's multiplatofrm/KMP efforts `androidx.statedstate` 1.3 is multiplatform itself and it does NOT compatiable with JetBrains savedstate 1.2 commonization. In the current release all jetbrains counterparts were migrated to this new API.
This migration removed usage `androidx.core.bundle.Bundle` type. For Android it's fully compatiable because this one and new `androidx.savedstate.SavedState` are typealiases to android's Bundle, but for other platform it's resolved into a different type.
Koin had the usage of old type, so this part is required to be updated

## Changes in build scripts

Bumping Desktop JVM target to 11 like in #2179
BTW publishing separate artifacts for Desktop and Android will also address possible issues like it was previously with [KT-71100](https://youtrack.jetbrains.com/issue/KT-71100)