### PR TITLE
Koin and KoinApplication implement AutoCloseable

### DIFF
--- a/docs/reference/koin-core/start-koin.md
+++ b/docs/reference/koin-core/start-koin.md
@@ -83,6 +83,12 @@ stopKoin()  // Global instance
 
 // Isolated instance
 koinApp.close()
+
+// Safe cleanup with use { } (KoinApplication and Koin implement AutoCloseable)
+koinApplication { modules(myModule) }.use { app ->
+    val service: MyService = app.koin.get()
+}
+// app.close() called automatically
 ```
 
 ## Logging

--- a/docs/reference/koin-core/starting-koin.md
+++ b/docs/reference/koin-core/starting-koin.md
@@ -356,6 +356,20 @@ val koinApp = koinApplication { modules(myModule) }
 koinApp.close()
 ```
 
+### Using `use { }` for Safe Cleanup
+
+Both `KoinApplication` and `Koin` implement `AutoCloseable`, so you can use Kotlin's `use { }` block for automatic cleanup. This is useful for testing, short-lived contexts, or any situation where you want to ensure resources are released:
+
+```kotlin
+koinApplication {
+    modules(myModule)
+}.use { app ->
+    val service: MyService = app.koin.get()
+    // work with service
+}
+// app.close() called automatically, even on exceptions
+```
+
 ## Logging
 
 ### Enable Logging

--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/Koin.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/Koin.kt
@@ -53,7 +53,7 @@ import kotlin.time.measureTime
  * @author Arnaud Giuliani
  */
 @OptIn(KoinInternalApi::class)
-class Koin {
+class Koin : AutoCloseable {
 
     @KoinInternalApi
     var logger: Logger = EmptyLogger()
@@ -318,7 +318,7 @@ class Koin {
     /**
      * Close all resources from context
      */
-    fun close() {
+    override fun close() {
         scopeRegistry.close()
         instanceRegistry.close()
         propertyRegistry.close()

--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/KoinApplication.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/KoinApplication.kt
@@ -34,7 +34,7 @@ import kotlin.time.measureTime
  */
 @OptIn(KoinInternalApi::class)
 @KoinApplicationDslMarker
-open class KoinApplication protected constructor() {
+open class KoinApplication protected constructor() : AutoCloseable {
 
     val koin = Koin()
     private var allowOverride = true
@@ -136,7 +136,7 @@ open class KoinApplication protected constructor() {
         return this
     }
 
-    fun close() {
+    override fun close() {
         koin.close()
     }
 

--- a/projects/core/koin-core/src/commonTest/kotlin/org/koin/core/KoinAutoCloseableTest.kt
+++ b/projects/core/koin-core/src/commonTest/kotlin/org/koin/core/KoinAutoCloseableTest.kt
@@ -1,0 +1,78 @@
+package org.koin.core
+
+import org.koin.Simple
+import org.koin.core.error.ClosedScopeException
+import org.koin.dsl.koinApplication
+import org.koin.dsl.module
+import kotlin.test.*
+
+class KoinAutoCloseableTest {
+
+    @Test
+    fun `Koin implements AutoCloseable and works with use`() {
+        val app = koinApplication {
+            modules(
+                module {
+                    single { Simple.ComponentA() }
+                },
+            )
+        }
+
+        val result = app.koin.use {
+            it.get<Simple.ComponentA>()
+        }
+
+        assertNotNull(result)
+        assertFailsWith<ClosedScopeException> { app.koin.get<Simple.ComponentA>() }
+    }
+
+    @Test
+    fun `Koin use closes on exception`() {
+        val app = koinApplication {
+            modules(
+                module {
+                    single { Simple.ComponentA() }
+                },
+            )
+        }
+
+        assertFailsWith<IllegalStateException>("test exception") {
+            app.koin.use {
+                error("test exception")
+            }
+        }
+        assertFailsWith<ClosedScopeException> { app.koin.get<Simple.ComponentA>() }
+    }
+
+    @Test
+    fun `KoinApplication implements AutoCloseable and works with use`() {
+        val app = koinApplication {
+            modules(
+                module {
+                    single { Simple.ComponentA() }
+                },
+            )
+        }
+
+        val result = app.use { it.koin.get<Simple.ComponentA>() }
+
+        assertNotNull(result)
+        assertFailsWith<ClosedScopeException> { app.koin.get<Simple.ComponentA>() }
+    }
+
+    @Test
+    fun `KoinApplication use closes on exception`() {
+        val app = koinApplication {
+            modules(
+                module {
+                    single { Simple.ComponentA() }
+                },
+            )
+        }
+
+        assertFailsWith<IllegalStateException>("test exception") {
+            app.use { error("test exception") }
+        }
+        assertFailsWith<ClosedScopeException> { app.koin.get<Simple.ComponentA>() }
+    }
+}


### PR DESCRIPTION
## Summary

- `Koin` and `KoinApplication` now implement `AutoCloseable`, enabling Kotlin's `use { }` pattern for safe resource cleanup
- `close()` already existed with the right signature on both classes, so the only change is adding the interface declaration and `override` modifier
- This is a **source-compatible** and **binary-compatible** change with no behavioral differences

## Motivation

Koin's `Koin` and `KoinApplication` have `close()` methods but don't implement `AutoCloseable`. This means developers can't use Kotlin's `use { }` pattern and must rely on manual `try/finally` blocks, which is error-prone.

With this change:

```kotlin
koinApplication {
    modules(myModule)
}.use { app ->
    val service: MyService = app.koin.get()
    // work with service
}
// app.close() called automatically, even on exceptions
```

This is the same pattern Kotlin developers use for `InputStream`, `Connection`, `ResultSet`, etc. Koin instances hold resources and have a lifecycle, so they belong in this family.

This is a companion to #2363, which added `AutoCloseable` to `Scope`.

## Changes

- **`Koin.kt`**: Added `AutoCloseable` interface and `override` on `close()`
- **`KoinApplication.kt`**: Added `AutoCloseable` interface and `override` on `close()`
- **`KoinAutoCloseableTest.kt`**: Four tests verifying `use { }` works and closes on exceptions for both classes
- **`start-koin.md`** / **`starting-koin.md`**: Updated documentation with `use { }` examples

## Compatibility

- **Source compatible**: existing code compiles without changes
- **Binary compatible**: adding an interface is ABI-safe
- **Behavioral**: no change, `close()` already exists with identical semantics
- **Multiplatform**: `AutoCloseable` is available in `kotlin.stdlib` for all targets since Kotlin 1.8

## Test plan

- [x] `Koin implements AutoCloseable and works with use` verifies `use { }` resolves instances and auto-closes
- [x] `Koin use closes on exception` verifies close is called even when an exception is thrown
- [x] `KoinApplication implements AutoCloseable and works with use` verifies `use { }` resolves instances and auto-closes
- [x] `KoinApplication use closes on exception` verifies close is called even when an exception is thrown