### PR TITLE
Fix #2379 - root factory's scoped deps resolved from _root_ (CoreResolverV2)

### DIFF
--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/resolution/CoreResolverV2.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/resolution/CoreResolverV2.kt
@@ -21,6 +21,7 @@ import org.koin.core.annotation.KoinInternalApi
 import org.koin.core.error.NoDefinitionFoundException
 import org.koin.core.instance.InstanceFactory
 import org.koin.core.instance.ResolutionContext
+import org.koin.core.instance.SingleInstanceFactory
 import org.koin.core.scope.Scope
 import org.koin.ext.getFullName
 
@@ -86,6 +87,17 @@ class CoreResolverV2(
             // 1. Registry on this linked scope
             val factory = findDefinitionInScope(linkedScope, ctx)
             if (factory != null) {
+                // #2379: a root FACTORY requested from a child scope keeps the ORIGINATING
+                // context, so its transitive (possibly scoped/archetype) dependencies
+                // resolve back in the requesting scope instead of falling through to _root_.
+                // The origin ctx already carries the scope + scopeArchetype and its params
+                // are already stacked on it, so no context switch or re-stacking is needed.
+                // Root SINGLES are excluded: a singleton must resolve its dependencies once,
+                // from root, and must never capture a scope-local instance (guard: #2325).
+                if (linkedScope.isRoot && factory !is SingleInstanceFactory<*>) {
+                    return factory.get(ctx) as T?
+                }
+
                 // we will loose parameters from parent context
                 val newCtx = ctx.newContextForScope(linkedScope)
                 if (linkedScope.scopeArchetype != null && !linkedScope.isRoot) {

--- a/projects/core/koin-core/src/commonTest/kotlin/org/koin/core/ArchetypeDeclareResolveTest.kt
+++ b/projects/core/koin-core/src/commonTest/kotlin/org/koin/core/ArchetypeDeclareResolveTest.kt
@@ -1,0 +1,95 @@
+package org.koin.core
+
+import org.koin.Simple
+import org.koin.core.annotation.KoinInternalApi
+import org.koin.core.component.getScopeId
+import org.koin.core.logger.Level
+import org.koin.core.module.KoinDslMarker
+import org.koin.core.module.Module
+import org.koin.core.qualifier.TypeQualifier
+import org.koin.dsl.ScopeDSL
+import org.koin.dsl.koinApplication
+import org.koin.dsl.module
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+/**
+ * Regression repro for issue #2379 (archetype-scope variant).
+ *
+ * The plain named-scope case is covered by DeclareInstanceTest. The case still
+ * reported failing in 4.2.0/4.2.1 (dees91) uses an *archetype* scope
+ * (activityRetainedScope): a scoped definition resolved through its archetype,
+ * whose transitive get() for a declared dependency falls through to _root_.
+ */
+class ArchetypeDeclareResolveTest {
+
+    open class Archetype
+    class ArchetypeExt : Archetype()
+
+    @KoinDslMarker
+    fun Module.scopeArchetype(scopeSet: ScopeDSL.() -> Unit) {
+        val qualifier = TypeQualifier(Archetype::class)
+        ScopeDSL(qualifier, this).apply(scopeSet)
+    }
+
+    @OptIn(KoinInternalApi::class)
+    @Test
+    fun archetype_scope_resolves_declared_transitive_dependency_issue_2379() {
+        val scopeModule = module {
+            scopeArchetype {
+                scoped { Simple.ComponentB(get()) }
+            }
+        }
+        val koin = koinApplication {
+            printLogger(Level.DEBUG)
+            modules(scopeModule)
+        }.koin
+
+        val archetypeExt = ArchetypeExt()
+        val scope = koin.createScope<ArchetypeExt>(
+            archetypeExt.getScopeId(), archetypeExt,
+            TypeQualifier(Archetype::class)
+        )
+        scope.declare(Simple.ComponentA())
+
+        // declared dependency must resolve from the scope it was declared in
+        val a = scope.getOrNull<Simple.ComponentA>()
+        assertNotNull(a)
+
+        // scoped ComponentB's transitive get() for ComponentA must resolve in-scope, not _root_
+        val b = scope.get<Simple.ComponentB>()
+        assertEquals(a, b.a)
+    }
+
+    // dees91 minimal shape: a ROOT factory depends on a SCOPED dependency,
+    // resolved transitively from the scope. v2 switches context to root when it
+    // finds the root factory via linked scopes, then can't resolve the scoped dep.
+    class Connector
+    class Interactor(val connector: Connector)
+
+    @OptIn(KoinInternalApi::class)
+    @Test
+    fun root_factory_depending_on_scoped_dep_resolves_in_scope_issue_2379() {
+        val scopeModule = module {
+            scopeArchetype {
+                scoped { Connector() }
+            }
+            factory { Interactor(get()) } // ROOT factory needs the scoped Connector
+        }
+        val koin = koinApplication {
+            printLogger(Level.DEBUG)
+            modules(scopeModule)
+        }.koin
+
+        val archetypeExt = ArchetypeExt()
+        val scope = koin.createScope<ArchetypeExt>(
+            archetypeExt.getScopeId(), archetypeExt,
+            TypeQualifier(Archetype::class)
+        )
+
+        // resolving the root factory FROM the scope must let its scoped dep resolve in-scope
+        val interactor = scope.get<Interactor>()
+        assertNotNull(interactor.connector)
+    }
+}


### PR DESCRIPTION
## Problem

A **root-level factory requested from a child scope** failed to resolve its transitive **scoped** dependencies — they fell through to `_root_` with `NoDefinitionFoundException`. Reported in 4.2.0/4.2.1 (still failing in Alpha1).

dees91's reproducer chain: `MainViewModel` (viewModelScope) → 3 root `factory` definitions → `ScopedConnector` (scoped in `activityRetainedScope`). Resolving the ViewModel fails with:

```
No definition found for type '...Connector' on scope '['_root_']'
```

Fixes #2379.

### Root cause
`resolveFromLinkedScopes` locates the root factory via the linked root scope, then calls `ctx.newContextForScope(root)` — switching the context to a bare root scope (and discarding the `scopeArchetype` the requesting scope had set). The factory body (`InstanceFactory.create` invokes `definition(context.scope, …)`) then resolves its scoped dependency from root, which can't see the originating scope.

## Fix

When the definition is found in the **root** linked scope and is **not a single**, invoke it with the **originating context** instead of switching to root:

```kotlin
if (linkedScope.isRoot && factory !is SingleInstanceFactory<*>) {
    return factory.get(ctx) as T?
}
```

The origin context already carries the requesting scope + `scopeArchetype` (and its params are already stacked on it), so the factory's scoped/archetype deps resolve in-scope. **O(1) preserved** — one type check, no recursion; V2's single-pass linked-scope walk is otherwise unchanged.

## Resolution-semantics delta (behavioral compatibility)

| Definition resolved *from a child scope* | Before | After |
|---|---|---|
| Root **single** found via linked scope | created with root context | **unchanged** — a singleton resolves its deps once, from root, and must not capture a scope-local instance |
| Root **factory** found via linked scope | created with root context → scoped deps fail on `_root_` | created with **originating context** → scoped deps resolve in-scope |
| Genuinely-scoped *parent* definition | switch to owning scope | **unchanged** |

The single exclusion is a deliberate guard: making singles resolve from the requesting scope regressed #2325 (a root single captured a scope-local `HttpClient`). Caught by the existing test; singles are excluded for that reason.

## Tests

`ArchetypeDeclareResolveTest` (commonTest), **falsified RED→GREEN on JVM, wasmJs, and native**:
- `root_factory_depending_on_scoped_dep_resolves_in_scope_issue_2379` — minimal repro of dees91's chain (no Android needed)
- `archetype_scope_resolves_declared_transitive_dependency_issue_2379` — declare + transitive get() in an archetype scope (already passing; kept as coverage)

## Verification

- Full `:core:koin-core:jvmTest` green; #2387 `ViewModelScopeArchetypeTest`, `ActivityScopeArchetypeTest`, `CascadeScopeLinkTest`, **#2325** `ScopeExampleTest` all pass
- `:core:koin-core-viewmodel:jvmTest`, `:android:koin-android:testDebugUnitTest` green
- wasmJs + native: new test passes; only the documented pre-existing off-JVM failures remain
- `./gradlew apiCheck` — **pass** (internal-only change)

## Also in this PR
- Bump `koinVersion` → **4.2.2-Alpha2**, a publishable build carrying the merged #2370/#2408 fix plus this one.

## Scope
Covers #2379 (root factory → scoped dep). #2393 (unqualified same-type param shadow) is by-design/documented. #2381 (qualified cross-module KMP) needs a reproduction and is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)