### PR TITLE
Fix #2299 - link viewModelScopeFactory scope to its parent scope

### DIFF
--- a/projects/core/koin-core-viewmodel/src/commonMain/kotlin/org/koin/viewmodel/factory/KoinViewModelFactory.kt
+++ b/projects/core/koin-core-viewmodel/src/commonMain/kotlin/org/koin/viewmodel/factory/KoinViewModelFactory.kt
@@ -50,6 +50,12 @@ class KoinViewModelFactory(
         } else {
             val scopeId = getViewModelScopeId(modelClass)
             val vmScope = koin.createScope(scopeId, TypeQualifier(modelClass), null, ViewModelScopeArchetype)
+            // #2299: link the auto-created VM scope to the requesting (parent) scope, so a ViewModel
+            // declared in a custom scope - and its scoped dependencies - resolve. New scopes already
+            // link to root, so only a non-root parent needs an explicit link.
+            if (!scope.isRoot) {
+                vmScope.linkTo(scope)
+            }
             val vm : T = vmScope.getWithParameters(kClass, qualifier, androidParams)
             vm.addCloseable(ViewModelScopeAutoCloseable(scopeId,koin))
             vm

--- a/projects/core/koin-core-viewmodel/src/commonTest/kotlin/org/koin/viewmodel/ViewModelScopeFactoryLinkTest.kt
+++ b/projects/core/koin-core-viewmodel/src/commonTest/kotlin/org/koin/viewmodel/ViewModelScopeFactoryLinkTest.kt
@@ -1,0 +1,56 @@
+package org.koin.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelStore
+import androidx.lifecycle.viewmodel.CreationExtras
+import org.koin.core.annotation.KoinExperimentalAPI
+import org.koin.core.annotation.KoinInternalApi
+import org.koin.core.module.dsl.scopedOf
+import org.koin.core.module.dsl.viewModelOf
+import org.koin.core.qualifier.TypeQualifier
+import org.koin.core.option.viewModelScopeFactory
+import org.koin.dsl.koinApplication
+import org.koin.dsl.module
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertSame
+
+/**
+ * Regression test for #2299: with viewModelScopeFactory() enabled, a ViewModel declared in a
+ * custom scope must resolve. KoinViewModelFactory creates a fresh vmScope (ViewModelScopeArchetype)
+ * but did not link it to the parent (custom) scope, so the ViewModel — and its scoped deps,
+ * registered under the custom scope qualifier — were unreachable.
+ */
+@OptIn(KoinInternalApi::class, KoinExperimentalAPI::class)
+class ViewModelScopeFactoryLinkTest {
+
+    class Example
+    class ScopedDep
+    class ScopedVM(val dep: ScopedDep) : ViewModel()
+
+    @Test
+    fun viewModelScopeFactory_resolves_viewModel_from_custom_scope_issue_2299() {
+        val koin = koinApplication {
+            options(viewModelScopeFactory())
+            modules(
+                module {
+                    scope<Example> {
+                        scopedOf(::ScopedDep)
+                        viewModelOf(::ScopedVM)
+                    }
+                },
+            )
+        }.koin
+
+        val parentScope = koin.createScope("example-1", TypeQualifier(Example::class), Example())
+
+        val vm = resolveViewModel(
+            ScopedVM::class, ViewModelStore(), null, CreationExtras.Empty, null, parentScope,
+        )
+
+        assertNotNull(vm)
+        // its scoped dependency must come from the parent custom scope
+        assertNotNull(vm.dep)
+        assertSame(parentScope.get<ScopedDep>(), vm.dep)
+    }
+}


### PR DESCRIPTION
## Problem
With `viewModelScopeFactory()` enabled, a ViewModel declared in a **custom scope** can't be resolved:
```kotlin
startKoin { options(viewModelScopeFactory()); modules(appModule) }

val appModule = module {
    scope<ExampleScopeComponent> {
        scoped { ... }
        viewModelOf(::ExampleScopedViewModel)   // crashes: NoDefinitionFound
    }
}
```
`KoinViewModelFactory` creates a fresh `vmScope` (ViewModelScopeArchetype) but **never links it to the requesting (parent) scope**, so the ViewModel — registered under the custom scope qualifier — and its scoped dependencies are unreachable. Works with the option off.

Fixes #2299.

## Fix
```kotlin
val vmScope = koin.createScope(scopeId, TypeQualifier(modelClass), null, ViewModelScopeArchetype)
if (!scope.isRoot) {
    vmScope.linkTo(scope)   // #2299
}
```
New scopes already link to root, so only a non-root parent needs an explicit link. The ViewModel and its scoped deps then resolve through the linked parent.

This is the **flip side of #2417(b)**: that guidance points users at `viewModelScopeFactory()`, so the option must work with custom scopes.

## Tests
`ViewModelScopeFactoryLinkTest` (commonTest), **RED→GREEN on JVM / wasmJs / native** — custom scope + option, asserts the VM resolves and its scoped dep comes from the parent scope.

## Verification
- New test green on JVM/wasmJs/native
- Full `:core:koin-core-viewmodel:jvmTest` + `:android:koin-android:testDebugUnitTest` green (incl. #2387 — the change is in the option-on branch, untouched by the SavedStateHandle path)
- `./gradlew apiCheck` — pass

## Scope
Only the `viewModelScopeFactory()` (option-on) branch of `KoinViewModelFactory`. No version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)