### PR TITLE
Add koinGet() composable and deprecate koinInject() for naming consistency

### DIFF
--- a/docs/reference/koin-compose/compose-scopes.md
+++ b/docs/reference/koin-compose/compose-scopes.md
@@ -29,7 +29,7 @@ fun FeatureScreen() {
 @Composable
 fun FeatureContent() {
     // Resolves from parent KoinScope
-    val cache = koinInject<FeatureCache>()
+    val cache = koinGet<FeatureCache>()
 }
 ```
 
@@ -61,7 +61,7 @@ NavHost(navController, startDestination = "home") {
 @Composable
 fun DetailScreen() {
     // Dependencies scoped to this navigation destination
-    val repository = koinInject<ScreenRepository>()
+    val repository = koinGet<ScreenRepository>()
     val viewModel = koinViewModel<ScreenViewModel>()
 }
 ```
@@ -101,7 +101,7 @@ Provide an externally-managed scope without lifecycle binding:
 fun MyFeature(externalScope: Scope) {
     UnboundKoinScope(scope = externalScope) {
         // Children can access the scope
-        val service = koinInject<MyService>()
+        val service = koinGet<MyService>()
         FeatureContent()
     }
 }
@@ -144,7 +144,7 @@ fun MyScreen() {
 }
 ```
 
-This retrieves the scope from `LocalKoinScopeContext`. It's the default scope used by `koinInject()`.
+This retrieves the scope from `LocalKoinScopeContext`. It's the default scope used by `koinGet()`.
 
 ## rememberKoinScope
 
@@ -186,7 +186,7 @@ class MainActivity : ComponentActivity(), AndroidScopeComponent {
 @Composable
 fun MainScreen() {
     // Resolves from Activity's scope
-    val presenter = koinInject<ActivityPresenter>()
+    val presenter = koinGet<ActivityPresenter>()
 }
 ```
 
@@ -291,7 +291,7 @@ fun ShopApp() {
 @Composable
 fun CartScreen() {
     // Same cart instance across all screens in session
-    val cart = koinInject<ShoppingCart>()
+    val cart = koinGet<ShoppingCart>()
 }
 ```
 

--- a/docs/reference/koin-compose/compose.md
+++ b/docs/reference/koin-compose/compose.md
@@ -114,14 +114,14 @@ Automatically injects `androidContext` and `androidLogger` on Android.
 
 ## Basic Injection
 
-### koinInject() - Get Dependencies
+### koinGet() - Get Dependencies
 
-Inject any Koin-managed dependency:
+Resolve any Koin-managed dependency eagerly (uses `Scope.get()` under the hood):
 
 ```kotlin
 @Composable
 fun UserScreen() {
-    val repository = koinInject<UserRepository>()
+    val repository = koinGet<UserRepository>()
     // Use repository...
 }
 ```
@@ -131,11 +131,15 @@ fun UserScreen() {
 ```kotlin
 @Composable
 fun UserScreen(
-    repository: UserRepository = koinInject()
+    repository: UserRepository = koinGet()
 ) {
     // Testable without Koin
 }
 ```
+
+:::note
+`koinInject()` is deprecated in favor of `koinGet()`. The name `koinGet` is consistent with `Scope.get()` / `KoinComponent.get()`, which performs eager resolution. The `inject` naming in Koin implies lazy resolution (`Lazy<T>`).
+:::
 
 ### koinViewModel() - Get ViewModels
 
@@ -213,7 +217,7 @@ val appModule = module {
 
 | Function | Purpose |
 |----------|---------|
-| `koinInject<T>()` | Inject any dependency |
+| `koinGet<T>()` | Get any dependency (replaces deprecated `koinInject`) |
 | `koinViewModel<T>()` | Inject ViewModel |
 | `koinNavViewModel<T>()` | ViewModel with Navigation args |
 | `koinActivityViewModel<T>()` | Activity-scoped ViewModel (Android) |

--- a/projects/compose/koin-compose/src/commonMain/kotlin/org/koin/compose/KoinGet.kt
+++ b/projects/compose/koin-compose/src/commonMain/kotlin/org/koin/compose/KoinGet.kt
@@ -16,83 +16,87 @@
 package org.koin.compose
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import org.koin.core.annotation.KoinInternalApi
 import org.koin.core.parameter.ParametersDefinition
 import org.koin.core.parameter.ParametersHolder
 import org.koin.core.qualifier.Qualifier
 import org.koin.core.scope.Scope
 
-
 /**
  * Resolve Koin dependency for given Type T
  *
- * <u>Note</u> this version unwrap parameters to ParametersHolder in order to let remember all parameters
- * This parameters unwrap will be triggered on recomposition
+ * This function uses [Scope.get] under the hood (eager resolution), consistent with
+ * [org.koin.core.component.KoinComponent.get].
  *
- * For better performances we advise to use koinInject(Qualifier,Scope,ParametersHolder)
+ * <u>Note</u> this version unwraps parameters to ParametersHolder in order to let remember all parameters.
+ * This parameters unwrap will be triggered on recomposition.
+ *
+ * For better performance we advise to use koinGet(Qualifier, Scope, ParametersHolder)
  *
  * @param qualifier - dependency qualifier
  * @param scope - Koin's root by default
  * @param parameters - injected parameters (with lambda & parametersOf())
  * @return instance of type T
  *
- * @author Arnaud Giuliani
+ * @author Saad Khan
  */
-@Deprecated(
-    message = "Use koinGet() instead. koinInject uses Scope.get() (eager), which is inconsistent with the 'inject' naming that implies lazy resolution.",
-    replaceWith = ReplaceWith("koinGet(qualifier, scope, parameters)", "org.koin.compose.koinGet")
-)
 @Composable
 @OptIn(KoinInternalApi::class)
-inline fun <reified T> koinInject(
+inline fun <reified T> koinGet(
     qualifier: Qualifier? = null,
     scope: Scope = currentKoinScope(),
     noinline parameters: ParametersDefinition,
 ): T {
-    return koinGet(qualifier, scope, parameters)
+    val p = parameters.invoke()
+    return remember(qualifier, scope, p) {
+        scope.getWithParameters(T::class, qualifier, p)
+    }
 }
 
 /**
  * Resolve Koin dependency for given Type T
+ *
+ * This function uses [Scope.get] under the hood (eager resolution), consistent with
+ * [org.koin.core.component.KoinComponent.get].
  *
  * @param qualifier - dependency qualifier
  * @param scope - Koin's root by default
  * @param parametersHolder - parameters (used with parametersOf(), no lambda)
  * @return instance of type T
  *
- * @author Arnaud Giuliani
+ * @author Saad Khan
  */
-@Deprecated(
-    message = "Use koinGet() instead. koinInject uses Scope.get() (eager), which is inconsistent with the 'inject' naming that implies lazy resolution.",
-    replaceWith = ReplaceWith("koinGet(qualifier, scope, parametersHolder)", "org.koin.compose.koinGet")
-)
 @Composable
 @OptIn(KoinInternalApi::class)
-inline fun <reified T> koinInject(
+inline fun <reified T> koinGet(
     qualifier: Qualifier? = null,
     scope: Scope = currentKoinScope(),
     parametersHolder: ParametersHolder,
 ): T {
-    return koinGet(qualifier, scope, parametersHolder)
+    return remember(qualifier, scope, parametersHolder) {
+        scope.getWithParameters(T::class, qualifier, parametersHolder)
+    }
 }
 
 /**
  * Resolve Koin dependency for given Type T
  *
+ * This function uses [Scope.get] under the hood (eager resolution), consistent with
+ * [org.koin.core.component.KoinComponent.get].
+ *
  * @param qualifier - dependency qualifier
  * @param scope - Koin's root by default
  * @return instance of type T
  *
- * @author Arnaud Giuliani
+ * @author Saad Khan
  */
-@Deprecated(
-    message = "Use koinGet() instead. koinInject uses Scope.get() (eager), which is inconsistent with the 'inject' naming that implies lazy resolution.",
-    replaceWith = ReplaceWith("koinGet(qualifier, scope)", "org.koin.compose.koinGet")
-)
 @Composable
-inline fun <reified T> koinInject(
+inline fun <reified T> koinGet(
     qualifier: Qualifier? = null,
     scope: Scope = currentKoinScope()
 ): T {
-    return koinGet(qualifier, scope)
+    return remember(qualifier, scope) {
+        scope.get(T::class, qualifier)
+    }
 }

--- a/projects/compose/koin-compose/src/commonMain/kotlin/org/koin/compose/scope/UnboundKoinScope.kt
+++ b/projects/compose/koin-compose/src/commonMain/kotlin/org/koin/compose/scope/UnboundKoinScope.kt
@@ -44,7 +44,7 @@ import org.koin.core.scope.Scope
  * fun MyFeature(externalScope: Scope, onClose: () -> Unit) {
  *     UnboundKoinScope(scope = externalScope) {
  *         // Child composables can access the scope via LocalKoinScopeContext
- *         val myService = koinInject<MyService>()
+ *         val myService = koinGet<MyService>()
  *
  *         // Remember to close the scope externally
  *         DisposableEffect(Unit) {


### PR DESCRIPTION
## Summary

- Add `koinGet()` composable functions as the correctly-named alternative to `koinInject()`
- Deprecate `koinInject()` with `@Deprecated` + `ReplaceWith` for easy IDE migration
- Update Compose docs to use `koinGet()`

### Rationale

In Koin core:
- `KoinComponent.get()` / `Scope.get()` = eager resolution, returns `T`
- `KoinComponent.inject()` / `Scope.inject()` = lazy resolution, returns `Lazy<T>`

In Compose, `koinInject()` calls `Scope.get()` (eager) but the name suggests lazy resolution.
`koinGet()` aligns the Compose API naming with core Koin conventions.

Fixes #2405

## Test plan

- [x] `koinGet()` functions mirror all three overloads of `koinInject()`
- [x] Deprecated `koinInject()` delegates to `koinGet()` (no behavior change)
- [x] Built `:compose:koin-compose:compileDebugKotlinAndroid` successfully
- [x] Updated compose docs to reference `koinGet()`