### PR TITLE
feat: add tvOS targets to koin-core-viewmodel

### DIFF
--- a/projects/core/koin-core-viewmodel/build.gradle.kts
+++ b/projects/core/koin-core-viewmodel/build.gradle.kts
@@ -45,6 +45,9 @@ kotlin {
     iosX64()
     iosArm64()
     iosSimulatorArm64()
+    tvosX64()
+    tvosArm64()
+    tvosSimulatorArm64()
     macosX64()
     macosArm64()
 


### PR DESCRIPTION
## Add tvOS targets to `koin-core-viewmodel`

Fixes #2426

### Changes

Add 3 Kotlin/Native tvOS targets to `koin-core-viewmodel/build.gradle.kts`:

```kotlin
tvosX64()
tvosArm64()
tvosSimulatorArm64()
```

**That is the entire change.** All source code is in `commonMain` with zero platform-specific code.

### Why only `koin-core-viewmodel`?

| Module | tvOS possible? | Blocker |
|--------|---------------|---------|
| `koin-core-viewmodel` | ✅ Yes | None — all deps have tvOS variants |
| `koin-compose-viewmodel` | ❌ Not yet | Depends on `koin-compose` → `compose-foundation` (no tvOS) |

`koin-core-viewmodel` is what KMP projects need for tvOS (Apple TV apps use SwiftUI, not Compose). It provides `buildViewModel` for `@KoinViewModel` annotations.

### Verification

- ✅ `compileKotlinTvosSimulatorArm64` passes
- ✅ `compileKotlinTvosArm64` passes
- ✅ `publishToMavenLocal` succeeds (all variants published)
- ✅ Integrated into a production KMP project with tvOS targets — all modules compile

### Dependencies (all support tvOS)

- `io.insert-koin:koin-core` ✅
- `org.jetbrains.androidx.lifecycle:lifecycle-viewmodel` ✅
- `org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-savedstate` ✅