### PR TITLE
Fix #2426 - add tvOS targets to koin-core-viewmodel

### DIFF
--- a/projects/core/koin-core-viewmodel/build.gradle.kts
+++ b/projects/core/koin-core-viewmodel/build.gradle.kts
@@ -47,6 +47,9 @@ kotlin {
     iosSimulatorArm64()
     macosX64()
     macosArm64()
+    tvosArm64()
+    tvosSimulatorArm64()
+    tvosX64()
 
     sourceSets {
         commonMain.dependencies {


### PR DESCRIPTION
## Problem
`koin-core-viewmodel` publishes no tvOS variants, so `@KoinViewModel` on a tvOS KMP target fails:
```
e: [Koin][KOIN-A001] @KoinViewModel definition '…' cannot be generated:
'buildViewModel' is not on classpath. Add dependency: io.insert-koin:koin-core-viewmodel
```
`koin-core` already ships tvOS, and the JetBrains `lifecycle-viewmodel` dependency supports it.

Fixes #2426.

## Change
Add `tvosArm64()`, `tvosSimulatorArm64()`, `tvosX64()` to `koin-core-viewmodel`. All three compile (`compileKotlinTvos*` green).

## Why not `koin-compose-viewmodel`?
The issue also lists `koin-compose-viewmodel`, but it depends on `koin-compose` → `org.jetbrains.compose.foundation` (Compose UI), which **publishes no tvOS variant** (Compose UI doesn't target tvOS). Verified: `compileKotlinTvosArm64` on `koin-compose` fails with *"Couldn't resolve dependency 'org.jetbrains.compose.foundation:foundation' … for tvosMain"*. That's an upstream Compose limitation, not something Koin can resolve. tvOS apps using `@KoinViewModel` rely on `koin-core-viewmodel` (this fix), not Compose UI.

## Verification
- `compileKotlinTvosArm64` / `TvosSimulatorArm64` / `TvosX64` on `koin-core-viewmodel` — all green
- `./gradlew apiCheck` — pass (native targets don't affect the JVM/Android `.api` dumps)

## Scope
`koin-core-viewmodel` tvOS only. `koin-compose-viewmodel` watchOS/tvOS is blocked upstream (Compose UI). No version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)