### PR TITLE
Add missing minSdk config for koin-compose-viewmodel modules

### DIFF
--- a/projects/compose/koin-compose-viewmodel-navigation/build.gradle.kts
+++ b/projects/compose/koin-compose-viewmodel-navigation/build.gradle.kts
@@ -48,10 +48,14 @@ kotlin {
 }
 
 val androidCompileSDK: String by project
+val androidMinSDK : String by project
 
 android {
     namespace = "org.koin.compose.viewmodel.navigation"
     compileSdk = androidCompileSDK.toInt()
+    defaultConfig {
+        minSdk = androidMinSDK.toInt()
+    }
 }
 
 tasks.withType<org.jetbrains.kotlin.gradle.targets.js.npm.tasks.KotlinNpmInstallTask>().configureEach {

--- a/projects/compose/koin-compose-viewmodel/build.gradle.kts
+++ b/projects/compose/koin-compose-viewmodel/build.gradle.kts
@@ -49,10 +49,14 @@ kotlin {
 }
 
 val androidCompileSDK: String by project
+val androidMinSDK : String by project
 
 android {
     namespace = "org.koin.compose.viewmodel"
     compileSdk = androidCompileSDK.toInt()
+    defaultConfig {
+        minSdk = androidMinSDK.toInt()
+    }
 }
 
 tasks.withType<org.jetbrains.kotlin.gradle.targets.js.npm.tasks.KotlinNpmInstallTask>().configureEach {


### PR DESCRIPTION
Adding minSdk for the modules that were freshly configured with the Android target in https://github.com/InsertKoinIO/koin/pull/2179