### PR TITLE
Docs note and checkModules test for qualified vs stacked parameters

### DIFF
--- a/docs/reference/koin-core/injection-parameters.md
+++ b/docs/reference/koin-core/injection-parameters.md
@@ -80,6 +80,9 @@ val myModule = module {
 }
 ```
 
+:::note
+Graph resolution of injected parameters only applies to unqualified requests: a qualified request like `get(named("a_name"))` always resolves from your module definitions, never from injected parameters, because parameters are matched by type and carry no qualifier.
+:::
 
 ## Injected parameters: indexed values or set (`3.4.3`)
 

--- a/projects/core/koin-test/src/jvmTest/kotlin/CheckModulesTest.kt
+++ b/projects/core/koin-test/src/jvmTest/kotlin/CheckModulesTest.kt
@@ -3,12 +3,33 @@ import org.koin.core.context.stopKoin
 import kotlin.test.Test
 import kotlin.test.fail
 import org.koin.core.error.InstanceCreationException
+import org.koin.core.qualifier.named
 import org.koin.dsl.module
 import org.koin.test.Simple
 import org.koin.test.check.checkKoinModules
 import org.koin.test.verify.MissingKoinDefinitionException
 
 class CheckModulesTest {
+
+    class ComponentWithNamedDependency(env: String) {
+        init {
+            require(env.isNotEmpty()) { "env was empty!" }
+        }
+    }
+
+    /**
+     * #2406 - checkModules must keep the named String single. It used to hand the
+     * get(named("env")) MockParameter's default "", tripping the require() below.
+     */
+    @Test
+    fun verify_module_with_named_string_dependency() {
+        val module = module {
+            single(named("env")) { "TEST" }
+            single { ComponentWithNamedDependency(get(named("env"))) }
+        }
+
+        checkKoinModules(listOf(module))
+    }
 
     @Test
     fun verify_one_simple_module() {


### PR DESCRIPTION
Follow-up to 4fae618a (#2370, #2408, also reported in #2406 and #2435), which made qualified requests resolve from definitions instead of stacked parameters. Replaces #2440, which made the same resolver change independently.

This PR carries over the two pieces that are not yet on `main`:

- **Docs**: a note in `injection-parameters.md` clarifying that graph resolution of injected parameters only applies to unqualified requests; `get(named(...))` always resolves from module definitions.
- **Test**: a regression test in `CheckModulesTest` covering the `checkKoinModules` path, where a `get(named("env"))` dependency used to receive the MockParameter default `""` instead of the named single. The existing tests from 4fae618a cover direct resolution but not the check/verify path.

Verified with `:core:koin-test:jvmTest --tests CheckModulesTest` on current `main`.