### PR TITLE
Use `@ReadOnlyComposable` wherever possible

### DIFF
--- a/projects/compose/koin-compose/src/androidMain/kotlin/org/koin/compose/KoinApplication.android.kt
+++ b/projects/compose/koin-compose/src/androidMain/kotlin/org/koin/compose/KoinApplication.android.kt
@@ -5,6 +5,7 @@ import android.content.ComponentCallbacks
 import android.content.Context
 import android.content.ContextWrapper
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.remember
 import org.koin.dsl.KoinConfiguration
 import androidx.compose.ui.platform.LocalContext
@@ -18,6 +19,7 @@ import org.koin.dsl.koinConfiguration
 import org.koin.dsl.includes
 
 @Composable
+@ReadOnlyComposable
 internal actual fun composeMultiplatformConfiguration(loggerLevel : Level, config : KoinConfiguration) : KoinConfiguration {
     val appContext = LocalContext.current.applicationContext ?: error("Android ApplicationContext not found in current Compose context!")
     return koinConfiguration {

--- a/projects/compose/koin-compose/src/commonMain/kotlin/org/koin/compose/KoinApplication.kt
+++ b/projects/compose/koin-compose/src/commonMain/kotlin/org/koin/compose/KoinApplication.kt
@@ -20,6 +20,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.InternalComposeApi
 import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.currentComposer
 import org.koin.compose.application.rememberKoinApplication
@@ -62,6 +63,7 @@ private fun getDefaultRootScope() = KoinPlatform.getKoin().scopeRegistry.rootSco
  */
 @OptIn(InternalComposeApi::class, KoinInternalApi::class)
 @Composable
+@ReadOnlyComposable
 fun getKoin(): Koin = currentComposer.run {
     try {
         consume(LocalKoinApplication).getValue()
@@ -79,6 +81,7 @@ fun getKoin(): Koin = currentComposer.run {
  */
 @OptIn(InternalComposeApi::class, KoinInternalApi::class)
 @Composable
+@ReadOnlyComposable
 fun currentKoinScope(): Scope = currentComposer.run {
     try {
         val currentScope = consume(LocalKoinScope).getValue()
@@ -154,6 +157,7 @@ fun KoinMultiplatformApplication(
  * - Help handle automatically Android Logger Anticipate Android context injection, to having to setup androidContext() and androidLogger
  */
 @Composable
+@ReadOnlyComposable
 @PublishedApi
 @KoinInternalApi
 internal expect fun composeMultiplatformConfiguration(

--- a/projects/compose/koin-compose/src/jsMain/kotlin/org/koin/compose/KoinApplication.js.kt
+++ b/projects/compose/koin-compose/src/jsMain/kotlin/org/koin/compose/KoinApplication.js.kt
@@ -1,8 +1,8 @@
 package org.koin.compose
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
 import org.koin.core.Koin
-import org.koin.core.KoinApplication
 import org.koin.core.annotation.KoinExperimentalAPI
 import org.koin.dsl.KoinConfiguration
 import org.koin.core.logger.Level
@@ -11,6 +11,7 @@ import org.koin.dsl.includes
 import org.koin.mp.KoinPlatform
 
 @Composable
+@ReadOnlyComposable
 @KoinExperimentalAPI
 internal actual fun composeMultiplatformConfiguration(loggerLevel : Level, config : KoinConfiguration) : KoinConfiguration {
     return koinConfiguration {

--- a/projects/compose/koin-compose/src/jvmMain/kotlin/org/koin/compose/KoinApplication.jvm.kt
+++ b/projects/compose/koin-compose/src/jvmMain/kotlin/org/koin/compose/KoinApplication.jvm.kt
@@ -1,8 +1,8 @@
 package org.koin.compose
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
 import org.koin.core.Koin
-import org.koin.core.KoinApplication
 import org.koin.dsl.KoinConfiguration
 import org.koin.core.logger.Level
 import org.koin.dsl.koinConfiguration
@@ -10,6 +10,7 @@ import org.koin.dsl.includes
 import org.koin.mp.KoinPlatform
 
 @Composable
+@ReadOnlyComposable
 internal actual fun composeMultiplatformConfiguration(loggerLevel : Level, config : KoinConfiguration) : KoinConfiguration {
     return koinConfiguration {
         printLogger(loggerLevel)

--- a/projects/compose/koin-compose/src/nativeMain/kotlin/org/koin/compose/KoinApplication.native.kt
+++ b/projects/compose/koin-compose/src/nativeMain/kotlin/org/koin/compose/KoinApplication.native.kt
@@ -1,8 +1,8 @@
 package org.koin.compose
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
 import org.koin.core.Koin
-import org.koin.core.KoinApplication
 import org.koin.dsl.KoinConfiguration
 import org.koin.core.logger.Level
 import org.koin.dsl.koinConfiguration
@@ -10,6 +10,7 @@ import org.koin.dsl.includes
 import org.koin.mp.KoinPlatform
 
 @Composable
+@ReadOnlyComposable
 internal actual fun composeMultiplatformConfiguration(loggerLevel : Level, config : KoinConfiguration) : KoinConfiguration {
     return koinConfiguration {
         printLogger(loggerLevel)

--- a/projects/compose/koin-compose/src/wasmJsMain/kotlin/org/koin/compose/KoinApplication.wasmJS.kt
+++ b/projects/compose/koin-compose/src/wasmJsMain/kotlin/org/koin/compose/KoinApplication.wasmJS.kt
@@ -1,8 +1,8 @@
 package org.koin.compose
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
 import org.koin.core.Koin
-import org.koin.core.KoinApplication
 import org.koin.dsl.KoinConfiguration
 import org.koin.core.logger.Level
 import org.koin.dsl.koinConfiguration
@@ -10,6 +10,7 @@ import org.koin.dsl.includes
 import org.koin.mp.KoinPlatform
 
 @Composable
+@ReadOnlyComposable
 internal actual fun composeMultiplatformConfiguration(loggerLevel : Level, config : KoinConfiguration) : KoinConfiguration {
     return koinConfiguration {
         printLogger(loggerLevel)


### PR DESCRIPTION
P. S. `org.koin.compose.viewmodel.{koinViewModel, koinActivityViewModel}` also wanna be `@ReadOnlyComposable` but `androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner.current` doesn't want them to be happy.