### PR TITLE
Fix #2410 - non-blocking RequestScope id (cherry-pick of #2432 by @lfavreli-betclic)

### DIFF
--- a/projects/ktor/koin-ktor/src/commonMain/kotlin/org/koin/ktor/plugin/RequestScope.kt
+++ b/projects/ktor/koin-ktor/src/commonMain/kotlin/org/koin/ktor/plugin/RequestScope.kt
@@ -19,16 +19,25 @@ import io.ktor.server.application.ApplicationCall
 import org.koin.core.Koin
 import org.koin.core.component.KoinScopeComponent
 import org.koin.core.component.createScope
-import org.koin.mp.KoinPlatformTools
-import org.koin.mp.generateId
+import kotlin.concurrent.atomics.AtomicLong
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
+import kotlin.concurrent.atomics.incrementAndFetch
+import kotlin.time.Clock
 
 /**
  * Request Scope Holder
  *
  * @author Arnaud Giuliani
+ * @author Loïc Favreliere
  */
+@OptIn(ExperimentalAtomicApi::class)
 class RequestScope(private val _koin: Koin, call: ApplicationCall) : KoinScopeComponent {
-    private val scopeId = "request_"+KoinPlatformTools.generateId()
+    private val scopeId = "request_" + counter.incrementAndFetch()
     override fun getKoin(): Koin = _koin
     override val scope = createScope(scopeId = scopeId, source = call)
+
+    private companion object {
+        // Monotonic counter seeded with the current time, for process-unique request scope ids
+        private val counter = AtomicLong(Clock.System.now().toEpochMilliseconds())
+    }
 }

--- a/projects/ktor/koin-ktor/src/jvmTest/kotlin/org/koin/ktor/ext/KoinPluginRunTest.kt
+++ b/projects/ktor/koin-ktor/src/jvmTest/kotlin/org/koin/ktor/ext/KoinPluginRunTest.kt
@@ -27,6 +27,10 @@ import io.ktor.server.response.respond
 import io.ktor.server.routing.get
 import io.ktor.server.routing.routing
 import io.ktor.server.testing.testApplication
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import org.junit.Before
@@ -59,9 +63,15 @@ class KoinPluginRunTest {
     }
 
     @Test
-    fun `each request gets a unique scope id`() {
+    fun `sequential and concurrent requests get unique scope ids`() {
         testMyApplication { client ->
-            val ids = (1..100).map { client.get("testurl").headers["X-Scope-Id"] }
+            suspend fun scopeId() = client.get("testurl").headers["X-Scope-Id"]
+
+            val sequentialIds = (1..100).map { scopeId() }
+            val concurrentIds = coroutineScope {
+                (1..1_000).map { async(Dispatchers.Default) { scopeId() } }.awaitAll()
+            }
+            val ids = sequentialIds + concurrentIds
 
             assertEquals(ids.size, ids.toSet().size, "all request scope ids should be unique")
             assertTrue(

--- a/projects/ktor/koin-ktor/src/jvmTest/kotlin/org/koin/ktor/ext/KoinPluginRunTest.kt
+++ b/projects/ktor/koin-ktor/src/jvmTest/kotlin/org/koin/ktor/ext/KoinPluginRunTest.kt
@@ -37,6 +37,7 @@ import org.koin.core.context.stopKoin
 import org.koin.core.logger.Level
 import org.koin.dsl.module
 import org.koin.ktor.plugin.Koin
+import org.koin.ktor.plugin.scope
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
@@ -54,6 +55,19 @@ class KoinPluginRunTest {
 
             assertEquals(HttpStatusCode.OK, response.status)
             assertTrue { response.bodyAsText().contains("Test response") }
+        }
+    }
+
+    @Test
+    fun `each request gets a unique scope id`() {
+        testMyApplication { client ->
+            val ids = (1..100).map { client.get("testurl").headers["X-Scope-Id"] }
+
+            assertEquals(ids.size, ids.toSet().size, "all request scope ids should be unique")
+            assertTrue(
+                ids.all { it?.removePrefix("request_")?.toLongOrNull() != null },
+                "scope ids should be 'request_<number>'",
+            )
         }
     }
 
@@ -135,7 +149,10 @@ private fun testMyApplicationNoKoin(test: suspend (jsonClient: HttpClient) -> Un
 class KtorMyModule(application: Application) {
     init {
         application.routing {
-            get("testurl") { call.respond(HttpStatusCode.OK, "Test response") }
+            get("testurl") {
+                call.response.headers.append("X-Scope-Id", call.scope.id)
+                call.respond(HttpStatusCode.OK, "Test response")
+            }
         }
     }
 }


### PR DESCRIPTION
**Authored by @lfavreli-betclic** (Loïc Favrelière) — this cherry-picks their work from #2432 onto `4.2.2` (the original PR targets `main`). All commits retain their authorship; full credit to them. 🙏

## Problem
`RequestScope` generated its scope id with `KoinPlatformTools.generateId()` — a `SecureRandom`-backed UUID whose blocking read runs on **every request**, stalling Ktor's non-blocking (Netty) event loop (detected via BlockHound). Fixes #2410.

## Fix
A per-request scope id only needs process-local uniqueness, so use a non-blocking monotonic `AtomicLong` (seeded once, at class load, from the wall clock) instead of a blocking UUID:
```kotlin
private val scopeId = "request_" + counter.incrementAndFetch()
// companion: AtomicLong(Clock.System.now().toEpochMilliseconds())  // seeded once per process
```
Scope ids become `request_<monotonic number>`. The wall-clock seed is intentional — it keeps ids large and restart-distinct, which is easier to follow across process runs in logs.

## Tests
`KoinPluginRunTest` — fires 100 sequential + 1000 concurrent requests and asserts every scope id is unique and well-formed (a sequential-only loop wouldn't surface a data race).

## Verification
- `:ktor:koin-ktor:jvmTest` green
- `commonMain` compiles on native (iosArm64) + wasmJs — the `kotlin.concurrent.atomics` / `kotlin.time.Clock` APIs work across koin-ktor's MP targets (Kotlin 2.3.20)
- `./gradlew apiCheck` — pass (internal field only; no public API change)

## Notes
- Original PR #2432 (targets `main`) is kept open so the fix also lands on `main`; this PR covers the **4.2.2** release.
- `@ExperimentalAtomicApi` opt-in is localized to the class (doesn't leak to users).

Co-authored-by: Loïc Favrelière <l.favreliere-ext@betclicgroup.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)