### PR TITLE
[Maintenance] Clean up in `AndroidManifest.xml` files

### DIFF
--- a/projects/android/koin-android-compat/src/main/AndroidManifest.xml
+++ b/projects/android/koin-android-compat/src/main/AndroidManifest.xml
@@ -1,4 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="org.koin.android.compat">
-    <application/>
-</manifest>
+<?xml version="1.0" encoding="utf-8"?>
+<manifest />

--- a/projects/android/koin-android-test/src/main/AndroidManifest.xml
+++ b/projects/android/koin-android-test/src/main/AndroidManifest.xml
@@ -1,4 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="org.koin.android.test">
-    <application/>
-</manifest>
+<?xml version="1.0" encoding="utf-8"?>
+<manifest />

--- a/projects/android/koin-android/src/main/AndroidManifest.xml
+++ b/projects/android/koin-android/src/main/AndroidManifest.xml
@@ -1,4 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="org.koin.android">
-    <application/>
-</manifest>
+<?xml version="1.0" encoding="utf-8"?>
+<manifest />

--- a/projects/android/koin-androidx-navigation/src/main/AndroidManifest.xml
+++ b/projects/android/koin-androidx-navigation/src/main/AndroidManifest.xml
@@ -1,4 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="org.koin.androidx.navigation">
-    <application/>
-</manifest>
+<?xml version="1.0" encoding="utf-8"?>
+<manifest />

--- a/projects/android/koin-androidx-startup/src/main/AndroidManifest.xml
+++ b/projects/android/koin-androidx-startup/src/main/AndroidManifest.xml
@@ -1,5 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="org.koin.androidx.startup" xmlns:tools="http://schemas.android.com/tools">
+    xmlns:tools="http://schemas.android.com/tools"
+    package="org.koin.androidx.startup">
+
     <application>
         <provider
             android:name="androidx.startup.InitializationProvider"
@@ -7,7 +10,8 @@
             android:exported="false"
             tools:node="merge">
             <!-- This entry makes ExampleLoggerInitializer discoverable. -->
-            <meta-data  android:name="org.koin.androix.startup.KoinInitializer"
+            <meta-data
+                android:name="org.koin.androix.startup.KoinInitializer"
                 android:value="androidx.startup" />
         </provider>
     </application>

--- a/projects/android/koin-androidx-workmanager/src/main/AndroidManifest.xml
+++ b/projects/android/koin-androidx-workmanager/src/main/AndroidManifest.xml
@@ -1,4 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="org.koin.androidx.workmanager">
-    <application/>
-</manifest>
+<?xml version="1.0" encoding="utf-8"?>
+<manifest />

--- a/projects/compose/koin-androidx-compose-navigation/src/main/AndroidManifest.xml
+++ b/projects/compose/koin-androidx-compose-navigation/src/main/AndroidManifest.xml
@@ -1,4 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="org.koin.androidx.compose.navigation">
-</manifest>
+<manifest />

--- a/projects/compose/koin-androidx-compose/src/main/AndroidManifest.xml
+++ b/projects/compose/koin-androidx-compose/src/main/AndroidManifest.xml
@@ -1,5 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="org.koin.androidx.compose">
-
-</manifest>
+<manifest />


### PR DESCRIPTION
- Removed redundant `xmlns:android` declarations;
- Removed obsolete `package` attributes;
- Removed empty `<application/>` blocks;
- Formatting;
- Closed empty `<manifest>` tags;
- Added standard XML declaration header.