### PR TITLE
Fix #2370 #2408 - qualified dependency shadowed by parametersOf in CoreResolverV2

### DIFF
--- a/projects/CLAUDE.md
+++ b/projects/CLAUDE.md
@@ -24,6 +24,7 @@ Koin is a pragmatic, lightweight dependency injection framework for Kotlin Multi
 ### Key engine areas (`core/koin-core/src/commonMain/kotlin/org/koin/`)
 
 - `core/resolution/` — instance resolution. `CoreResolverV2.kt` is the 4.2+ engine: injected params → stacked params → registry (scope source → linked scopes → archetype)
+  - **Qualified lookups are registry-only.** A `get(named(...))` skips the stacked-parameter path entirely — parameters carry no qualifier (`ParametersHolder` matches by type only), so a stacked param can never satisfy a qualified request. Removing this guard re-opens #2370/#2408 (a `parametersOf` value shadowing a qualified dependency of the same type). Only unqualified resolution reads the param stack — that's the #2387 ViewModel path; don't break it.
 - `core/registry/` — definition & instance registries (indexing by type + qualifier)
 - `core/scope/` — `Scope`, scope archetypes, linked scopes
 - `core/module/` — module DSL (`single`, `factory`, `scoped`, `bind`, `includes`)
@@ -73,6 +74,13 @@ Before opening (or approving) any PR, both guards must pass:
 - **Never weaken `test.sh` to scoped tasks.** In KMP projects `./gradlew test` resolves only to Android/JVM unit tests and **silently skips** native, JS, and WASM tests. Full verification = `allTests` (or per-target tasks explicitly). Do not add `-x` exclusions to make a run green — fix the failing test at the root cause.
 - **No backtick test names in `commonTest`** — backtick names (`` fun `my test`() ``) break `compileTestKotlinJs`/`compileTestKotlinWasmJs` (invalid JS identifiers). Use snake_case in `commonTest`; backticks are fine in `jvmTest` only.
 - **`runTest {}` in `commonTest` must use block-body syntax** — on wasmJs, expression-body forms (`fun foo() = runTest { }`) fail with return-type mismatch. Use `fun testX() { runTest { ... } }`.
+
+#### Known pre-existing off-JVM failures (not yours — don't chase them)
+
+`allTests` is currently red on two counts unrelated to any recent resolver work (verified by stash-comparison on the `4.2.2` branch, 2026-06-08). If you touch `commonMain` and run `allTests`, expect these and confirm your diff doesn't change them:
+
+- **`createdAtStart` on wasmJs** — `CreateOnStart`, `OverrideAndCreateatStartTest` fail with `AssertionError: Expected value to be true`. Core `single(createdAtStart = true)` eager-init doesn't fire on wasmJs. This is *core*, **not** the compiler-plugin `createdAtStart` drop (#2425/#2415) — same symptom family, different layer.
+- **`DynamicModulesTest` on native** — its backtick names contain `" - "` (e.g. `` `should unload one module definition - factory` ``), crashing the Kotlin/Native test reporter (`ServiceMessagesParser`) and aborting `macosArm64Test`. This is the backtick-name trap above, already shipped. Fix = rename to snake_case.
 
 ## Versioning
 

