### PR TITLE
do not assume system properties are strings (gh-2348)

### DIFF
--- a/projects/core/koin-core/src/jvmMain/kotlin/org/koin/core/registry/PropertyRegistryExt.kt
+++ b/projects/core/koin-core/src/jvmMain/kotlin/org/koin/core/registry/PropertyRegistryExt.kt
@@ -8,7 +8,7 @@ import org.koin.core.error.NoPropertyFileFoundException
 import java.util.*
 
 /**
- *Save properties values into PropertyRegister
+ * Save [Properties] values into PropertyRegistry
  */
 fun PropertyRegistry.saveProperties(properties: Properties) {
     _koin.logger.debug("load ${properties.size} properties")

--- a/projects/core/koin-core/src/jvmMain/kotlin/org/koin/core/registry/PropertyRegistryExt.kt
+++ b/projects/core/koin-core/src/jvmMain/kotlin/org/koin/core/registry/PropertyRegistryExt.kt
@@ -13,16 +13,13 @@ import java.util.*
 fun PropertyRegistry.saveProperties(properties: Properties) {
     _koin.logger.debug("load ${properties.size} properties")
 
-    properties.filter { (key, _) ->
+    properties.forEach { (key, value) ->
         if (key is String) {
-            return@filter true
+            saveProperty(key, value)
         }
         else {
             _koin.logger.debug("Skipping property $key")
-            return@filter false
         }
-    }.forEach { (key, value) ->
-        saveProperty(key as String, value)
     }
 }
 

--- a/projects/core/koin-core/src/jvmMain/kotlin/org/koin/core/registry/PropertyRegistryExt.kt
+++ b/projects/core/koin-core/src/jvmMain/kotlin/org/koin/core/registry/PropertyRegistryExt.kt
@@ -10,13 +10,19 @@ import java.util.*
 /**
  *Save properties values into PropertyRegister
  */
-@Suppress("UNCHECKED_CAST")
 fun PropertyRegistry.saveProperties(properties: Properties) {
     _koin.logger.debug("load ${properties.size} properties")
 
-    val propertiesMapValues = properties.toMap() as Map<String, String>
-    propertiesMapValues.forEach { (k: String, v: String) ->
-        saveProperty(k, v)
+    properties.filter { (key, _) ->
+        if (key is String) {
+            return@filter true
+        }
+        else {
+            _koin.logger.debug("Skipping property $key")
+            return@filter false
+        }
+    }.forEach { (key, value) ->
+        saveProperty(key as String, value)
     }
 }
 

--- a/projects/core/koin-core/src/jvmTest/kotlin/org/koin/core/registry/PropertyRegistryTest.kt
+++ b/projects/core/koin-core/src/jvmTest/kotlin/org/koin/core/registry/PropertyRegistryTest.kt
@@ -1,0 +1,40 @@
+package org.koin.core.registry
+
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import org.koin.KoinCoreTest
+import org.koin.core.annotation.KoinInternalApi
+import org.koin.core.context.GlobalContext.startKoin
+import org.koin.core.logger.Level
+import org.koin.environmentProperties
+import java.util.*
+
+class PropertyRegistryTest : KoinCoreTest() {
+
+    @Before
+    fun setupEdgeCaseProperties() {
+        val map = Properties()
+
+        // load existing properties
+        map.putAll(System.getProperties())
+
+        map[Any::class.java] = Any()
+        map["koin.test.kotlin.any.class"] = Any::class
+        map[ArrayList::class.java] = ArrayList<Any?>()
+
+        System.setProperties(map)
+    }
+
+    @OptIn(KoinInternalApi::class)
+    @Test
+    fun arbitraryObjectProperties() {
+        val koin = startKoin {
+            printLogger(Level.INFO)
+
+            environmentProperties()
+        }.koin
+
+        Assert.assertEquals(Any::class, koin.propertyRegistry.getProperty<Any?>("koin.test.kotlin.any.class"))
+    }
+}


### PR DESCRIPTION
This fixes #2348 by properly checking whether property keys are strings.

No check is done on the property value, since Koin already supports arbitrary types for property values.
And I removed the unnecessary copy to a map before iterating.

Also attempted to add a test case for this, but I could not get tests to run on my local machine so would appreciate if someone could double check that.