### PR TITLE
Fix override create at start

### DIFF
--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/registry/InstanceRegistry.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/registry/InstanceRegistry.kt
@@ -35,6 +35,7 @@ import org.koin.core.qualifier.Qualifier
 import org.koin.core.scope.Scope
 import org.koin.core.scope.ScopeID
 import org.koin.mp.KoinPlatformTools.safeHashMap
+import kotlin.collections.set
 import kotlin.collections.toTypedArray
 import kotlin.reflect.KClass
 
@@ -85,6 +86,11 @@ class InstanceRegistry(val _koin: Koin) {
                 overrideError(factory, mapping)
             } else if (logWarning) {
                 _koin.logger.warn("(+) override index '$mapping' -> '${factory.beanDefinition}'")
+                // remove previous eager isntance too
+                val existingFactory = eagerInstances.values.firstOrNull { it.beanDefinition == factory.beanDefinition }
+                if (existingFactory != null) {
+                    eagerInstances.remove(factory.beanDefinition.hashCode())
+                }
             }
         }
         _koin.logger.debug("(+) index '$mapping' -> '${factory.beanDefinition}'")

--- a/projects/core/koin-core/src/commonTest/kotlin/org/koin/core/OverrideAndCreateatStartTest.kt
+++ b/projects/core/koin-core/src/commonTest/kotlin/org/koin/core/OverrideAndCreateatStartTest.kt
@@ -10,7 +10,9 @@ import org.koin.core.logger.Level
 import org.koin.dsl.koinApplication
 import org.koin.dsl.module
 import org.koin.mp.KoinPlatform
+import org.koin.mp.KoinPlatform.getKoin
 import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -33,6 +35,14 @@ class SomeClassB : SomeClassInterface {
         created = "SomeClassB"
     }
 }
+class SomeClassC : SomeClassInterface {
+    init {
+        println("SomeClassC created")
+        count++
+        created = "SomeClassC"
+    }
+}
+
 
 class OverrideAndCreateatStartTest : KoinCoreTest(){
     val moduleA = module {
@@ -47,6 +57,18 @@ class OverrideAndCreateatStartTest : KoinCoreTest(){
         }
     }
 
+    val moduleC = module {
+        single<SomeClassInterface> {
+            SomeClassC()
+        }
+    }
+
+    @BeforeTest
+    fun setup(){
+        count = 0
+        created = ""
+    }
+
     @OptIn(KoinInternalApi::class)
     @Test
     fun testDefinitionOverride() {
@@ -57,9 +79,30 @@ class OverrideAndCreateatStartTest : KoinCoreTest(){
 
         assertTrue(count == 1)
         assertTrue(created == "SomeClassB")
-        KoinPlatform.getKoin().instanceRegistry.instances.firstNotNullOf { (k: IndexKey,v: InstanceFactory<*>) ->
+
+        getKoin().instanceRegistry.instances.firstNotNullOf { (k: IndexKey,v: InstanceFactory<*>) ->
             assertEquals(k, moduleB.mappings.keys.first())
             assertEquals(v, moduleB.mappings.values.first())
+        }
+    }
+
+    @OptIn(KoinInternalApi::class)
+    @Test
+    fun testDefinitionOverride_no_created_at_start() {
+        startKoin {
+            printLogger(Level.DEBUG)
+            modules(moduleA + moduleC)
+        }
+
+        assertTrue(count == 0)
+        val result = getKoin().get<SomeClassInterface>()
+        println("=> $result")
+        assertTrue(count == 1)
+        assertTrue(created == "SomeClassC")
+
+        getKoin().instanceRegistry.instances.firstNotNullOf { (k: IndexKey,v: InstanceFactory<*>) ->
+            assertEquals(k, moduleC.mappings.keys.first())
+            assertEquals(v, moduleC.mappings.values.first())
         }
     }
 }

--- a/projects/test.sh
+++ b/projects/test.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-./gradlew clean test --parallel --no-build-cache
+./gradlew clean test --parallel --no-build-cache --rerun-tasks


### PR DESCRIPTION
Fix definition override regarding "createdAtStart" flagged definition. It removes old definition from it.