--- a/projects/core/koin-core-viewmodel/src/commonTest/kotlin/org/koin/viewmodel/ViewModelQualifiedParamTest.kt
+++ b/projects/core/koin-core-viewmodel/src/commonTest/kotlin/org/koin/viewmodel/ViewModelQualifiedParamTest.kt
@@ -1,0 +1,53 @@
+package org.koin.viewmodel
+
+import androidx.lifecycle.ViewModel
+import org.koin.core.logger.Level
+import org.koin.core.module.dsl.viewModel
+import org.koin.core.parameter.parametersOf
+import org.koin.core.qualifier.named
+import org.koin.dsl.koinApplication
+import org.koin.dsl.module
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Regression test for issue #2370 / #2408 in the ViewModel resolution path.
+ *
+ * A ViewModel that receives a runtime parameter via parametersOf() AND a qualified
+ * collaborator of an overlapping type (String here) must not have the qualified
+ * dependency shadowed by the parameter. Before the qualifier guard in
+ * CoreResolverV2.resolveFromStackedParameters, the qualified `get(named("Config"))`
+ * was satisfied by the stacked "screenId" parameter instead of the registry definition.
+ */
+class ViewModelQualifiedParamTest {
+
+    private val configQualifier = named("Config")
+    private val globalConfig = "CONFIG_STRING"
+
+    private class MyViewModel(val screenId: String, val config: String) : ViewModel()
+
+    private val testModule = module {
+        single(configQualifier) { globalConfig }
+
+        viewModel { (screenId: String) ->
+            MyViewModel(screenId = screenId, config = get(configQualifier))
+        }
+    }
+
+    @Test
+    fun viewModel_qualified_dependency_is_not_shadowed_by_parameter() {
+        val koin = koinApplication {
+            printLogger(Level.DEBUG)
+            modules(testModule)
+        }.koin
+
+        val vm: MyViewModel = koin.get { parametersOf("screenId") }
+
+        // The parameter must reach the ViewModel constructor param
+        assertEquals("screenId", vm.screenId)
+
+        // ...but the qualified dependency must come from the registry, NOT the parameter.
+        // Bug: vm.config == "screenId"
+        assertEquals(globalConfig, vm.config)
+    }
+}

