### PR TITLE
Finalize 4.2.2 — version bump + Navigation 3 typed entryProvider docs (#2336)

### DIFF
--- a/docs/reference/koin-compose/navigation3.md
+++ b/docs/reference/koin-compose/navigation3.md
@@ -152,6 +152,31 @@ fun App() {
 }
 ```
 
+:::tip Pass your route type when `NavDisplay` is typed
+`koinEntryProvider<T>()` is generic — `T` is the route type. If you leave it as `koinEntryProvider<Any>()` but `NavDisplay` becomes typed (for example via a typed `SceneStrategy` like `rememberSupportingPaneSceneStrategy<Route>()`), the compiler infers `NavDisplay<Route>` and expects `(Route) -> NavEntry<Route>`, so an `Any`-typed provider won't match:
+
+```
+Argument type mismatch: actual type is 'Function1<Any, NavEntry<Any>>',
+but 'Function1<Route, NavEntry<Route>>' was expected.
+```
+
+Pass your route type to match:
+
+```kotlin
+val sceneStrategy = rememberSupportingPaneSceneStrategy<Route>()
+val entryProvider = koinEntryProvider<Route>()   // (Route) -> NavEntry<Route>
+
+NavDisplay(
+    backStack = backStack,
+    onBack = onBack,
+    sceneStrategy = sceneStrategy,
+    entryProvider = entryProvider,               // ✅ matches NavDisplay<Route>
+)
+```
+
+(equivalently, `val entryProvider: EntryProvider<Route> = koinEntryProvider()` — the type argument is inferred from the expected type.)
+:::
+
 ### Complete Example
 
 ```kotlin

--- a/projects/gradle.properties
+++ b/projects/gradle.properties
@@ -11,7 +11,7 @@ kotlin.incremental.multiplatform=true
 kotlin.code.style=official
 
 #Koin
-koinVersion=4.2.2-Alpha1
+koinVersion=4.2.2
 
 #Compose
 org.jetbrains.compose.experimental.jscanvas.enabled=true


### PR DESCRIPTION
Finalizes the 4.2.2 release.

## Version
Bump `koinVersion` `4.2.2-Alpha1` → **`4.2.2`**.

## #2336 — Navigation 3 typed `entryProvider` (docs)
`koinEntryProvider<T>()` is already generic (`(T) -> NavEntry<T>`). The reported mismatch happens when it's called as `koinEntryProvider<Any>()` but `NavDisplay` is typed (e.g. via a typed `SceneStrategy` such as `rememberSupportingPaneSceneStrategy<Route>()`) — the compiler then infers `NavDisplay<Route>` and expects `(Route) -> NavEntry<Route>`. The API didn't need changing; the fix is to **document** passing the route type:
```kotlin
val entryProvider = koinEntryProvider<Route>()   // matches NavDisplay<Route>
// or: val entryProvider: EntryProvider<Route> = koinEntryProvider()
```
Added a `:::tip` to the Navigation 3 reference page covering the exact error and both forms.

## Verification
- Docs + version only — no code change. `./gradlew apiCheck` passes (no `.api` delta).

Closes #2336.

🤖 Generated with [Claude Code](https://claude.com/claude-code)