### PR TITLE
build: migrate to type-safe project dependencies

### DIFF
--- a/projects/android/koin-android-compat/build.gradle.kts
+++ b/projects/android/koin-android-compat/build.gradle.kts
@@ -34,7 +34,7 @@ tasks.withType<KotlinCompile>().all {
 }
 
 dependencies {
-    api(project(":android:koin-android"))
+    api(projects.android.koinAndroid)
 }
 
 // android sources

--- a/projects/android/koin-android-test/build.gradle.kts
+++ b/projects/android/koin-android-test/build.gradle.kts
@@ -34,9 +34,9 @@ tasks.withType<KotlinCompile>().all {
 }
 
 dependencies {
-    api(project(":android:koin-android"))
-    api(project(":android:koin-androidx-workmanager"))
-    api(project(":core:koin-test"))
+    api(projects.android.koinAndroid)
+    api(projects.android.koinAndroidxWorkmanager)
+    api(projects.core.koinTest)
     // Test
     testImplementation(libs.test.junit)
     testImplementation(libs.test.mockito)

--- a/projects/android/koin-android/build.gradle.kts
+++ b/projects/android/koin-android/build.gradle.kts
@@ -40,16 +40,16 @@ tasks.withType<KotlinCompile>().all {
 }
 
 dependencies {
-    api(project(":core:koin-core"))
-    api(project(":core:koin-core-viewmodel"))
+    api(projects.core.koinCore)
+    api(projects.core.koinCoreViewmodel)
     api(libs.android.appcompat)
     api(libs.android.activity)
     api(libs.android.fragment)
     api(libs.androidx.viewmodel)
 
     // tests
-    testImplementation(project(":core:koin-test"))
-    testImplementation(project(":core:koin-test-junit4"))
+    testImplementation(projects.core.koinTest)
+    testImplementation(projects.core.koinTestJunit4)
     testImplementation(libs.kotlin.test)
     testImplementation(libs.test.junit)
     testImplementation(libs.test.mockito)

--- a/projects/android/koin-androidx-navigation/build.gradle.kts
+++ b/projects/android/koin-androidx-navigation/build.gradle.kts
@@ -34,7 +34,7 @@ tasks.withType<KotlinCompile>().all {
 }
 
 dependencies {
-    api(project(":android:koin-android"))
+    api(projects.android.koinAndroid)
     api(libs.androidx.navigation)
 }
 

--- a/projects/android/koin-androidx-startup/build.gradle.kts
+++ b/projects/android/koin-androidx-startup/build.gradle.kts
@@ -34,7 +34,7 @@ tasks.withType<KotlinCompile>().all {
 }
 
 dependencies {
-    api(project(":android:koin-android"))
+    api(projects.android.koinAndroid)
     api(libs.androidx.startup)
 
     // Test

--- a/projects/android/koin-androidx-workmanager/build.gradle.kts
+++ b/projects/android/koin-androidx-workmanager/build.gradle.kts
@@ -34,7 +34,7 @@ tasks.withType<KotlinCompile>().all {
 }
 
 dependencies {
-    api(project(":android:koin-android"))
+    api(projects.android.koinAndroid)
     api(libs.androidx.workmanager)
 
     // Test

--- a/projects/android/koin-dagger-bridge/build.gradle.kts
+++ b/projects/android/koin-dagger-bridge/build.gradle.kts
@@ -34,7 +34,7 @@ tasks.withType<KotlinCompile>().all {
 }
 
 dependencies {
-    api(project(":android:koin-android"))
+    api(projects.android.koinAndroid)
     implementation(libs.dagger.core)
 }
 

--- a/projects/bom/koin-bom/build.gradle.kts
+++ b/projects/bom/koin-bom/build.gradle.kts
@@ -8,35 +8,35 @@ javaPlatform {
 
 dependencies {
     constraints {
-        api(project(":core:koin-core-annotations"))
-        api(project(":core:koin-annotations"))
-        api(project(":core:koin-core"))
+        api(projects.core.koinCoreAnnotations)
+        api(projects.core.koinAnnotations)
+        api(projects.core.koinCore)
         api("io.insert-koin:koin-core-jvm:$version") //Check later KMP Bom
-        api(project(":core:koin-core-coroutines"))
-        api(project(":core:koin-core-viewmodel"))
-        api(project(":core:koin-test"))
-        api(project(":core:koin-test-coroutines"))
-        api(project(":core:koin-test-junit4"))
-        api(project(":core:koin-test-junit5"))
+        api(projects.core.koinCoreCoroutines)
+        api(projects.core.koinCoreViewmodel)
+        api(projects.core.koinTest)
+        api(projects.core.koinTestCoroutines)
+        api(projects.core.koinTestJunit4)
+        api(projects.core.koinTestJunit5)
 
-        api(project(":ktor:koin-ktor"))
+        api(projects.ktor.koinKtor)
         api("io.insert-koin:koin-ktor-jvm:$version") //Check later KMP Bom
-        api(project(":ktor:koin-logger-slf4j"))
+        api(projects.ktor.koinLoggerSlf4j)
 
-        api(project(":android:koin-android"))
-        api(project(":android:koin-android-compat"))
-        api(project(":android:koin-android-test"))
-        api(project(":android:koin-androidx-navigation"))
-        api(project(":android:koin-androidx-workmanager"))
-        api(project(":android:koin-androidx-startup"))
-        api(project(":android:koin-dagger-bridge"))
+        api(projects.android.koinAndroid)
+        api(projects.android.koinAndroidCompat)
+        api(projects.android.koinAndroidTest)
+        api(projects.android.koinAndroidxNavigation)
+        api(projects.android.koinAndroidxWorkmanager)
+        api(projects.android.koinAndroidxStartup)
+        api(projects.android.koinDaggerBridge)
 
-        api(project(":compose:koin-compose"))
-        api(project(":compose:koin-compose-navigation3"))
-        api(project(":compose:koin-compose-viewmodel"))
-        api(project(":compose:koin-compose-viewmodel-navigation"))
-        api(project(":compose:koin-androidx-compose"))
-        api(project(":compose:koin-androidx-compose-navigation"))
+        api(projects.compose.koinCompose)
+        api(projects.compose.koinComposeNavigation3)
+        api(projects.compose.koinComposeViewmodel)
+        api(projects.compose.koinComposeViewmodelNavigation)
+        api(projects.compose.koinAndroidxCompose)
+        api(projects.compose.koinAndroidxComposeNavigation)
     }
 }
 

--- a/projects/compose/koin-androidx-compose-navigation/build.gradle.kts
+++ b/projects/compose/koin-androidx-compose-navigation/build.gradle.kts
@@ -40,7 +40,7 @@ tasks.withType<KotlinCompile>().all {
 }
 
 dependencies {
-    api(project(":compose:koin-androidx-compose"))
+    api(projects.compose.koinAndroidxCompose)
 //    api(libs.androidx.composeNavigation)
 }
 

--- a/projects/compose/koin-androidx-compose/build.gradle.kts
+++ b/projects/compose/koin-androidx-compose/build.gradle.kts
@@ -40,8 +40,8 @@ tasks.withType<KotlinCompile>().all {
 }
 
 dependencies {
-    api(project(":compose:koin-compose"))
-    api(project(":compose:koin-compose-viewmodel"))
+    api(projects.compose.koinCompose)
+    api(projects.compose.koinComposeViewmodel)
 }
 
 // android sources

--- a/projects/compose/koin-compose-navigation3/build.gradle.kts
+++ b/projects/compose/koin-compose-navigation3/build.gradle.kts
@@ -43,10 +43,10 @@ kotlin {
 
     sourceSets {
         androidMain.dependencies {
-            api(project(":android:koin-android"))
+            api(projects.android.koinAndroid)
         }
         commonMain.dependencies {
-            api(project(":compose:koin-compose"))
+            api(projects.compose.koinCompose)
             implementation(libs.androidx.navigation3.runtime)
         }
     }

--- a/projects/compose/koin-compose-viewmodel-navigation/build.gradle.kts
+++ b/projects/compose/koin-compose-viewmodel-navigation/build.gradle.kts
@@ -43,7 +43,7 @@ kotlin {
 
     sourceSets {
         commonMain.dependencies {
-            api(project(":compose:koin-compose-viewmodel"))
+            api(projects.compose.koinComposeViewmodel)
             api(libs.jb.composeNavigation)
         }
     }

--- a/projects/compose/koin-compose-viewmodel/build.gradle.kts
+++ b/projects/compose/koin-compose-viewmodel/build.gradle.kts
@@ -43,8 +43,8 @@ kotlin {
 
     sourceSets {
         commonMain.dependencies {
-            api(project(":compose:koin-compose"))
-            api(project(":core:koin-core-viewmodel"))
+            api(projects.compose.koinCompose)
+            api(projects.core.koinCoreViewmodel)
             api(libs.jb.composeViewmodel)
         }
         androidMain.dependencies {

--- a/projects/compose/koin-compose/build.gradle.kts
+++ b/projects/compose/koin-compose/build.gradle.kts
@@ -43,13 +43,13 @@ kotlin {
 
     sourceSets {
         commonMain.dependencies {
-            api(project(":core:koin-core"))
+            api(projects.core.koinCore)
             api(libs.jb.composeRuntime)
             api(libs.jb.composeFoundation)
         }
         androidMain.dependencies {
             api(libs.android.activity.compose)
-            api(project(":android:koin-android"))
+            api(projects.android.koinAndroid)
         }
         nativeMain.dependencies {
         }

--- a/projects/core/benchmark/build.gradle.kts
+++ b/projects/core/benchmark/build.gradle.kts
@@ -17,8 +17,8 @@ kotlin {
     sourceSets {
         commonMain.dependencies {
             implementation(libs.benchmark.runtime)
-            api(project(":core:koin-core"))
-            api(project(":core:koin-core-coroutines"))
+            api(projects.core.koinCore)
+            api(projects.core.koinCoreCoroutines)
         }
         jvmMain.dependencies {
 

--- a/projects/core/koin-annotations/build.gradle.kts
+++ b/projects/core/koin-annotations/build.gradle.kts
@@ -39,7 +39,7 @@ kotlin {
 
     sourceSets {
         commonMain.dependencies {
-            api(project(":core:koin-core-annotations"))
+            api(projects.core.koinCoreAnnotations)
         }
     }
 }

--- a/projects/core/koin-core-coroutines/build.gradle.kts
+++ b/projects/core/koin-core-coroutines/build.gradle.kts
@@ -34,7 +34,7 @@ kotlin {
 
     sourceSets {
         commonMain.dependencies {
-            api(project(":core:koin-core"))
+            api(projects.core.koinCore)
             api(libs.kotlin.coroutines)
         }
         commonTest.dependencies {

--- a/projects/core/koin-core-viewmodel/build.gradle.kts
+++ b/projects/core/koin-core-viewmodel/build.gradle.kts
@@ -50,7 +50,7 @@ kotlin {
 
     sourceSets {
         commonMain.dependencies {
-            api(project(":core:koin-core"))
+            api(projects.core.koinCore)
             api(libs.jb.lifecycleViewmodel)
             api(libs.jb.lifecycleViewmodelSavedState)
         }

--- a/projects/core/koin-test-coroutines/build.gradle.kts
+++ b/projects/core/koin-test-coroutines/build.gradle.kts
@@ -11,13 +11,13 @@ kotlin {
 
     sourceSets {
         commonMain.dependencies {
-            api(project(":core:koin-core"))
-            api(project(":core:koin-test"))
-            api(project(":core:koin-core-coroutines"))
+            api(projects.core.koinCore)
+            api(projects.core.koinTest)
+            api(projects.core.koinCoreCoroutines)
             api(libs.kotlin.test)
         }
         jvmMain.dependencies {
-            api(project(":core:koin-test"))
+            api(projects.core.koinTest)
             api(kotlin("reflect"))
         }
         commonTest.dependencies {

--- a/projects/core/koin-test-junit4/build.gradle.kts
+++ b/projects/core/koin-test-junit4/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 dependencies {
-    api(project(":core:koin-test"))
+    api(projects.core.koinTest)
     api(libs.test.junit)
     testImplementation(libs.kotlin.test)
     testImplementation(libs.test.mockito)

--- a/projects/core/koin-test-junit5/build.gradle.kts
+++ b/projects/core/koin-test-junit5/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 dependencies {
-    api(project(":core:koin-test"))
+    api(projects.core.koinTest)
     api(libs.test.jupiter)
     testImplementation(libs.test.mockito)
 }

--- a/projects/core/koin-test/build.gradle.kts
+++ b/projects/core/koin-test/build.gradle.kts
@@ -39,8 +39,8 @@ kotlin {
 
     sourceSets {
         commonMain.dependencies {
-            api(project(":core:koin-core"))
-            api(project(":core:koin-core-annotations"))
+            api(projects.core.koinCore)
+            api(projects.core.koinCoreAnnotations)
             api(libs.kotlin.test)
         }
         jvmMain.dependencies {

--- a/projects/ktor/koin-ktor/build.gradle.kts
+++ b/projects/ktor/koin-ktor/build.gradle.kts
@@ -38,7 +38,7 @@ kotlin {
 
     sourceSets {
         commonMain.dependencies {
-            api(project(":core:koin-core"))
+            api(projects.core.koinCore)
             // Ktor
             implementation(libs.ktor.core)
             implementation(libs.ktor.core.di)

--- a/projects/ktor/koin-logger-slf4j/build.gradle.kts
+++ b/projects/ktor/koin-logger-slf4j/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 dependencies {
-    api(project(":core:koin-core"))
+    api(projects.core.koinCore)
     api(libs.ktor.slf4j)
 }
 

--- a/projects/plugins/koin-gradle-plugin/build.gradle.kts
+++ b/projects/plugins/koin-gradle-plugin/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 dependencies {
-    implementation(project(":core:koin-test"))
+    implementation(projects.core.koinTest)
     implementation(gradleApi())
 }
 


### PR DESCRIPTION
### Description
This PR migrates internal module dependencies from string-based paths to Gradle Type-safe project accessors.

### Changes
Enabled `TYPESAFE_PROJECT_ACCESSORS` in `settings.gradle.kts`.

Refactored `build.gradle.kts` files to use the `projects` extension instead of `project(":path")`.

### Example Change:

- Old: `api(project(":core:koin-core"))`
- New: `api(projects.core.koinCore)`

### Motivation

- **Type Safety:** Prevents build failures caused by typos in module strings.

- **IDE Support:** Enables autocompletion and "find usages" for modules within Gradle files.

- **Modernization:** Aligns the build system with current Gradle best practices.