### PR TITLE
Docs: viewModelScope { } requires viewModelScopeFactory() (#2417)

### DIFF
--- a/docs/reference/koin-compose/compose-viewmodel.md
+++ b/docs/reference/koin-compose/compose-viewmodel.md
@@ -278,6 +278,10 @@ val appModule = module {
 }
 ```
 
+:::caution Requires the `viewModelScopeFactory()` option
+Declaring a ViewModel inside `viewModelScope { }` requires enabling `options(viewModelScopeFactory())` in your Koin configuration — otherwise `koinViewModel()` fails with `No definition found … on scope '['_root_']'`. See [ViewModel Scope](/docs/reference/koin-core/viewmodel#viewmodel-scope) for details.
+:::
+
 ## Quick Reference
 
 | API | Use Case | Package |

--- a/docs/reference/koin-core/viewmodel.md
+++ b/docs/reference/koin-core/viewmodel.md
@@ -146,6 +146,25 @@ val appModule = module {
 Dependencies inside `viewModelScope` are created when the ViewModel is first accessed and destroyed when the ViewModel is cleared.
 :::
 
+:::caution Requires the `viewModelScopeFactory()` option
+Declaring the **ViewModel itself** inside `viewModelScope { }` (so Koin creates its scope automatically) requires enabling the `viewModelScopeFactory()` option in your Koin configuration:
+
+```kotlin
+startKoin {
+    options(viewModelScopeFactory())
+    modules(appModule)
+}
+```
+
+Without it, resolving the ViewModel fails with:
+
+```
+No definition found for type 'MyViewModel' on scope '['_root_']'
+```
+
+because the ViewModel is registered under the ViewModel scope archetype, and that scope is only created when the option is enabled. (This is separate from the manual `ScopeViewModel` pattern, which creates its own scope and does not need the option.)
+:::
+
 ## Injecting ViewModels
 
 ### In Compose (Multiplatform)


### PR DESCRIPTION
Documents the `viewModelScope { }` → `viewModelScopeFactory()` requirement that #2417 reporters hit.

## Why
After applying the advised #2417 workaround — wrapping `viewModelOf` in `viewModelScope { }` — resolution fails with:
```
No definition found for type 'MyViewModel' on scope '['_root_']'
```
Declaring the ViewModel inside `viewModelScope { }` registers it under the ViewModel scope archetype, which is **only resolvable when `viewModelScopeFactory()` is enabled** (the option creates the scope). This was undocumented.

## Changes (docs only)
- `koin-core/viewmodel.md` — caution in the canonical *ViewModel Scope* section: the option, the exact error, and the distinction from the manual `ScopeViewModel` pattern (which doesn't need it).
- `koin-compose/compose-viewmodel.md` — short pointer where CMP users land.

## Note
This is the **documentation** half of #2417(b). The code-level "actionable error when the option is missing" was attempted and **reverted** — it regressed `ViewModelScopeArchetypeTest`'s #2387 tests via an exception-flow interaction in the VM resolution path that needs separate investigation. Tracked as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)