### PR TITLE
Use a monotonic counter for Ktor request scope ids

### DIFF
--- a/projects/ktor/koin-ktor/src/commonMain/kotlin/org/koin/ktor/plugin/RequestScope.kt
+++ b/projects/ktor/koin-ktor/src/commonMain/kotlin/org/koin/ktor/plugin/RequestScope.kt
@@ -19,16 +19,25 @@ import io.ktor.server.application.ApplicationCall
 import org.koin.core.Koin
 import org.koin.core.component.KoinScopeComponent
 import org.koin.core.component.createScope
-import org.koin.mp.KoinPlatformTools
-import org.koin.mp.generateId
+import kotlin.concurrent.atomics.AtomicLong
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
+import kotlin.concurrent.atomics.incrementAndFetch
+import kotlin.time.Clock
 
 /**
  * Request Scope Holder
  *
  * @author Arnaud Giuliani
+ * @author Loïc Favreliere
  */
+@OptIn(ExperimentalAtomicApi::class)
 class RequestScope(private val _koin: Koin, call: ApplicationCall) : KoinScopeComponent {
-    private val scopeId = "request_"+KoinPlatformTools.generateId()
+    private val scopeId = "request_" + counter.incrementAndFetch()
     override fun getKoin(): Koin = _koin
     override val scope = createScope(scopeId = scopeId, source = call)
+
+    private companion object {
+        // Monotonic counter seeded with the current time, for process-unique request scope ids
+        private val counter = AtomicLong(Clock.System.now().toEpochMilliseconds())
+    }
 }

--- a/projects/ktor/koin-ktor/src/jvmTest/kotlin/org/koin/ktor/ext/KoinPluginRunTest.kt
+++ b/projects/ktor/koin-ktor/src/jvmTest/kotlin/org/koin/ktor/ext/KoinPluginRunTest.kt
@@ -27,6 +27,10 @@ import io.ktor.server.response.respond
 import io.ktor.server.routing.get
 import io.ktor.server.routing.routing
 import io.ktor.server.testing.testApplication
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import org.junit.Before
@@ -59,9 +63,15 @@ class KoinPluginRunTest {
     }
 
     @Test
-    fun `each request gets a unique scope id`() {
+    fun `sequential and concurrent requests get unique scope ids`() {
         testMyApplication { client ->
-            val ids = (1..100).map { client.get("testurl").headers["X-Scope-Id"] }
+            suspend fun scopeId() = client.get("testurl").headers["X-Scope-Id"]
+
+            val sequentialIds = (1..100).map { scopeId() }
+            val concurrentIds = coroutineScope {
+                (1..1_000).map { async(Dispatchers.Default) { scopeId() } }.awaitAll()
+            }
+            val ids = sequentialIds + concurrentIds
 
             assertEquals(ids.size, ids.toSet().size, "all request scope ids should be unique")
             assertTrue(

--- a/projects/ktor/koin-ktor/src/jvmTest/kotlin/org/koin/ktor/ext/KoinPluginRunTest.kt
+++ b/projects/ktor/koin-ktor/src/jvmTest/kotlin/org/koin/ktor/ext/KoinPluginRunTest.kt
@@ -37,6 +37,7 @@ import org.koin.core.context.stopKoin
 import org.koin.core.logger.Level
 import org.koin.dsl.module
 import org.koin.ktor.plugin.Koin
+import org.koin.ktor.plugin.scope
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
@@ -54,6 +55,19 @@ class KoinPluginRunTest {
 
             assertEquals(HttpStatusCode.OK, response.status)
             assertTrue { response.bodyAsText().contains("Test response") }
+        }
+    }
+
+    @Test
+    fun `each request gets a unique scope id`() {
+        testMyApplication { client ->
+            val ids = (1..100).map { client.get("testurl").headers["X-Scope-Id"] }
+
+            assertEquals(ids.size, ids.toSet().size, "all request scope ids should be unique")
+            assertTrue(
+                ids.all { it?.removePrefix("request_")?.toLongOrNull() != null },
+                "scope ids should be 'request_<number>'",
+            )
         }
     }
 
@@ -135,7 +149,10 @@ private fun testMyApplicationNoKoin(test: suspend (jsonClient: HttpClient) -> Un
 class KtorMyModule(application: Application) {
     init {
         application.routing {
-            get("testurl") { call.respond(HttpStatusCode.OK, "Test response") }
+            get("testurl") {
+                call.response.headers.append("X-Scope-Id", call.scope.id)
+                call.respond(HttpStatusCode.OK, "Test response")
+            }
         }
     }
 }


### PR DESCRIPTION
## Problem

Fixes #2410.

`RequestScope` builds its scope id with `KoinPlatformTools.generateId()`, a SecureRandom-backed UUID. That blocking call runs on every request, which is problematic on non-blocking / event-loop threads. It happens even when no `scoped { }` definitions are declared, since the request scope is created unconditionally.

## Change

Replace the random UUID with a process-wide monotonic `AtomicLong`, seeded with the current wall-clock millis so ids don't restart at the same value across process restarts:

`request_<n>` (e.g. `request_1780500226902`)

A request scope id only needs uniqueness within the running process, which the counter guarantees without touching `SecureRandom`.

- `kotlin.concurrent.atomics.AtomicLong` (multiplatform, `RequestScope` is `commonMain`)
- `kotlin.time.Clock` for the seed (stable since Kotlin 2.3, no new dependency)

_Reference_: same approach backs block id generation in [Apache Spark](https://github.com/apache/spark/blob/13b526d534e3b6115be4769d39d861b321bb3a02/streaming/src/main/scala/org/apache/spark/streaming/receiver/ReceiverSupervisorImpl.scala#L95).

## Test

Added to `KoinPluginRunTest`: 100 requests against the running plugin assert every request scope id is unique and counter-formatted.