### PR TITLE
Koin + Ktor DI 3.2 Integration

### DIFF
--- a/examples/gradle/versions.gradle
+++ b/examples/gradle/versions.gradle
@@ -7,7 +7,7 @@ ext {
     koin_compose_version = koin_version
 
     coroutines_version = "1.9.0"
-    ktor_version = "3.1.3"//"3.2.0-eap-1310"
+    ktor_version = "3.2.1"
     jb_compose_version = "1.8.0"
 
     // Test

--- a/examples/ktor-di-sample/build.gradle
+++ b/examples/ktor-di-sample/build.gradle
@@ -1,0 +1,31 @@
+apply plugin: 'kotlin'
+apply plugin: 'application'
+
+archivesBaseName = 'ktor-di-sample'
+mainClassName = 'org.koin.sample.ApplicationKt'
+
+dependencies {
+    // Kotlin
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
+    implementation "io.ktor:ktor-server-netty:$ktor_version"
+    implementation "io.ktor:ktor-server-call-logging:$ktor_version"
+    implementation "io.ktor:ktor-server-di:$ktor_version"
+
+    // Use local Koin project dependencies
+    implementation "io.insert-koin:koin-ktor"
+    implementation "io.insert-koin:koin-logger-slf4j"
+    implementation("org.slf4j:slf4j-api:2.0.16")
+    implementation "ch.qos.logback:logback-classic:1.5.16"
+
+    testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
+    testImplementation "io.ktor:ktor-server-test-host:$ktor_version"
+    testImplementation "io.insert-koin:koin-test"
+    testImplementation "io.insert-koin:koin-test-junit4"
+}
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+    maven { url "https://dl.bintray.com/kotlin/kotlinx" }
+    maven { url "https://dl.bintray.com/kotlin/ktor" }
+}

--- a/examples/ktor-di-sample/src/main/kotlin/org/koin/sample/ktor/di/Application.kt
+++ b/examples/ktor-di-sample/src/main/kotlin/org/koin/sample/ktor/di/Application.kt
@@ -1,0 +1,60 @@
+package org.koin.sample.ktor.di
+
+import io.ktor.server.application.*
+import io.ktor.server.engine.*
+import io.ktor.server.netty.*
+import io.ktor.server.plugins.calllogging.*
+import io.ktor.server.plugins.di.dependencies
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import org.koin.core.logger.Level
+import org.koin.dsl.module
+import org.koin.ktor.ext.inject
+import org.koin.ktor.plugin.Koin
+
+fun main() {
+    embeddedServer(Netty, port = 8080) {
+        mainModule()
+    }.start(wait = true)
+}
+
+fun Application.mainModule() {
+    install(CallLogging)
+    
+    install(Koin) {
+        printLogger(Level.DEBUG)
+        modules(module {
+            single<HelloService> { HelloServiceImpl() }
+        })
+    }
+    
+    dependencies {
+        provide<KtorSpecificService> { KtorSpecificServiceImpl() }
+    }
+
+    routing {
+        get("/koin") {
+            val helloService: HelloService by inject() // From koin
+            call.respondText(helloService.sayHello())
+        }
+        
+        get("/ktor-di") {
+            val ktorService: KtorSpecificService by dependencies // From Ktor DI
+            call.respondText(ktorService.process())
+        }
+        
+        get("/mixed-ktor-di") {
+            val helloService: HelloService by dependencies // From Koin via Ktor DI
+            val ktorService: KtorSpecificService by dependencies // From Ktor DI
+            
+            call.respondText("${helloService.sayHello()} - ${ktorService.process()}")
+        }
+
+        get("/mixed-koin") {
+            val helloService: HelloService by inject() // From Koin
+            val ktorService: KtorSpecificService by inject() // From Ktor Di via Koin
+
+            call.respondText("${helloService.sayHello()} - ${ktorService.process()}")
+        }
+    }
+}

