### PR TITLE
Fix nested module overrides

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
         uses: ./.github/actions/prepare-env
 
       - name: Install
-        run: cd projects && ./install.sh
+        run: cd projects && ./install.sh && ./test.sh
 
       - name: Test Examples
         run: cd examples && ./test.sh

--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,0 +1,3 @@
+# Enable auto-env through the sdkman_auto_env config
+# Add key=value pairs of SDKs to use below
+java=17.0.15-zulu

--- a/projects/core/koin-core/build.gradle.kts
+++ b/projects/core/koin-core/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
 }
 
 kotlin {
+    jvmToolchain(8)
     jvm()
 
     js(IR) {
@@ -55,8 +56,8 @@ kotlin {
 
 tasks.withType<KotlinCompile>().all {
     compilerOptions {
-            jvmTarget.set(JvmTarget.JVM_1_8)
-        }
+        jvmTarget.set(JvmTarget.JVM_1_8)
+    }
 }
 
 apply(from = file("../../gradle/publish.gradle.kts"))

--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/module/Module.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/module/Module.kt
@@ -248,7 +248,7 @@ fun flatten(modules: List<Module>): Set<Module> {
         }
 
         // Add all the included modules to the stack if they haven't been visited yet.
-        for (module in current.includedModules) {
+        for (module in current.includedModules.asReversed()) {
             if (module !in flatten) {
                 stack += module
             }

--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/resolution/CoreResolver.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/resolution/CoreResolver.kt
@@ -75,7 +75,11 @@ class CoreResolver(
             ?: resolveFromStackedParameters(scope,instanceContext)
             ?: resolveFromScopeSource(scope,instanceContext)
             ?: resolveFromScopeArchetype(scope,instanceContext)
-            ?: if (lookupParent) resolveFromParentScopes(scope,instanceContext) else null
+            ?: if (lookupParent) {
+                resolveFromParentScopes(scope, instanceContext)
+            } else {
+                null
+            }
             ?: resolveInExtensions(scope,instanceContext)
     }
 

--- a/projects/core/koin-core/src/commonTest/kotlin/org/koin/core/MultipleModuleDeclarationTest.kt
+++ b/projects/core/koin-core/src/commonTest/kotlin/org/koin/core/MultipleModuleDeclarationTest.kt
@@ -1,6 +1,10 @@
 package org.koin.core
 
 import org.koin.Simple
+import org.koin.core.component.KoinScopeComponent
+import org.koin.core.component.get
+import org.koin.core.component.getOrCreateScope
+import org.koin.core.scope.Scope
 import org.koin.dsl.koinApplication
 import org.koin.dsl.module
 import org.koin.test.assertDefinitionsCount
@@ -47,5 +51,217 @@ class MultipleModuleDeclarationTest {
         val b = koin.get<Simple.ComponentB>()
 
         assertEquals(a, b.a)
+    }
+
+    @Test
+    fun `resolve DI with several modules with override contract`() {
+        val expected = TestDependency(
+            name = "expected",
+        )
+
+        val app = koinApplication {
+            modules(
+                module {
+                    single {
+                        TestDependency(
+                            name = "a",
+                        )
+                    }
+                },
+                module {
+                    single {
+                        TestDependency(
+                            name = "b",
+                        )
+                    }
+                },
+                module {
+                    single {
+                        TestDependency(
+                            name = "c",
+                        )
+                    }
+                },
+                module {
+                    single {
+                        expected
+                    }
+                },
+            )
+        }
+
+        val koin = app.koin
+        val actual = koin.get<TestDependency>()
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `resolve DI with several nested modules with override contract`() {
+        val expected = TestDependency(
+            name = "expected",
+        )
+
+        val app = koinApplication {
+            modules(
+                module {
+                    includes(
+                        module {
+                            TestDependency(
+                                name = "a",
+                            )
+                        },
+                    )
+                    single {
+                        TestDependency(
+                            name = "a",
+                        )
+                    }
+                },
+                module {
+                    single {
+                        TestDependency(
+                            name = "b",
+                        )
+                    }
+                },
+                module {
+                    single {
+                        TestDependency(
+                            name = "c",
+                        )
+                    }
+                },
+                module {
+                    single {
+                        expected
+                    }
+                },
+            )
+        }
+
+        val koin = app.koin
+        val actual = koin.get<TestDependency>()
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `resolve DI with several nested modules from scope with override contract`() {
+        val expected = TestDependency(
+            name = "expected",
+        )
+
+        val app = koinApplication {
+            modules(
+                module {
+                    includes(
+                        module {
+                            TestDependency(
+                                name = "a",
+                            )
+                        },
+                    )
+                    single {
+                        TestDependency(
+                            name = "a",
+                        )
+                    }
+                },
+                module {
+                    single {
+                        TestDependency(
+                            name = "b",
+                        )
+                    }
+                },
+                module {
+                    single {
+                        TestDependency(
+                            name = "c",
+                        )
+                    }
+                },
+                module {
+                    single {
+                        expected
+                    }
+                },
+            )
+        }
+
+        val koin = app.koin
+        val scope = ModuleTestScope(koin)
+        val actual = scope.get<TestDependency>()
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `resolve DI with several deeply nested modules from scope with override contract`() {
+        val expected = TestDependency(
+            name = "expected",
+        )
+
+        val app = koinApplication {
+            modules(
+                module {
+                    includes(
+                        module {
+                            includes(
+                                module {
+                                    TestDependency(
+                                        name = "a",
+                                    )
+                                },
+                            )
+                            single {
+                                TestDependency(
+                                    name = "a",
+                                )
+                            }
+                        },
+                        module {
+                            single {
+                                TestDependency(
+                                    name = "b",
+                                )
+                            }
+                        },
+                        module {
+                            single {
+                                TestDependency(
+                                    name = "c",
+                                )
+                            }
+                        },
+                        module {
+                            single {
+                                expected
+                            }
+                        },
+                    )
+                },
+            )
+        }
+
+        val koin = app.koin
+        val scope = ModuleTestScope(koin)
+        val actual = scope.get<TestDependency>()
+
+        assertEquals(expected, actual)
+    }
+
+    data class TestDependency(
+        val name: String,
+    )
+
+    class ModuleTestScope(
+        private val koin: Koin,
+    ) : KoinScopeComponent {
+        override val scope: Scope by getOrCreateScope()
+
+        override fun getKoin(): Koin =
+            koin
     }
 }

--- a/projects/core/koin-core/src/commonTest/kotlin/org/koin/core/ScopeTest.kt
+++ b/projects/core/koin-core/src/commonTest/kotlin/org/koin/core/ScopeTest.kt
@@ -5,6 +5,7 @@ import org.koin.core.component.KoinScopeComponent
 import org.koin.core.component.getOrCreateScope
 import org.koin.core.component.inject
 import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
 import org.koin.core.error.ClosedScopeException
 import org.koin.core.logger.Level
 import org.koin.core.module.dsl.scopedOf
@@ -20,6 +21,11 @@ class ScopeTest {
 
     private class A
     private class B
+
+    @AfterTest
+    fun tearDown() {
+        stopKoin()
+    }
 
     @Test
     fun scope_component() {
@@ -45,8 +51,8 @@ class ScopeTest {
         }
 
         with(SubClass()) {
-            assertTrue { a is A }
-            assertTrue { b is B }
+            assertIs<A>(a)
+            assertIs<B>(b)
         }
     }
 


### PR DESCRIPTION
This pull request primarily adds a fix for nested module overrides.

Additionally, previously failing unit tests of the koin-core module are fixed - one even with a problem in the production code (if braces). To prevent this in the future, the projects folder's test.sh is added to the test pipeline as well.

Furthermore, the JVM version is now correctly set for the koin-core module, so that `jvmTest` now works. To reflect the necessary Java version for building for IDEs and CLIs, a corresponding `.sdkmanrc` with the same version and variant as is used in the pipeline is added.