### PR TITLE
Add optional navGraphRoute parameter to sharedKoinViewModel for flexible navigation graph resolution

### DIFF
--- a/projects/compose/koin-compose-viewmodel-navigation/src/commonMain/kotlin/org/koin/compose/viewmodel/NavViewModel.kt
+++ b/projects/compose/koin-compose-viewmodel-navigation/src/commonMain/kotlin/org/koin/compose/viewmodel/NavViewModel.kt
@@ -77,11 +77,12 @@ inline fun <reified T : ViewModel> koinNavViewModel(
  *
  * @author Arnaud Giuliani
  */
-@Composable
-inline fun <reified T: ViewModel> NavBackStackEntry.sharedKoinViewModel(
-    navController: NavController
-): T {
-    val navGraphRoute = destination.parent?.route ?: return koinViewModel<T>()
+ @Composable
+inline fun <reified VM : ViewModel> NavBackStackEntry.sharedKoinViewModel(
+    navController: NavController,
+    navGraphRoute: Any? = this.destination.parent?.route,
+): VM {
+    val navGraphRoute = navGraphRoute ?: return koinViewModel<VM>()
     val parentEntry = remember(this) {
         navController.getBackStackEntry(navGraphRoute)
     }


### PR DESCRIPTION
This PR introduces an overload for sharedKoinViewModel to allow an optional navGraphRoute parameter.

Motivation
The current implementation relies on destination.parent?.route which works for simple hierarchies. In more complex navigation setups (nested graphs, sibling graphs, multi-level NavHost), developers may need explicit control over which NavBackStackEntry to use.

Changes
	•	Added navGraphRoute parameter with default this.destination.parent?.route.
	•	Fallback to default koinViewModel<VM>() if navGraphRoute is null.

Example Usage
val vm: MyViewModel = navBackStackEntry.sharedKoinViewModel(
    navController = navController,
    navGraphRoute = "parent_graph"
)

This improves flexibility without breaking existing API.