### PR TITLE
fix CoreResolver to call to resolveInExtensions()

### DIFF
--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/resolution/CoreResolver.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/resolution/CoreResolver.kt
@@ -75,7 +75,7 @@ class CoreResolver(
             ?: resolveFromStackedParameters(scope,instanceContext)
             ?: resolveFromScopeSource(scope,instanceContext)
             ?: resolveFromScopeArchetype(scope,instanceContext)
-            ?: if (lookupParent) resolveFromParentScopes(scope,instanceContext) else null
+            ?: (if (lookupParent) resolveFromParentScopes(scope,instanceContext) else null)
             ?: resolveInExtensions(scope,instanceContext)
     }
 


### PR DESCRIPTION
incorrect brackets mean resolveInExtensions() is never reached unless lookupParent=false

to my understanding this is undesired behaviour and ResolutionExtensions should be called to if all previous resolution functions return "null"