--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/resolution/CoreResolverV2.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/resolution/CoreResolverV2.kt
@@ -131,6 +131,10 @@ class CoreResolverV2(
     }
 
     private inline fun <T> resolveFromStackedParameters(scope: Scope, ctx: ResolutionContext): T? {
+        // A qualified lookup (get(named(...))) is a registry-only question: stacked parameters
+        // carry no qualifier (ParametersHolder matches by type only), so they can never be a
+        // legitimate match and would only shadow the qualified definition (#2370, #2408).
+        if (ctx.qualifier != null) return null
         val stack = scope._parameterStack ?: return null
         val current = stack.get()
         return if (current.isNullOrEmpty()) null

--- a/projects/core/koin-core/src/commonTest/kotlin/org/koin/core/QualifierParameterShadowingTest.kt
+++ b/projects/core/koin-core/src/commonTest/kotlin/org/koin/core/QualifierParameterShadowingTest.kt
@@ -1,0 +1,62 @@
+package org.koin.core
+
+import org.koin.core.logger.Level
+import org.koin.core.parameter.parametersOf
+import org.koin.core.qualifier.named
+import org.koin.dsl.koinApplication
+import org.koin.dsl.module
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Regression test for issue #2370 / #2408 / #2393.
+ *
+ * CoreResolverV2 consults the stacked-parameter stack BEFORE the registry, and the
+ * stacked-parameter lookup matches by type only (ignoring the qualifier). As a result a
+ * qualified dependency (`get(named(...))`) of the same type as a value passed via
+ * `parametersOf(...)` is silently shadowed by the parameter.
+ *
+ * Worked in 4.0.0 / 3.5.6, broke in 4.1.1+ (resolver order change).
+ */
+class QualifierParameterShadowingTest {
+
+    private val configQualifier = named("Config")
+    private val activityScope = named("TestScope")
+
+    private val globalConfig = "CONFIG_STRING"
+
+    private class Service(val config: String)
+
+    private data class UseCase(val parameter: String, val service: Service)
+
+    private val testModule = module {
+        single(configQualifier) { globalConfig }
+
+        factory { Service(config = get(configQualifier)) }
+
+        factory { (parameterString: String) ->
+            UseCase(parameter = parameterString, service = get())
+        }
+
+        scope(activityScope) { }
+    }
+
+    @Test
+    fun qualified_string_is_not_shadowed_by_parametersOf_value() {
+        val koin = koinApplication {
+            printLogger(Level.DEBUG)
+            modules(testModule)
+        }.koin
+
+        val scope = koin.createScope("test", activityScope)
+
+        val useCase: UseCase = scope.get { parametersOf("parameterString") }
+
+        // The parameter must reach UseCase.parameter
+        assertEquals("parameterString", useCase.parameter)
+
+        // ...but Service.config must come from the qualified definition, NOT the parameter.
+        // Bug: useCase.service.config == "parameterString"
+        assertEquals(globalConfig, useCase.service.config)
+    }
+}


### PR DESCRIPTION
## Problem

A qualified lookup `get(named("X"))` could be **silently satisfied by a value passed via `parametersOf(...)`** of the same type, instead of the qualified definition from the registry.

`CoreResolverV2` consults the stacked-parameter stack **before** the registry (`resolveFromInjectedParameters → resolveFromStackedParameters → resolveFromRegistry`), and `resolveFromStackedParameters` matches **by type only** — `ParametersHolder` carries no qualifier. So a qualified dependency of an overlapping type was shadowed by an unqualified parameter.

Fixes #2370, #2408.

### Reproduction (#2370)
```kotlin
single(named("Config")) { "CONFIG_STRING" }
factory { Service(config = get(named("Config"))) }
factory { (p: String) -> UseCase(parameter = p, service = get()) }
scope(named("TestScope")) { }

val useCase = scope.get<UseCase> { parametersOf("parameterString") }
useCase.parameter        // "parameterString"  ✅
useCase.service.config   // expected "CONFIG_STRING" — got "parameterString" ❌
```

Worked in 4.0.0 / 3.5.6, regressed with the resolver ordering change in 4.1.1+.

## Resolution-semantics delta (behavioral compatibility)

This is a resolution-behavior change, stated explicitly per project doctrine. **Only qualified resolutions change**:

| Call shape | Before | After |
|---|---|---|
| `get()` — unqualified | stack → registry | **unchanged** (stack → registry) |
| `get(named("X"))` — qualified | stack (type-only, can shadow) → registry | **registry only** |

A qualified request is a registry-only question by construction: a parameter cannot carry a qualifier, so a stacked parameter can never be a legitimate match for `get(named(...))` — skipping it loses nothing correct and removes the shadowing.

## Fix

One guard at the top of `CoreResolverV2.resolveFromStackedParameters`:
```kotlin
if (ctx.qualifier != null) return null
```

The unqualified ViewModel param-stacking path added in #2387 (e.g. `AndroidParametersHolder` stacked on root, resolved from a child ViewModel scope) is **untouched** — those resolutions are unqualified.

## Tests

Two regression tests in `commonTest`, each **falsified RED→GREEN** (proven to fail on the unfixed resolver, pass with the guard) on **JVM, wasmJs, and native (macosArm64)**:

- `QualifierParameterShadowingTest` — plain factory + qualified dependency (#2370 / #2408)
- `ViewModelQualifiedParamTest` — `viewModel { }` DSL: a ViewModel receiving a runtime param **and** a qualified collaborator of overlapping type

Each test also asserts the parameter still reaches its intended constructor slot, so it guards against an over-broad fix.

## Verification

- `:core:koin-core:jvmTest`, `:core:koin-core-viewmodel:jvmTest`, `:android:koin-android:testDebugUnitTest` (incl. #2387 `ViewModelScopeArchetypeTest`) — **green**
- wasmJs / native — new tests green (stash-comparison: fix takes wasmJs from 3→2 failures; the 2 remaining are pre-existing `createdAtStart` failures unrelated to this change)
- `./gradlew apiCheck` — **pass** (internal-only change, no public API delta)

## Scope

Covers the **qualified** shadowing case (#2370, #2408). The separate **unqualified** shadow question raised in #2393 (registry singleton vs `parametersOf` value, neither qualified) is intentionally **not** addressed here and remains tracked on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)