### PR TITLE
Fix #2406, #2435: qualified requests no longer pick up stacked parameters

### DIFF
--- a/docs/reference/koin-core/injection-parameters.md
+++ b/docs/reference/koin-core/injection-parameters.md
@@ -80,6 +80,9 @@ val myModule = module {
 }
 ```
 
+:::note
+Graph resolution of injected parameters only applies to unqualified requests: a qualified request like `get(named("a_name"))` always resolves from your module definitions, never from injected parameters — parameters are matched by type and carry no qualifier.
+:::
 
 ## Injected parameters: indexed values or set (`3.4.3`)
 

--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/resolution/CoreResolverV2.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/resolution/CoreResolverV2.kt
@@ -27,6 +27,9 @@ import org.koin.ext.getFullName
 
 /**
  * Resolver - optimised version
+ *
+ * Resolution order: injected parameters, stacked parameters (unqualified requests only),
+ * registry (direct definition, scope archetype, scope source, linked scopes), extensions.
  */
 @KoinInternalApi
 class CoreResolverV2(
@@ -131,6 +134,9 @@ class CoreResolverV2(
     }
 
     private inline fun <T> resolveFromStackedParameters(scope: Scope, ctx: ResolutionContext): T? {
+        // Params are matched by type only, so a qualified request can never come off the
+        // stack - let it fall through to the registry (#2406, #2435). Same rule as resolveFromScopeSource.
+        if (ctx.qualifier != null) return null
         val stack = scope._parameterStack ?: return null
         val current = stack.get()
         return if (current.isNullOrEmpty()) null

--- a/projects/core/koin-core/src/commonTest/kotlin/org/koin/core/ParametersInjectionTest.kt
+++ b/projects/core/koin-core/src/commonTest/kotlin/org/koin/core/ParametersInjectionTest.kt
@@ -446,4 +446,81 @@ class ParametersInjectionTest {
         // Verify that our passed instance was used, not the singleton from registry
         assertEquals(passedInstance, b.a)
     }
+
+    // Test classes for #2435 / #2406
+    class NamedStringConsumer(val id: String)
+    class InjectedParamConsumer(val id: String, val nested: NamedStringConsumer)
+    class NamedEnvComponent(val env: String)
+
+    /**
+     * #2435 - InjectedParamConsumer is built with parametersOf("event-id"), and its nested
+     * NamedStringConsumer asks for get(named("customId")). The "event-id" param must not bleed
+     * into that named String - a get(named(...)) always comes from the registry.
+     */
+    @Test
+    fun qualified_dependency_is_resolved_from_registry_not_from_stacked_parameters() {
+        val app = koinApplication {
+            printLogger(Level.DEBUG)
+            modules(
+                module {
+                    single(named("customId")) { "named-id" }
+                    factory { NamedStringConsumer(get(named("customId"))) }
+                    factory { p -> InjectedParamConsumer(p.get(), get()) }
+                },
+            )
+        }
+
+        val koin = app.koin
+        val consumer: InjectedParamConsumer = koin.get { parametersOf("event-id") }
+
+        // param goes where it was asked for
+        assertEquals("event-id", consumer.id)
+        // but not into the named slot
+        assertEquals("named-id", consumer.nested.id)
+    }
+
+    /**
+     * #2406 - get(named("env")) must resolve the named single even while a String param
+     * ("param-value") sits on the scope's parameter stack.
+     */
+    @Test
+    fun qualified_string_dependency_is_not_filled_from_stacked_parameter() {
+        val app = koinApplication {
+            modules(
+                module {
+                    single(named("env")) { "PROD" }
+                    single { NamedEnvComponent(get(named("env"))) }
+                },
+            )
+        }
+
+        val koin = app.koin
+        val component: NamedEnvComponent = koin.get { parametersOf("param-value") }
+
+        assertEquals("PROD", component.env)
+    }
+
+    /**
+     * #2435, scope variant - a param stacked on a child scope must not satisfy a qualified
+     * lookup either; it should fall through to the root definition via linked scopes.
+     */
+    @Test
+    fun qualified_dependency_in_scope_is_resolved_from_linked_registry_not_from_stacked_parameters() {
+        val app = koinApplication {
+            modules(
+                module {
+                    single(named("customId")) { "named-id" }
+                    scope(named("aScope")) {
+                        scoped { NamedStringConsumer(get(named("customId"))) }
+                    }
+                },
+            )
+        }
+
+        val koin = app.koin
+        val scope = koin.createScope("scope-1", named("aScope"))
+        val consumer: NamedStringConsumer = scope.get { parametersOf("event-id") }
+
+        assertEquals("named-id", consumer.id)
+    }
 }

--- a/projects/core/koin-test/src/jvmTest/kotlin/CheckModulesTest.kt
+++ b/projects/core/koin-test/src/jvmTest/kotlin/CheckModulesTest.kt
@@ -3,12 +3,33 @@ import org.koin.core.context.stopKoin
 import kotlin.test.Test
 import kotlin.test.fail
 import org.koin.core.error.InstanceCreationException
+import org.koin.core.qualifier.named
 import org.koin.dsl.module
 import org.koin.test.Simple
 import org.koin.test.check.checkKoinModules
 import org.koin.test.verify.MissingKoinDefinitionException
 
 class CheckModulesTest {
+
+    class ComponentWithNamedDependency(env: String) {
+        init {
+            require(env.isNotEmpty()) { "env was empty!" }
+        }
+    }
+
+    /**
+     * #2406 - checkModules must keep the named String single. It used to hand the
+     * get(named("env")) MockParameter's default "", tripping the require() below.
+     */
+    @Test
+    fun verify_module_with_named_string_dependency() {
+        val module = module {
+            single(named("env")) { "TEST" }
+            single { ComponentWithNamedDependency(get(named("env"))) }
+        }
+
+        checkKoinModules(listOf(module))
+    }
 
     @Test
     fun verify_one_simple_module() {


### PR DESCRIPTION
## Problem
A `get(named(...))` could be satisfied by a same-typed value sitting on the scope's
parameter stack, shadowing the qualified definition. So passing `parametersOf("event-id")`
to one dependency could bleed that String into an unrelated `@Named` String further down
the graph (#2435), and `checkKoinModules` handed `get(named("env"))` the MockParameter
default `""` instead of the named single (#2406).

## Cause
In `CoreResolverV2`, resolution tries the parameter stack before the registry. Parameters
match by type only and carry no qualifier, so a qualified request would match whatever
same-typed value was on the stack.

## Fix
`resolveFromStackedParameters` now returns null when the request has a qualifier, letting
it fall through to the registry. This mirrors the rule already used by
`resolveFromScopeSource`.

## Behavioral change
Qualified resolutions could previously return a stacked parameter of the matching type;
they now always resolve from definitions. Unqualified resolution, including the #2387
stacked-parameter path, is unchanged.

## Tests
Added cases in `ParametersInjectionTest` (root, scope, and linked-scope variants) and
`CheckModulesTest`. Verified on JVM, wasmJs, and native.

Closes #2406
Closes #2435