### PR TITLE
Scope implements AutoCloseable

### DIFF
--- a/docs/reference/koin-core/scopes.md
+++ b/docs/reference/koin-core/scopes.md
@@ -81,10 +81,23 @@ class FragmentPresenter
 
 ## Creating and Using Scopes
 
-### Manual Scope Management
+### Using Scopes with `use { }`
+
+`Scope` implements `AutoCloseable`, so you can use Kotlin's `use { }` block for safe, automatic cleanup. This is the recommended approach for short-lived scopes (request handling, transactions, batch jobs, etc.):
 
 ```kotlin
-// Create a scope
+getKoin().createScope("my_scope_id", named("session")).use { scope ->
+    val sessionData: SessionData = scope.get()
+    val prefs: UserPreferences = scope.get()
+}
+// scope is closed automatically, even on exceptions
+```
+
+### Manual Scope Management
+
+For longer-lived scopes, you can manage the lifecycle manually:
+
+```kotlin
 val myScope = getKoin().createScope("my_scope_id", named("session"))
 
 // Get instances from scope
@@ -324,18 +337,24 @@ fun MyScreen() {
 
 ### Closing Scopes
 
+`Scope` implements `AutoCloseable`. The recommended way to handle scope cleanup is with `use { }`:
+
+```kotlin
+getKoin().createScope("my_scope", named("session")).use { scope ->
+    val data: SessionData = scope.get()
+}
+// All scoped instances released automatically, even on exceptions
+```
+
 When a scope closes:
 1. All scoped instances are released
 2. `onClose` callbacks are invoked
 3. Scope becomes unusable
 
 ```kotlin
+// Manual close is also supported
 val scope = getKoin().createScope("my_scope", named("session"))
-
-// Use the scope
 val data: SessionData = scope.get()
-
-// Close when done
 scope.close()  // SessionData instance released
 
 // This throws an exception
@@ -406,7 +425,7 @@ class CheckoutActivity : AppCompatActivity(), AndroidScopeComponent {
 
 1. **Use singletons sparingly** - Only for truly app-wide dependencies
 2. **Scope shared state** - When multiple components need the same instance
-3. **Close scopes explicitly** - Don't rely on garbage collection
+3. **Close scopes explicitly** - Use `scope.use { }` for short-lived scopes, or call `close()` manually
 4. **Keep scopes focused** - Don't put everything in one scope
 5. **Use Android scope components** - For automatic lifecycle management
 

--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/scope/Scope.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/scope/Scope.kt
@@ -51,7 +51,7 @@ class Scope(
     val scopeArchetype : TypeQualifier? = null,
     @PublishedApi
     internal val _koin: Koin,
-) : Lockable() {
+) : Lockable(), AutoCloseable {
 
     internal val linkedScopes = ArrayList<Scope>()
     @KoinInternalApi
@@ -431,7 +431,7 @@ class Scope(
     /**
      * Close all instances from this scope
      */
-    fun close() = KoinPlatformTools.synchronized(this) {
+    override fun close() = KoinPlatformTools.synchronized(this) {
         _koin.logger.debug("|- (-) Scope - id:'$id'")
 
         _callbacks.forEach { it.onScopeClose(this) }

--- a/projects/core/koin-core/src/commonTest/kotlin/org/koin/core/ScopeAPITest.kt
+++ b/projects/core/koin-core/src/commonTest/kotlin/org/koin/core/ScopeAPITest.kt
@@ -127,6 +127,46 @@ class ScopeAPITest {
         assertTrue(closed)
     }
 
+    @Test
+    fun `scope implements AutoCloseable and works with use`() {
+        val scope = koin.createScope("myScope", scopeKey)
+        var closed = false
+        scope.registerCallback(object : ScopeCallback {
+            override fun onScopeClose(scope: Scope) {
+                closed = true
+            }
+        })
+
+        val result = scope.use {
+            it.get<A>()
+        }
+
+        assertNotNull(result)
+        assertTrue(closed)
+    }
+
+    @Test
+    fun `scope use closes on exception`() {
+        val scope = koin.createScope("myScope", scopeKey)
+        var closed = false
+        scope.registerCallback(object : ScopeCallback {
+            override fun onScopeClose(scope: Scope) {
+                closed = true
+            }
+        })
+
+        try {
+            scope.use {
+                error("test exception")
+            }
+            fail()
+        } catch (e: IllegalStateException) {
+            assertEquals("test exception", e.message)
+        }
+
+        assertTrue(closed)
+    }
+
     class MyScopeComponent(private val _koin: Koin) : KoinScopeComponent {
         override fun getKoin(): Koin = _koin
         override val scope: Scope = createScope()


### PR DESCRIPTION
## Summary

- `Scope` now implements `AutoCloseable`, enabling Kotlin's `use { }` pattern for safe scope lifecycle management
- `close()` already existed with the right signature, so the only change is adding the interface declaration and `override` modifier
- This is a **source-compatible** and **binary-compatible** change with no behavioral differences

## Motivation

Koin's `Scope` has a `close()` method but doesn't implement `AutoCloseable`. This means developers can't use Kotlin's `use { }` pattern and must rely on manual `try/finally` blocks, which is error-prone.

With this change:

```kotlin
koin.createScope<MyScope>().use { scope ->
    scope.get<MyService>().execute()
}
// scope.close() called automatically, even on exceptions
```

This is the same pattern Kotlin developers use for `InputStream`, `Connection`, `ResultSet`, etc. Scopes hold resources and have a lifecycle, so they belong in this family.

## Changes

- **`Scope.kt`**: Added `AutoCloseable` interface and `override` on `close()`
- **`ScopeAPITest.kt`**: Two new tests verifying `use { }` works and closes on exceptions
- **`scopes.md`**: Updated documentation with `use { }` as the recommended approach for short-lived scopes

## Compatibility

- **Source compatible**: existing code compiles without changes
- **Binary compatible**: adding an interface is ABI-safe
- **Behavioral**: no change, `close()` already exists with identical semantics
- **Multiplatform**: `AutoCloseable` is available in `kotlin.stdlib` for all targets since Kotlin 1.8

## Test plan

- [x] `scope implements AutoCloseable and works with use` verifies `use { }` resolves instances and auto-closes
- [x] `scope use closes on exception` verifies close is called even when an exception is thrown
- [x] All existing `ScopeAPITest` tests pass (13/13)