--- a/examples/ktor-di-sample/src/main/kotlin/org/koin/sample/ktor/di/Services.kt
+++ b/examples/ktor-di-sample/src/main/kotlin/org/koin/sample/ktor/di/Services.kt
@@ -1,0 +1,17 @@
+package org.koin.sample.ktor.di
+
+interface HelloService {
+    fun sayHello(): String
+}
+
+class HelloServiceImpl : HelloService {
+    override fun sayHello(): String = "Hello from Koin!"
+}
+
+interface KtorSpecificService {
+    fun process(): String
+}
+
+class KtorSpecificServiceImpl : KtorSpecificService {
+    override fun process(): String = "Processed by Ktor DI"
+}

--- a/examples/ktor-di-sample/src/test/kotlin/org/koin/sample/ktor/di/ApplicationTest.kt
+++ b/examples/ktor-di-sample/src/test/kotlin/org/koin/sample/ktor/di/ApplicationTest.kt
@@ -1,0 +1,60 @@
+package org.koin.sample.ktor.di
+
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.testing.testApplication
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class ApplicationTest {
+
+    @Test
+    fun `test koin endpoint`() = testApplication {
+        application {
+            mainModule()
+        }
+
+        val response = client.get("/koin")
+
+        assertEquals(HttpStatusCode.Companion.OK, response.status)
+        assertEquals("Hello from Koin!", response.bodyAsText())
+    }
+
+    @Test
+    fun `test ktor-di endpoint`() = testApplication {
+        application {
+            mainModule()
+        }
+
+        val response = client.get("/ktor-di")
+
+        assertEquals(HttpStatusCode.Companion.OK, response.status)
+        assertEquals("Processed by Ktor DI", response.bodyAsText())
+    }
+
+    @Test
+    fun `test mixed-ktor-di endpoint`() = testApplication {
+        application {
+            mainModule()
+        }
+
+        val response = client.get("/mixed-ktor-di")
+
+        assertEquals(HttpStatusCode.Companion.OK, response.status)
+        assertEquals("Hello from Koin! - Processed by Ktor DI", response.bodyAsText())
+    }
+
+    @Test
+    fun `test mixed-koin endpoint`() = testApplication {
+        application {
+            mainModule()
+        }
+
+        val response = client.get("/mixed-koin")
+
+        assertEquals(HttpStatusCode.Companion.OK, response.status)
+        assertEquals("Hello from Koin! - Processed by Ktor DI", response.bodyAsText())
+    }
+
+}

--- a/examples/settings.gradle
+++ b/examples/settings.gradle
@@ -6,6 +6,7 @@ include 'jvm-perfs'
 include 'android-perfs'
 // ktor
 include 'hello-ktor'
+include 'ktor-di-sample'
 
 // Compose
 include 'sample-android-compose'

--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/resolution/CoreResolver.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/resolution/CoreResolver.kt
@@ -75,7 +75,7 @@ class CoreResolver(
             ?: resolveFromStackedParameters(scope,instanceContext)
             ?: resolveFromScopeSource(scope,instanceContext)
             ?: resolveFromScopeArchetype(scope,instanceContext)
-            ?: if (lookupParent) resolveFromParentScopes(scope,instanceContext) else null
+            ?: (if (lookupParent) resolveFromParentScopes(scope,instanceContext) else null)
             ?: resolveInExtensions(scope,instanceContext)
     }
 

--- a/projects/gradle/libs.versions.toml
+++ b/projects/gradle/libs.versions.toml
@@ -39,7 +39,7 @@ mockito = "4.8.0"
 mockk = "1.13.16"
 robolectric = "4.14.1"
 # Ktor
-ktor = "3.1.3"
+ktor = "3.2.1"
 slf4j = "2.0.17"
 uuidVersion = "0.8.4"
 
@@ -73,7 +73,7 @@ androidx-startup = {module ="androidx.startup:startup-runtime", version.ref = "a
 
 # Ktor
 ktor-core = { module = "io.ktor:ktor-server-core", version.ref = "ktor" }
-#ktor-core-di = { module = "io.ktor:ktor-server-di", version.ref = "ktor" }
+ktor-core-di = { module = "io.ktor:ktor-server-di", version.ref = "ktor" }
 ktor-netty = { module = "io.ktor:ktor-server-netty", version.ref = "ktor" }
 ktor-testHost = { module = "io.ktor:ktor-server-test-host", version.ref = "ktor" }
 ktor-slf4j = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }

