### PR TITLE
Fix #2386 - withOptions leaves stale index entries on qualifier/secondary change

### DIFF
--- a/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/module/dsl/OptionDSL.kt
+++ b/projects/core/koin-core/src/commonMain/kotlin/org/koin/core/module/dsl/OptionDSL.kt
@@ -7,6 +7,7 @@ import org.koin.core.definition.BeanDefinition
 import org.koin.core.definition.Callbacks
 import org.koin.core.definition.KoinDefinition
 import org.koin.core.definition.OnCloseCallback
+import org.koin.core.definition.indexKey
 import org.koin.core.instance.SingleInstanceFactory
 import org.koin.core.module.OptionDslMarker
 import org.koin.core.qualifier.StringQualifier
@@ -41,13 +42,22 @@ inline infix fun <T> KoinDefinition<T>.withOptions(
     options: DefinitionOptions<T>,
 ): KoinDefinition<T> {
     val def = factory.beanDefinition
-    val primary = def.qualifier
+    val previousQualifier = def.qualifier
+    val previousSecondaryTypes = def.secondaryTypes.toList()
     def.also(options)
-    if (def.qualifier != primary) {
+    // #2386: mutating qualifier/secondaryTypes changes the definition's index coordinates. The
+    // original entries (from single()/factory() or a prior withOptions) must be removed before
+    // re-indexing, otherwise the definition stays reachable under its old qualifier and its
+    // secondary types desync from the primary index.
+    if (def.qualifier != previousQualifier || def.secondaryTypes != previousSecondaryTypes) {
+        module.mappings.remove(indexKey(def.primaryType, previousQualifier, def.scopeQualifier))
+        previousSecondaryTypes.forEach { secondaryType ->
+            module.mappings.remove(indexKey(secondaryType, previousQualifier, def.scopeQualifier))
+        }
         module.indexPrimaryType(factory)
-    }
-    if (def.secondaryTypes.isNotEmpty()) {
-        module.indexSecondaryTypes(factory)
+        if (def.secondaryTypes.isNotEmpty()) {
+            module.indexSecondaryTypes(factory)
+        }
     }
     if (def._createdAtStart && factory is SingleInstanceFactory<*>) {
         module.prepareForCreationAtStart(factory)

--- a/projects/core/koin-core/src/commonTest/kotlin/org/koin/core/WithOptionsStaleIndexTest.kt
+++ b/projects/core/koin-core/src/commonTest/kotlin/org/koin/core/WithOptionsStaleIndexTest.kt
@@ -1,0 +1,57 @@
+package org.koin.core
+
+import org.koin.Simple
+import org.koin.core.module.dsl.withOptions
+import org.koin.core.qualifier.StringQualifier
+import org.koin.core.qualifier.named
+import org.koin.dsl.koinApplication
+import org.koin.dsl.module
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+/**
+ * Regression test for #2386. Mutating a definition's qualifier/secondaryTypes via withOptions
+ * added new index entries but never removed the originals, leaving stale dual-index entries:
+ * the definition stayed reachable under its OLD qualifier, and secondary types were indexed
+ * only under the new qualifier (asymmetry). After the fix, the old coordinates must be dropped.
+ */
+class WithOptionsStaleIndexTest {
+
+    @Test
+    fun qualifier_change_drops_stale_primary_index_2386() {
+        val koin = koinApplication {
+            modules(
+                module {
+                    single(named("a")) { Simple.ComponentA() } withOptions { qualifier = StringQualifier("b") }
+                },
+            )
+        }.koin
+
+        // reachable under the new qualifier
+        assertNotNull(koin.getOrNull<Simple.ComponentA>(named("b")))
+        // NOT reachable under the old qualifier (stale index removed)
+        assertNull(koin.getOrNull<Simple.ComponentA>(named("a")))
+    }
+
+    @Test
+    fun qualifier_change_keeps_primary_and_secondary_reachability_consistent_2386() {
+        val koin = koinApplication {
+            modules(
+                module {
+                    single(named("a")) { Simple.Component1() } withOptions {
+                        qualifier = StringQualifier("b")
+                        secondaryTypes = listOf(Simple.ComponentInterface1::class)
+                    }
+                },
+            )
+        }.koin
+
+        // primary + secondary both reachable under the NEW qualifier
+        assertNotNull(koin.getOrNull<Simple.Component1>(named("b")))
+        assertNotNull(koin.getOrNull<Simple.ComponentInterface1>(named("b")))
+        // neither reachable under the OLD qualifier — consistent (no asymmetry)
+        assertNull(koin.getOrNull<Simple.Component1>(named("a")))
+        assertNull(koin.getOrNull<Simple.ComponentInterface1>(named("a")))
+    }
+}

--- a/projects/core/koin-core/src/commonTest/kotlin/org/koin/dsl/NewDSLTest.kt
+++ b/projects/core/koin-core/src/commonTest/kotlin/org/koin/dsl/NewDSLTest.kt
@@ -30,7 +30,8 @@ class NewDSLTest : KoinCoreTest() {
                 bind<IClassA>()
             }
         }
-        assertEquals(3, module.mappings.size)
+        // qualified primary + secondary; the original unqualified primary index is dropped (#2386)
+        assertEquals(2, module.mappings.size)
         val factory = module.mappings.values.iterator().next()
         assertTrue {
             factory is SingleInstanceFactory<*> && factory.beanDefinition._createdAtStart
@@ -47,7 +48,8 @@ class NewDSLTest : KoinCoreTest() {
                 bind<IClassA>()
             }
         }
-        assertEquals(3, module.mappings.size)
+        // qualified primary + secondary; the original unqualified primary index is dropped (#2386)
+        assertEquals(2, module.mappings.size)
         val factory = module.mappings.values.iterator().next()
         assertTrue {
             factory is FactoryInstanceFactory<*> && !factory.beanDefinition._createdAtStart
@@ -114,6 +116,7 @@ class NewDSLTest : KoinCoreTest() {
         }
 
         assertEquals(1, module.eagerInstances.size)
-        assertEquals(4, module.mappings.size)
+        // ClassA: qualified primary + secondary (old unqualified primary dropped, #2386) + ClassB
+        assertEquals(3, module.mappings.size)
     }
 }


### PR DESCRIPTION
## Problem
`withOptions` mutates a `BeanDefinition` in place, then re-indexes from the mutated state — but never removes the entry registered under the **previous** coordinates. So:
```kotlin
single<Foo>(named("a")) { Foo() } withOptions { qualifier = named("b") }
```
leaves **both** `Foo:a` (stale) and `Foo:b` in `Module.mappings`, pointing at the same factory — `get<Foo>(named("a"))` still resolves even though the definition's qualifier is now `b`. With `secondaryTypes` it gets worse: secondaries are indexed only under the new qualifier, so `Foo` is reachable via old+new but `Bar` only via new (asymmetry). Fixes #2386.

## Fix
Snapshot the previous `qualifier` + `secondaryTypes` before applying the options; when either changes, drop the stale `mappings` entries (old primary + old secondaries under the old qualifier) before re-indexing with the new coordinates:
```kotlin
val previousQualifier = def.qualifier
val previousSecondaryTypes = def.secondaryTypes.toList()
def.also(options)
if (def.qualifier != previousQualifier || def.secondaryTypes != previousSecondaryTypes) {
    module.mappings.remove(indexKey(def.primaryType, previousQualifier, def.scopeQualifier))
    previousSecondaryTypes.forEach { module.mappings.remove(indexKey(it, previousQualifier, def.scopeQualifier)) }
    module.indexPrimaryType(factory)
    if (def.secondaryTypes.isNotEmpty()) module.indexSecondaryTypes(factory)
}
```
No-op when nothing index-relevant changed.

## Behavioral note (resolution semantics)
A definition is **no longer reachable under a qualifier it had before `withOptions` changed it** — this removes unintended/undocumented reachability (the dual-index). Resolution by the definition's *current* qualifier is unchanged.

## Tests
- `WithOptionsStaleIndexTest` (commonTest, RED→GREEN): qualifier change drops the stale primary index; primary + secondary reachability stay consistent.
- `NewDSLTest`: corrected three `mappings.size` expectations that were **counting the stale entry** (3→2, 3→2, 4→3) — they encoded the bug.

## Verification
- `:core:koin-core:jvmTest` green; wasmJs green except the documented pre-existing `createdAtStart` reds; native validated via JVM+wasmJs (native run hits the known pre-existing `ServiceMessagesParser` backtick-reporter crash, unrelated).
- `./gradlew apiCheck` — pass (no public API change; `mappings` is `@KoinInternalApi`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)