--- a/projects/ktor/koin-ktor/build.gradle.kts
+++ b/projects/ktor/koin-ktor/build.gradle.kts
@@ -41,8 +41,9 @@ kotlin {
             api(project(":core:koin-core"))
             // Ktor
             implementation(libs.ktor.core)
-            //TODO Ktor 3.2
-//            implementation(libs.ktor.core.di)
+            implementation(libs.ktor.core.di)
+            // Coroutines
+            implementation(libs.kotlin.coroutines)
         }
         jvmTest.dependencies {
             implementation(libs.kotlin.test)

--- a/projects/ktor/koin-ktor/src/commonMain/kotlin/org/koin/ktor/di/KoinDependencyMap.kt
+++ b/projects/ktor/koin-ktor/src/commonMain/kotlin/org/koin/ktor/di/KoinDependencyMap.kt
@@ -1,26 +1,68 @@
+/*
+ * Copyright 2017-Present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.koin.ktor.di
 
-//import io.ktor.server.plugins.di.DependencyKey
-//import io.ktor.server.plugins.di.DependencyMap
-//import org.koin.core.Koin
-//import org.koin.core.qualifier.Qualifier
-//import org.koin.core.qualifier.named
-//
-///**
-// * Provide Ktor DI Support for Koin to allow reverse resolution from dependencies { } expression
-// *
-// * @param koin - Koin instance
-// */
-//TODO Ktor 3.2
-//class KoinDependencyMap(val koin: Koin): DependencyMap {
-//    override fun contains(key: DependencyKey): Boolean {
-//        return key.qualifier !is Qualifier && koin.getOrNull<Any>(key.type.type, key.toQualifier()) == null
-//    }
-//    override fun <T> get(key: DependencyKey): T {
-//        return koin.get(key.type.type, key.toQualifier())
-//    }
-//}
-//
-//private fun DependencyKey.toQualifier(): Qualifier? {
-//    return name?.let(::named)
-//}
+import io.ktor.server.application.Application
+import io.ktor.server.plugins.di.*
+import org.koin.core.Koin
+import org.koin.core.error.NoDefinitionFoundException
+import org.koin.core.qualifier.Qualifier
+import org.koin.core.qualifier.named
+import org.koin.ktor.plugin.koin
+
+/**
+ * Full DependencyMapExtension integration for Koin with Ktor 3.2 DI
+ *
+ * This implementation provides seamless integration by implementing the
+ * DependencyMapExtension interface, allowing Ktor DI to automatically
+ * resolve dependencies from Koin when not found in Ktor's registry.
+ */
+class KoinDependencyMapExtension : DependencyMapExtension {
+
+    override fun get(application: Application): DependencyMap {
+        return KoinDependencyMap(application.koin())
+    }
+}
+
+/**
+ * Koin implementation of DependencyMap interface
+ */
+class KoinDependencyMap(private val koin: Koin) : DependencyMap {
+
+    override fun contains(key: DependencyKey): Boolean =
+        try {
+            resolve(key)
+            true
+        } catch (e: NoDefinitionFoundException) {
+            false
+        }
+
+    override fun getInitializer(key: DependencyKey): DependencyInitializer =
+        DependencyInitializer.Explicit(key) {
+            resolve(key)
+        }
+
+    // Here we are using Any because we do not have the type
+    private fun resolve(key: DependencyKey): Any {
+        val clazz = key.type.type
+        val qualifier = key.toQualifier()
+        return koin.get(clazz, qualifier)
+    }
+}
+
+private fun DependencyKey.toQualifier(): Qualifier? {
+    return name?.let(::named)
+}

--- a/projects/ktor/koin-ktor/src/commonMain/kotlin/org/koin/ktor/di/KtorDIExtension.kt
+++ b/projects/ktor/koin-ktor/src/commonMain/kotlin/org/koin/ktor/di/KtorDIExtension.kt
@@ -15,25 +15,29 @@
  */
 package org.koin.ktor.di
 
-//import io.ktor.server.application.Application
-//import io.ktor.server.plugins.di.DependencyKey
-//import io.ktor.server.plugins.di.dependencies
-//import io.ktor.server.plugins.di.getOrNull
-//import io.ktor.util.reflect.TypeInfo
-//import org.koin.core.instance.ResolutionContext
-//import org.koin.core.resolution.ResolutionExtension
-//import org.koin.core.scope.Scope
-//
-///**
-// * Ktor DI Resolver Extension to help Koin resolve Ktor DI objects
-// *
-// * @author Arnaud Giuliani
-// */
-//TODO Ktor 3.2 - @see setupKoinApplication()
-//internal class KtorDIExtension(private val application : Application) : ResolutionExtension {
-//    override val name: String = "ktor-di"
-//    override fun resolve(scope: Scope, instanceContext: ResolutionContext): Any? {
-//        val key = DependencyKey(TypeInfo(instanceContext.clazz), qualifier = instanceContext.qualifier?.value)
-//        return application.dependencies.getOrNull(key)
-//    }
-//}
+import io.ktor.server.application.Application
+import io.ktor.server.plugins.di.DependencyKey
+import io.ktor.server.plugins.di.dependencies
+import io.ktor.util.reflect.TypeInfo
+import org.koin.core.instance.ResolutionContext
+import org.koin.core.resolution.ResolutionExtension
+import org.koin.core.scope.Scope
+import kotlinx.coroutines.runBlocking
+
+/**
+ * Ktor DI Resolver Extension to help Koin resolve Ktor DI objects
+ *
+ * @author Arnaud Giuliani
+ */
+internal class KtorDIExtension(private val application : Application) : ResolutionExtension {
+    override val name: String = "ktor-di"
+    override fun resolve(scope: Scope, instanceContext: ResolutionContext): Any? {
+        val key = DependencyKey(TypeInfo(instanceContext.clazz), qualifier = instanceContext.qualifier?.value)
+        // runBlocking is required here because Ktor DI's get() function is suspend
+        // The blocking call is generally safe as dependency resolution is typically fast and non-blocking
+        // WARNING: This may cause problems for users as it can impact performance
+        return runBlocking {
+            application.dependencies.get(key)
+        }
+    }
+}

--- a/projects/ktor/koin-ktor/src/commonMain/kotlin/org/koin/ktor/plugin/KoinPlugin.kt
+++ b/projects/ktor/koin-ktor/src/commonMain/kotlin/org/koin/ktor/plugin/KoinPlugin.kt
@@ -34,6 +34,7 @@ import org.koin.core.module.Module
 import org.koin.core.scope.Scope
 import org.koin.dsl.KoinAppDeclaration
 import org.koin.dsl.ModuleDeclaration
+import org.koin.ktor.di.KtorDIExtension
 import org.koin.mp.KoinPlatformTools
 
 /**
@@ -58,8 +59,10 @@ val Koin =
 internal fun PluginBuilder<KoinApplication>.setupKoinApplication(): KoinApplication {
     val koinApplication = pluginConfig
     koinApplication.createEagerInstances()
-    //TODO Ktor 3.2
-//    koinApplication.koin.resolver.addResolutionExtension(KtorDIExtension(application))
+    
+    // Register KtorDIExtension for Ktor DI integration
+    koinApplication.koin.resolver.addResolutionExtension(KtorDIExtension(application))
+    
     application.setKoinApplication(koinApplication)
     return koinApplication
 }

--- a/projects/ktor/koin-ktor/src/commonMain/resources/META-INF/services/io.ktor.server.plugins.di.DependencyMapExtension
+++ b/projects/ktor/koin-ktor/src/commonMain/resources/META-INF/services/io.ktor.server.plugins.di.DependencyMapExtension
@@ -1,0 +1,1 @@
+org.koin.ktor.di.KoinDependencyMapExtension

--- a/projects/ktor/koin-ktor/src/jvmTest/kotlin/org/koin/ktor/di/KtorDIBridgeTest.kt
+++ b/projects/ktor/koin-ktor/src/jvmTest/kotlin/org/koin/ktor/di/KtorDIBridgeTest.kt
@@ -1,0 +1,128 @@
+package org.koin.ktor.di
+
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import io.ktor.server.application.*
+import io.ktor.server.plugins.di.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
+import io.ktor.server.testing.*
+import org.junit.Test
+import org.koin.dsl.module
+import org.koin.ktor.ext.inject
+import org.koin.ktor.plugin.Koin
+import kotlin.test.assertEquals
+
+class KtorDIBridgeTest {
+
+    @Test
+    fun `should access Koin dependency via inject delegate`() = testApplication {
+        application {
+            bridgeModule()
+        }
+
+        val response = client.get("/koin")
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertEquals("Hello from Koin!", response.bodyAsText())
+    }
+
+    @Test
+    fun `should access Ktor DI dependency via dependencies delegate`() = testApplication {
+        application {
+            bridgeModule()
+        }
+
+        val response = client.get("/ktor-di")
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertEquals("Processed by Ktor DI", response.bodyAsText())
+    }
+
+    @Test
+    fun `should access both dependencies in mixed mode via dependencies delegate`() = testApplication {
+        application {
+            bridgeModule()
+        }
+
+        val response = client.get("/mixed-ktor-di")
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertEquals("Hello from Koin! - Processed by Ktor DI", response.bodyAsText())
+    }
+
+    @Test
+    fun `should access both dependencies in mixed mode via inject delegate`() = testApplication {
+        application {
+            bridgeModule()
+        }
+
+        val response = client.get("/mixed-koin")
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertEquals("Hello from Koin! - Processed by Ktor DI", response.bodyAsText())
+    }
+
+    private fun Application.bridgeModule() {
+        // Install Koin first
+        install(Koin) {
+            modules(module {
+                single<HelloService> { HelloServiceImpl() }
+            })
+        }
+
+        // Install Ktor DI and register dependencies
+        dependencies {
+            provide<KtorSpecificService> { KtorSpecificServiceImpl() }
+        }
+
+        routing {
+            get("/koin") {
+                val helloService: HelloService by inject() // From koin
+                call.respond(helloService.sayHello())
+            }
+
+            get("/ktor-di") {
+                val ktorService: KtorSpecificService by dependencies // From Ktor DI
+                call.respond(ktorService.process())
+            }
+
+            get("/mixed-ktor-di") {
+                // Using both Koin and Ktor DI via dependencies delegate
+                val helloService: HelloService by dependencies // From Koin via Ktor DI
+                val ktorService: KtorSpecificService by dependencies // From Ktor DI
+                try {
+                    call.respond("${helloService.sayHello()} - ${ktorService.process()}")
+                } catch (e: Exception) {
+                    call.respond(HttpStatusCode.InternalServerError, "Error: ${e.message}")
+                }
+
+            }
+
+            get("/mixed-koin") {
+                // Using both Koin and Ktor DI via inject delegate
+                val helloService: HelloService by inject() // From Koin
+                val ktorService: KtorSpecificService by inject() // From Ktor DI via Koin
+                try {
+                    call.respond("${helloService.sayHello()} - ${ktorService.process()}")
+                } catch (e: Exception) {
+                    call.respond(HttpStatusCode.InternalServerError, "Error: ${e.message}")
+                }
+            }
+        }
+    }
+
+}
+
+interface HelloService {
+    fun sayHello(): String
+}
+
+class HelloServiceImpl : HelloService {
+    override fun sayHello(): String = "Hello from Koin!"
+}
+
+interface KtorSpecificService {
+    fun process(): String
+}
+
+class KtorSpecificServiceImpl : KtorSpecificService {
+    override fun process(): String = "Processed by Ktor DI"
+}


### PR DESCRIPTION
Ktor DI Bridge Implementation
  - Added KoinDependencyMapExtension implementing Ktor 3.2's DependencyMapExtension interface
  - Registered via SPI in META-INF/services/io.ktor.server.plugins.di.DependencyMapExtension

Koin can resolve Ktor DI dependencies via KtorDIExtension resolution extension.
  - There is a potential problem with runBlocking usage

When dependency is not found, each library is delegating to the other in an infinite loop

Fixed a problem in CoreResolver that was not resolving extensions

Created a sample application to show usage.